### PR TITLE
Create copies of test namespace files for eventual redirection.

### DIFF
--- a/ns/rdftest.ttl
+++ b/ns/rdftest.ttl
@@ -1,0 +1,129 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdft: <http://www.w3.org/ns/rdftest#> .
+
+<http://www.w3.org/ns/rdftest> a owl:Ontology;
+   rdfs:label "The RDF 1.1 Test Vocabulary"@en;
+   dcterms:title "The RDF 1.1 Test Vocabulary"@en;
+   dcterms:description """This is a vocabulary document and is used to define classes and properties used in
+      RDF 1.1 Test Cases and associated test manifests.
+      The URI of the vocabulary is http://www.w3.org/ns/rdftest# (abbreviated by rdft: in this document).
+      Turtle and an JSON-LD versions of the vocabulary are also available.
+      The vocabulary is published by W3C.
+    """@en;
+   dcterms:publisher <http://www.w3.org/data#W3C>;
+   rdfs:comment """This is a vocabulary document and is used to define classes and properties used in
+      RDF 1.1 Test Cases and associated test manifests.
+      The URI of the vocabulary is http://www.w3.org/ns/rdftest# (abbreviated by rdft: in this document).
+      Turtle and an JSON-LD versions of the vocabulary are also available.
+      The vocabulary is published by W3C.
+    """@en .
+
+rdft:Approval a rdfs:Class;
+   rdfs:label "Approval"@en;
+   rdfs:comment "The superclass of all test approval statuses."@en .
+
+rdft:Approved a rdfs:Class;
+   rdfs:label "Approved"@en;
+   rdfs:comment "Indicates that a test is approved."@en;
+   rdfs:subClassOf rdft:Approval .
+
+rdft:Proposed a rdfs:Class;
+   rdfs:label "Proposed"@en;
+   rdfs:comment "Indicates that a test is proposed, but not approved."@en;
+   rdfs:subClassOf rdft:Approval .
+
+rdft:Rejected a rdfs:Class;
+   rdfs:label "Rejected"@en;
+   rdfs:comment "Indicates that a test is not approved."@en;
+   rdfs:subClassOf rdft:Approval .
+
+rdft:Test a rdfs:Class;
+   rdfs:label "Test"@en;
+   rdfs:comment "Superclass of all RDF Tests."@en .
+
+rdft:TestEval a rdfs:Class;
+   rdfs:label "Test Evaluation"@en;
+   rdfs:comment "Superclass of all RDF Evaluation Tests."@en;
+   rdfs:subClassOf rdft:Test .
+
+rdft:TestNQuadsNegativeSyntax a rdfs:Class;
+   rdfs:label "N-Quads Negative Syntax"@en;
+   rdfs:comment "A negative N-Quads syntax test."@en;
+   rdfs:subClassOf rdft:TestSyntax .
+
+rdft:TestNQuadsPositiveSyntax a rdfs:Class;
+   rdfs:label "N-Quads Positive Syntax"@en;
+   rdfs:comment "A positive N-Quads syntax test."@en;
+   rdfs:subClassOf rdft:TestSyntax .
+
+rdft:TestNTriplesNegativeSyntax a rdfs:Class;
+   rdfs:label "N-Triples Negative Syntax"@en;
+   rdfs:comment "A negative N-Triples syntax test."@en;
+   rdfs:subClassOf rdft:TestSyntax .
+
+rdft:TestNTriplesPositiveSyntax a rdfs:Class;
+   rdfs:label "N-Triples Positive Syntax"@en;
+   rdfs:comment "A positive N-Triples syntax test."@en;
+   rdfs:subClassOf rdft:TestSyntax .
+
+rdft:TestSyntax a rdfs:Class;
+   rdfs:label "Test Syntax"@en;
+   rdfs:comment "Superclass of all RDF Syntax Tests."@en;
+   rdfs:subClassOf rdft:Test .
+
+rdft:TestTriGNegativeSyntax a rdfs:Class;
+   rdfs:label "TriG Negative Syntax"@en;
+   rdfs:comment "A negative TriG syntax test."@en;
+   rdfs:subClassOf rdft:TestSyntax .
+
+rdft:TestTriGPositiveSyntax a rdfs:Class;
+   rdfs:label "TriG Positive Syntax"@en;
+   rdfs:comment "A positive TriG syntax test."@en;
+   rdfs:subClassOf rdft:TestSyntax .
+
+rdft:TestTrigEval a rdfs:Class;
+   rdfs:label "TriG Positive Evaluation"@en;
+   rdfs:comment "A positive TriG evaluation test."@en .
+
+rdft:TestTrigNegativeEval a rdfs:Class;
+   rdfs:label "TriG Negative Evaluation"@en;
+   rdfs:comment "A negative TriG evaluation test."@en;
+   rdfs:subClassOf rdft:TestEval .
+
+rdft:TestTurtleEval a rdfs:Class;
+   rdfs:label "Turtle Positive Evaluation"@en;
+   rdfs:comment "A positive Turtle evaluation test."@en;
+   rdfs:subClassOf rdft:TestEval .
+
+rdft:TestTurtleNegativeEval a rdfs:Class;
+   rdfs:label "Turtle Negative Evaluation"@en;
+   rdfs:comment "A negative Turtle evaluation test."@en;
+   rdfs:subClassOf rdft:TestEval .
+
+rdft:TestTurtleNegativeSyntax a rdfs:Class;
+   rdfs:label "Turtle Negative Syntax"@en;
+   rdfs:comment "A negative Turtle syntax test."@en;
+   rdfs:subClassOf rdft:TestSyntax .
+
+rdft:TestTurtlePositiveSyntax a rdfs:Class;
+   rdfs:label "Turtle Positive Syntax"@en;
+   rdfs:comment "A positive Turtle syntax test."@en;
+   rdfs:subClassOf rdft:TestSyntax .
+
+rdft:TestXMLNegativeSyntax a rdfs:Class;
+   rdfs:label "RDF/XML Negative Syntax"@en;
+   rdfs:comment "A negative RDF/XML syntax test."@en .
+
+rdft:XMLEval a rdfs:Class;
+   rdfs:label "RDF/XML Evaluation"@en;
+   rdfs:comment "A positive RDF/XML evaluation test."@en;
+   rdfs:subClassOf rdft:TestEval .
+
+rdft:approval a rdf:Property;
+   rdfs:label "approval"@en;
+   rdfs:comment "Approval status of a test."@en;
+   rdfs:domain rdft:Test;
+   rdfs:range rdft:Approval .

--- a/ns/test-dawg.ttl
+++ b/ns/test-dawg.ttl
@@ -1,0 +1,116 @@
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dc:     <http://purl.org/dc/elements/1.1/> .
+@prefix owl:    <http://www.w3.org/2002/07/owl#> .
+@prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+
+# RDF Core tests
+@prefix rct:    <http://www.w3.org/2000/10/rdf-tests/rdfcore/testSchema#> .
+
+dawgt:   rdfs:comment     "Vocabulary for DAWG test cases" ;
+    dc:creator       "Andy Seaborne" ;
+    dc:subject       "" ;
+    dc:publisher     "W3C RDF Data Access Working Group" ;
+    dc:title         "Vocabulary for DAWG test cases" ;
+    dc:description   "Vocabulary for DAWG test cases" ;
+    dc:date          "2004-07" ;
+    dc:format        "RDF" ;
+    dc:identifier    dawgt: ;
+    .
+
+
+## ---- Classes ----
+
+dawgt:ResultForm    rdf:type rdfs:Class ;
+    rdfs:comment    "Super class of all result forms" ;
+    .
+
+dawgt:Status    rdf:type rdfs:Class ;
+    rdfs:comment     "Super class of all test status classes" ;
+    .
+
+## ---- Properties ----
+
+# Could be a subPropertyOf rdf:type
+# or could just use rdf:type.
+dawgt:resultForm    rdf:type rdf:Property ;
+    rdfs:range          dawgt:ResultForm ;
+    rdfs:isDefinedBy    dawgt: ;
+    .
+
+#dawgt:status   rdf:type rdf:Property ;
+#    rdfs:range          dawgt:Status ;
+#    rdfs:isDefinedBy    dawgt: ;
+#    rdfs:label          "Status" ;
+#    .
+
+dawgt:approval rdf:type rdf:Property ;
+    rdfs:range          dawgt:Status ;
+    rdfs:isDefinedBy    dawgt: ;
+    rdfs:comment        "The approval status of the test with respect to the working group." ;
+    rdfs:label          "Approval" ;
+    .
+
+dawgt:approvedBy rdf:type rdf:Property ;
+    rdfs:comment        "Contains a reference to the minutes of the RDF Data Access Working Group where the test case status was last changed." ;
+    rdfs:label          "Approval" ;
+    owl:sameAs          rct:approval ;
+    .
+
+dawgt:description rdf:type rdf:Property ;
+    rdfs:comment        "A human-readable summary of the test case.";
+    rdfs:label          "Description" ;
+    owl:sameAs          rct:description ;
+    .
+
+dawgt:issue     rdf:type rdf:Property ;
+    rdfs:comment        "Contains a pointer to the associated issue on the RDF Data Access Working Group Tracking document.";
+    owl:sameAs          rct:issue ;
+    rdfs:label          "Issue" .
+
+dawgt:warning   rdf:type rdf:Property;
+    rdfs:comment        "Indicates that while the test should pass, it may generate a warning.";
+    owl:sameAs          rct:warning ;
+    rdfs:label          "Warning" .
+
+## ---- Defined terms ----
+
+## ---- Test statuses
+
+dawgt:NotClassified     rdfs:subClassOf dawgt:Status ;
+    rdfs:comment        "Class of tests that have not been classified" ;
+    rdfs:label          "NotClassified" .
+
+dawgt:Approved          rdfs:subClassOf dawgt:Status ;
+    rdfs:comment        "Class of tests that are Approved" ;
+    rdfs:label          "Approved" .
+
+dawgt:Rejected          rdfs:subClassOf dawgt:Status ;
+    rdfs:comment        "Class of tests that are Rejected" ;
+    rdfs:label          "Rejected" .
+
+dawgt:Obsoleted         rdfs:subClassOf dawgt:Status ;
+    rdfs:comment        "Class of tests that are Obsolete" ;
+    rdfs:label          "Obsoleted" .
+
+dawgt:Withdrawn         rdfs:subClassOf dawgt:Status ;
+    rdfs:comment        "Class of tests that have been Withdrawn" ;
+    rdfs:label          "Withdrawn" .
+
+
+## ---- Result forms
+## The result may still be encoded in RDF - classifying it helps
+## check for expected form.
+
+dawgt:ResultSet         rdfs:subClassOf dawgt:ResultForm ;
+    rdfs:comment        "Class of result expected to be from a SELECT query" ;
+    rdfs:label          "Result Set" .
+ 
+dawgt:ResultGraph       rdfs:subClassOf dawgt:ResultForm ;
+    rdfs:comment        "Class of result expected to be a graph" ;
+    rdfs:label          "Graph Result" .
+ 
+dawgt:ResultBoolean     rdfs:subClassOf dawgt:ResultForm ;
+    rdfs:comment        "Class of result expected to be a boolean" ;
+    rdfs:label          "Boolean Result" .

--- a/ns/test-manifest.ttl
+++ b/ns/test-manifest.ttl
@@ -1,0 +1,178 @@
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dc:     <http://purl.org/dc/elements/1.1/> .
+@prefix :       <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+
+## A Manifest is typically a list (RDF Collection) of manifest entries.
+## The :entries property has an object of the list.
+## There may be more than one list per file.
+
+:   rdfs:comment     "Manifest vocabulary for test cases" ;
+    dc:creator       "Andy Seaborne" ;
+    dc:subject       "" ;
+    dc:publisher     "W3C RDF Data Access Working Group" ;
+    dc:title         "Test case manifest vocabulary" ;
+    dc:description   "Test case manifest vocabulary" ;
+    dc:date          "2004-07" ;
+    dc:format        "RDF" ;
+    dc:identifier    : ;
+    .
+
+## ---- Class declarations ----
+
+:Manifest rdf:type rdfs:Class ;
+    rdfs:comment "The class of manifests" .
+
+:ManifestEntry rdf:type rdfs:Class ;
+    rdfs:comment "One entry in rdf:type list of entries" .
+
+## ---- Property declarations for the manifest ----
+
+:include rdf:type rdf:Property ;
+    rdfs:comment "Connects the manifest resource to rdf:type list of manifests" ;
+    rdfs:domain	 :Manifest ;
+    rdfs:range   rdf:List ;
+    .
+
+:entries rdf:type rdf:Property ;
+    rdfs:comment "Connects the manifest resource to rdf:type list of entries" ;
+    rdfs:domain	 :Manifest ;
+    rdfs:range   rdf:List ;
+
+    .
+	
+## ---- Property declarations for each test ----
+
+:name rdf:type rdf:Property ;
+    rdfs:comment "Optional name of this entry" ;
+    rdfs:domain	 :ManifestEntry ;
+    rdfs:range   rdfs:Literal ;
+    .	
+    
+:action rdf:type rdf:Property ;
+    rdfs:comment "Action to perform" ;
+    rdfs:domain	 :ManifestEntry ;
+    # rdfs:range   ?? ;
+    .	
+
+:result rdf:type rdf:Property ;
+    rdfs:comment "The expected outcome" ;
+    rdfs:domain	 :ManifestEntry ;
+    # rdfs:range   ?? ;
+    .	
+
+:result rdf:type rdf:Property ;
+    rdfs:comment "The test status" ;
+    rdfs:domain	 :ManifestEntry ;
+    rdfs:range   :TestStatus ;
+    .
+
+:requires rdf:type rdf:Property ;
+    rdfs:comment "Required functionality for execution of this test" ;
+    rdfs:domain :ManifestEntry ;
+    rdfs:range	:Requirement .
+
+:notable rdf:type rdf:Property ;
+    rdfs:comment "Notable feature of this test (advisory)" ;
+    rdfs:domain :ManifestEntry .
+
+:resultCardinality rdf:type rdf:Property ;
+    rdfs:comment "Specifies whether passing the test requires strict or lax cardinality adherence" ;
+    rdfs:domain :ManifestEntry ;
+    rdfs:range :ResultCardinality .
+
+## ---- Test Case Type ---
+
+:PositiveSyntaxTest rdf:type rdfs:Class ;
+      rdfs:label "Positive Syntax Test" ;
+      rdfs:comment "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action." .
+
+:PositiveSyntaxTest11 rdf:type rdfs:Class ;
+      rdfs:label "Positive Syntax Test for SPARQL1.1 Query" ;
+      rdfs:comment "A type of test specifically for syntax testing of new features in the SPARQL1.1 Query Language. Syntax tests are not required to have an associated result, only an action." .
+
+:PositiveUpdateSyntaxTest11 rdf:type rdfs:Class ;
+      rdfs:label "Positive Syntax Test for SPARQL1.1 Update" ;
+      rdfs:comment "A type of test specifically for syntax testing of SPARQL1.1 Update. Syntax tests are not required to have an associated result, only an action." .
+
+
+:NegativeSyntaxTest rdf:type rdfs:Class ;
+      rdfs:label "Negative Syntax Test" ;
+      rdfs:comment "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error." .
+
+:NegativeSyntaxTest11 rdf:type rdfs:Class ;
+      rdfs:label "Negative Syntax Test for SPARQL1.1 Query" ;
+      rdfs:comment "A type of test specifically for syntax testing of new features in the SPARQL1.1 Query Language. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error." .
+
+:NegativeUpdateSyntaxTest11 rdf:type rdfs:Class ;
+      rdfs:label "Negative Syntax Test for SPARQL1.1 Update" ;
+      rdfs:comment "A type of test specifically for syntax testing of SPARQL1.1 Update. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error." .
+
+
+:QueryEvaluationTest rdf:type rdfs:Class ;
+      rdfs:label "Query Evaluation Test" ;
+      rdfs:comment "A type of test specifically for query evaluation testing. Query evaluation tests are required to have an associated input dataset, a query, and an expected output dataset." .
+
+:UpdateEvaluationTest rdf:type rdfs:Class ;
+      rdfs:label "Update Evaluation Test" ;
+      rdfs:comment "The class of all SPARQL 1.1 Update evaluation tests" .
+
+## ---- Test Statuses ----
+
+:TestStatus rdf:type rdfs:Class ;
+    rdfs:comment "Statuses a test can have" ;
+    .
+
+:proposed rdf:type :TestStatus ;
+    rdfs:label "proposed" ;
+    .
+
+:accepted rdf:type :TestStatus ;
+    rdfs:label "accepted" ;
+    .
+
+:rejected rdf:type :TestStatus ;
+    rdfs:label "rejected" ;
+    .
+
+## ---- Required functions ----
+
+:Requirement rdf:type rdfs:Class ;
+     rdfs:comment "Requirements for a  particular test" .
+
+:Notable rdf:type rdfs:Class ;
+     rdfs:comment "Requirements for a  particular test" .
+
+
+:XsdDateOperations	rdf:type :Requirement ;
+    rdfs:comment "Tests that require xsd:date operations" .
+	
+:StringSimpleLiteralCmp	rdf:type :Requirement ;
+    rdfs:comment "Tests that require simple literal is the same value as an xsd:string of the same lexicial form" .
+    
+:KnownTypesDefault2Neq	rdf:type :Requirement ;
+    rdfs:comment "Values in disjoint value spaces are not equal" .
+    
+:LangTagAwareness	rdf:type :Requirement ;
+    rdfs:comment "Tests that require langauge tag handling in FILTERs" .
+
+## ---- Notable features ----
+
+:IllFormedLiterals	rdf:type :Notable ;
+    rdfs:comment "Tests that involve lexical forms which are illegal for the datatype" .
+
+## ---- Test cardinality ----
+
+:ResultCardinality rdf:type rdfs:Class ;
+    rdfs:comment "Potential modes of evaluating a test's results with respect to solution cardinality" .
+
+:LaxCardinality rdf:type :ResultCardinality ;
+    rdfs:comment
+"""The given mf:result for a test with an mf:resultCardinality of mf:ReducedCardinalityTest 
+is the results as if the REDUCED keyword were omitted. To pass such
+a test, an implementation must produce a result set 
+with each solution in the expected results appearing at least once and 
+no more than the number of times it appears in the expected results. Of 
+course, there must also be no results produced that are not in the 
+expected results.""" .
+

--- a/ns/test-manifest.ttl
+++ b/ns/test-manifest.ttl
@@ -38,9 +38,20 @@
     rdfs:comment "Connects the manifest resource to rdf:type list of entries" ;
     rdfs:domain	 :Manifest ;
     rdfs:range   rdf:List ;
-
     .
-	
+
+:includedSpecifications rdf:type rdf:Property ;
+    rdfs:comment "References the specifications covered by the manifest" ;
+    rdfs:domain	 :Manifest ;
+    rdfs:range   rdf:List ;
+    .
+
+:conformanceRequirement rdf:type rdf:Property ;
+    rdfs:comment "Identifies manifests testing conformance requirements for the specified specification" ;
+    #rdfs:domain	 :Specification ;
+    rdfs:range   rdf:List ;
+    .
+
 ## ---- Property declarations for each test ----
 
 :name rdf:type rdf:Property ;

--- a/ns/test-query.ttl
+++ b/ns/test-query.ttl
@@ -1,0 +1,76 @@
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl:    <http://www.w3.org/2002/07/owl#> .
+@prefix dc:     <http://purl.org/dc/elements/1.1/> .
+
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix :       <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
+
+## Query-specific test vocabulary for a manifest action.
+
+:   rdfs:comment     "Vocabulary for query test cases" ;
+    dc:creator       "Andy Seaborne" ;
+    dc:subject       "" ;
+    dc:publisher     "W3C RDF Data Access Working Group" ;
+    dc:title         "Query test case vocabulary" ;
+    dc:description   "Query test case vocabulary" ;
+    dc:date          "2004-07" ;
+    dc:format        "RDF" ;
+    dc:identifier    : ;
+    .
+## ---- Class declarations ----
+
+:QueryTest a rdfs:Class ;
+    rdfs:comment "The class of query tests" .
+
+:QueryForm    rdf:type rdfs:Class ;
+    rdfs:comment   "Super class of all query forms" ;
+    .
+
+
+## ---- Property declarations ----
+
+
+:query a rdf:Property ;
+    rdfs:comment "The query to ask" ;
+    rdfs:domain	 :QueryTest ;
+    ## rdfs:range   ?? ;
+    .	
+
+:data a rdf:Property ;
+    rdfs:comment "Optional: data for the query test" ;
+    rdfs:domain	 :QueryTest ;
+    rdfs:range   rdfs:Resource ;
+    .
+
+:graphData a rdf:Property ;
+    rdfs:comment "Optional: named-graph only data for the query test (ie. not loaded into the background graph)" ;
+    rdfs:domain	 :QueryTest ;
+    rdfs:range   rdfs:Resource ;
+    .
+
+# Could be a subPropertyOf rdf:type
+# or could just use rdf:type.
+:queryForm   rdf:type rdf:Property ;
+    rdfs:range          :QueryForm ;
+    rdfs:isDefinedBy    : ;
+    .
+
+## ---- Query forms 
+## The types of query there are
+
+:QuerySelect       rdfs:subClassOf :QueryForm ;
+    rdfs:comment        "Class of queries that are seeking variable bindings" ;
+    rdfs:label          "Variable Binding Query" .
+ 
+:QueryConstruct    rdfs:subClassOf :QueryForm ;
+    rdfs:comment        "Class of queries that are seeking a constructed graph" ;
+    rdfs:label          "Defined Graph Query" .
+
+:QueryDescribe     rdfs:subClassOf :QueryForm ;
+    rdfs:comment        "Class of queries that are seeking a descriptive graph" ;
+    rdfs:label          "Open Graph Query" .
+
+:QueryAsk          rdfs:subClassOf :QueryForm ;
+    rdfs:comment        "Class of queries that are seeking a yes/no question" ;
+    rdfs:label          "Boolean Query" .

--- a/ns/test-update.ttl
+++ b/ns/test-update.ttl
@@ -1,0 +1,146 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+  <title>404 not found</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <link rel="Help" href="/Help/" />
+  <link rel="stylesheet" href="/2008/site/css/minimum" type="text/css" media="handheld, all" />
+  <style type="text/css"  media="print, screen and (min-width: 481px)">@import url("/2008/site/css/advanced");</style>
+  <link href="/2008/site/css/minimum" rel="stylesheet" type="text/css" media="handheld, only screen and (max-device-width: 480px)" />
+  <meta name="viewport" content="width=device-width"/>
+  <link rel="stylesheet" href="/2008/site/css/print" type="text/css" media="print" />
+  <link rel="shortcut icon" href="/2008/site/images/favicon.ico" type="image/x-icon" />
+  </head>
+
+
+<body id="www-w3-org" class="w3c_public">
+ <div id="w3c_container">
+  <div id="w3c_mast"> <!-- #w3c_mast / Page top header -->
+   <h1 class="logo"><a tabindex="2" accesskey="1" href="/"><img src="/2008/site/images/logo-w3c-mobile-lg" width="90" height="53" alt="W3C" /></a>
+   <span class="alt-logo">W3C</span>
+   </h1>
+   <div id="w3c_nav">
+        <form action="http://www.w3.org/Help/search" method="get" enctype="application/x-www-form-urlencoded">
+       <!-- w3c_sec_nav is populated through js -->
+       <div class="w3c_sec_nav"><!-- --></div>
+           <ul class="main_nav"> <!-- Main navigation menu -->
+     <li class="first-item"><a href="/standards/">Standards</a></li><li><a href="/participate/">Participate</a></li><li><a href="/Consortium/membership">Membership</a></li><li class="last-item"><a href="/Consortium/">About W3C</a></li>
+       <li class="search-item">
+      <div id="search-form">
+       <input tabindex="3" class="text" name="q" value="" title="Search" />
+       <button id="search-submit" name="search-submit" type="submit"><img class="submit" src="/2008/site/images/search-button" alt="Search" width="21" height="17" /></button> 
+      </div>
+    </li>
+   </ul>
+
+
+     </form>
+   </div>
+  </div> <!-- /end #w3c_mast -->
+
+
+  <div id="w3c_main"> 
+    <div id="w3c_logo_shadow" class="w3c_leftCol">
+      <img height="32" alt="" src="/2008/site/images/logo-shadow" />
+    </div>
+   <div id="w3c_sidenavigation" class="w3c_leftCol">       <h2 class="offscreen">Site Navigation</h2>
+    <h3 class="category"><span class="ribbon"><a href="/Help/" title="Up to Help and FAQ">Help and FAQ <img src="/2008/site/images/header-link" alt="Header link" width="13" height="13" class="header-link"/></a></span></h3>
+       <ul class="theme">
+        <li><a href="/Help/Webmaster.html">FAQ about W3C Web Site</a></li>
+        <li><a href="/Consortium/siteindex.html">W3C Site Map</a></li>
+        <li><a href="/Help/Account/">W3C User Account Management</a></li>
+        <li><a href="/Help/about-redesign.html">About the W3C Site Redesign</a></li>
+       </ul>
+       <br/>
+      </div>
+   <div class="w3c_mainCol">
+          <div id="w3c_crumbs">
+       <div id="w3c_crumbs_frame">
+        <ul class="bct"> <!-- .bct / Breadcrumbs -->
+          <li class="skip"><a tabindex="1" accesskey="2" title="Skip to content (e.g., when browsing via audio)" href="#w3c_content_body">Skip</a></li>
+          <li><a href="/">W3C</a>&#160;<span class="cr">&#x00bb;</span>&#160;</li>
+          <li><a href="/Consortium/">About&#160;W3C</a>&#160;<span class="cr">&#x00bb;</span>&#160;</li>
+          <li><a href="/Help/">Help&#160;and&#160;FAQ</a>&#160;<span class="cr">&#x00bb;</span>&#160;</li>
+          <li class="current">404 Not Found</li>
+        </ul>            
+     </div>
+    </div>
+
+    <h1 class="title">Document not found</h1>
+    <div id="w3c_content_body">
+    <div class="line">
+
+
+<p class="intro tPadding">
+  Sorry, the document you requested is not available.
+  Here are some steps you may try to find the page you were
+  looking for:
+</p>
+<ol class="show_items">
+  <li>If you typed the URL by hand then please make sure that it is exactly
+  as it should be. Also check the capitalization and that you are using
+  forward slashes ( / ).</li>
+  <li>If you are looking for information on a particular subject, please
+  start on the <a href="http://www.w3.org/">W3C Home
+  page</a> or <a href="http://www.w3.org/Consortium/siteindex.html">Site
+  Map</a>.</li>
+  <li>Try searching the site using the search box at the top of this page.</li>
+</ol>
+
+<p>The <a href="http://www.w3.org/Help/Webmaster">W3C Webmaster FAQ</a> has
+answers to frequently asked questions about our site.</p>
+
+          </div> <!-- /end .line -->
+        </div> <!-- /end #w3c_content_body -->
+      </div> <!-- /end #w3c_mainCol -->
+    </div> <!-- end #w3c_main -->
+  </div> <!-- /end #w3c_container -->
+
+<div id="w3c_footer">
+  <div id="w3c_footer-inner">
+    <h2 class="offscreen">Footer Navigation</h2>
+    <div class="w3c_footer-nav">
+      <h3>Navigation</h3>
+      <ul class="footer_top_nav">   
+       <li><a href="/">Home</a></li>
+       <li><a href="/standards/">Standards</a></li>
+       <li><a href="/participate/">Participate</a></li>
+       <li><a href="/Consortium/membership">Membership</a></li>
+       <li class="last-item"><a href="/Consortium/">About W3C</a></li>
+      </ul>
+    </div>
+    <div class="w3c_footer-nav">
+      <h3>Contact W3C</h3>
+      <ul class="footer_bottom_nav">
+           <li><a href="/Consortium/contact">Contact</a></li>
+           <li><a accesskey="0" href="/Help/">Help and FAQ</a></li>
+           <li><a href="/Consortium/sponsor/">Sponsor / Donate</a></li>
+           <li><a href="/Consortium/siteindex">Site Map</a></li>
+           <li><address id="w3c_signature"><a href="http://lists.w3.org/Archives/Public/site-comments/">Feedback</a></address></li>
+      </ul>
+    </div>
+    <div class="w3c_footer-nav">
+      <h3>W3C Updates</h3>
+      <ul class="footer_follow_nav">
+           <li>
+	   	   <a href="http://twitter.com/W3C" title="Follow W3C on Twitter"><img src="/2008/site/images/Twitter_bird_logo_2012.svg" alt="Twitter" class="social-icon" height="40"/></a>
+          </li>
+     </ul>
+    </div>
+    <!-- #footer address / page signature -->
+        <p class="copyright">Copyright © 2015 W3C <sup>®</sup> (<a href="http://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="http://www.ercim.eu/"><acronym title="European Research Consortium for Informatics and Mathematics"> ERCIM</acronym></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>) <a href="/Consortium/Legal/ipr-notice">Usage policies apply</a>.</p>
+
+
+  </div>
+</div><!-- /end #footer -->
+
+<div id="w3c_scripts">
+  <script type="text/javascript" src="/2008/site/js/main"><!-- --></script>
+</div>
+
+
+
+</body>
+</html>
+
+


### PR DESCRIPTION
Adds a couple of missing definitions.

Perhaps @afs, @ericprud or someone else more familiar with the genesis of these manifests can verify that this satisfies the intent.

We should probably update the w3c source files to redirect here so that these files can be maintained.