### PR TITLE
Removed function tests strdt03 and strlang03 to align with RDF 1.1 (#19)

### DIFF
--- a/sparql11/data-sparql11/functions/manifest.ttl
+++ b/sparql11/data-sparql11/functions/manifest.ttl
@@ -113,7 +113,6 @@
 	mf:name    "STRDT() TypeErrors (updated for RDF 1.1)" ;
 	mf:feature sparql:strdt ;
     dawgt:approval dawgt:NotClassified ;
-    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <strdt03.rq> ;
            qt:data   <data.ttl> ] ;
@@ -157,7 +156,6 @@
 	mf:name    "STRLANG() TypeErrors (updated for RDF 1.1)" ;
 	mf:feature sparql:strlang ;
     dawgt:approval dawgt:NotClassified ;
-    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <strlang03.rq> ;
            qt:data   <data.ttl> ] ;

--- a/sparql11/data-sparql11/functions/manifest.ttl
+++ b/sparql11/data-sparql11/functions/manifest.ttl
@@ -12,10 +12,12 @@
     ( 
 	:strdt01
 	:strdt02
-	:strdt03
+	# :strdt03 # RDF 1.1 conformance causes this test to fail
+	:strdt03-rdf11
 	:strlang01
 	:strlang02
-	:strlang03
+	# :strlang03 # RDF 1.1 conformance causes this test to fail
+	:strlang03-rdf11
 	:isnumeric01
 	:abs01
 	:ceil01
@@ -107,6 +109,17 @@
     mf:result  <strdt03.srx> ;
 	.
 
+:strdt03-rdf11 rdf:type mf:QueryEvaluationTest ;
+	mf:name    "STRDT() TypeErrors (updated for RDF 1.1)" ;
+	mf:feature sparql:strdt ;
+    dawgt:approval dawgt:NotClassified ;
+    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
+    mf:action
+         [ qt:query  <strdt03.rq> ;
+           qt:data   <data.ttl> ] ;
+    mf:result  <strdt03-rdf11.srx> ;
+	.
+
 :strlang01 rdf:type mf:QueryEvaluationTest ;
 	mf:name    "STRLANG()" ;
 	mf:feature sparql:strlang ;
@@ -138,6 +151,17 @@
          [ qt:query  <strlang03.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <strlang03.srx> ;
+	.
+
+:strlang03-rdf11 rdf:type mf:QueryEvaluationTest ;
+	mf:name    "STRLANG() TypeErrors (updated for RDF 1.1)" ;
+	mf:feature sparql:strlang ;
+    dawgt:approval dawgt:NotClassified ;
+    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
+    mf:action
+         [ qt:query  <strlang03.rq> ;
+           qt:data   <data.ttl> ] ;
+    mf:result  <strlang03-rdf11.srx> ;
 	.
 
 :isnumeric01 rdf:type mf:QueryEvaluationTest ;

--- a/sparql11/data-sparql11/functions/strdt03-rdf11.srx
+++ b/sparql11/data-sparql11/functions/strdt03-rdf11.srx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+<head>
+	<variable name="s"/>
+	<variable name="str1"/>
+</head>
+<results>
+		<result><binding name="s"><uri>http://example.org/n1</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/n2</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/n3</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/n4</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/n5</uri></binding></result>
+		
+		<result>
+			<binding name="s"><uri>http://example.org/s1</uri></binding>
+			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">foo</literal></binding>
+		</result>
+		<result><binding name="s"><uri>http://example.org/s2</uri></binding></result>
+		<result>
+			<binding name="s"><uri>http://example.org/s3</uri></binding>
+			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">BAZ</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s4</uri></binding>
+			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">食べ物</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s5</uri></binding>
+			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">100%</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s6</uri></binding>
+			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s7</uri></binding>
+			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">DEF</literal></binding>
+		</result>
+
+		<result><binding name="s"><uri>http://example.org/d1</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/d2</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/d3</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/d4</uri></binding></result>
+</results>
+</sparql>

--- a/sparql11/data-sparql11/functions/strdt03-rdf11.srx
+++ b/sparql11/data-sparql11/functions/strdt03-rdf11.srx
@@ -34,7 +34,7 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">DEF</literal></binding>
+			<binding name="str1"><literal>DEF</literal></binding>
 		</result>
 
 		<result><binding name="s"><uri>http://example.org/d1</uri></binding></result>

--- a/sparql11/data-sparql11/functions/strlang03-rdf11.srx
+++ b/sparql11/data-sparql11/functions/strlang03-rdf11.srx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+<head>
+	<variable name="s"/>
+	<variable name="str1"/>
+</head>
+<results>
+		<result><binding name="s"><uri>http://example.org/n1</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/n2</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/n3</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/n4</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/n5</uri></binding></result>
+		
+		<result>
+			<binding name="s"><uri>http://example.org/s1</uri></binding>
+			<binding name="str1"><literal xml:lang="en-us">foo</literal></binding>
+		</result>
+		<result><binding name="s"><uri>http://example.org/s2</uri></binding></result>
+		<result>
+			<binding name="s"><uri>http://example.org/s3</uri></binding>
+			<binding name="str1"><literal xml:lang="en-us">BAZ</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s4</uri></binding>
+			<binding name="str1"><literal xml:lang="en-us">食べ物</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s5</uri></binding>
+			<binding name="str1"><literal xml:lang="en-us">100%</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s6</uri></binding>
+			<binding name="str1"><literal xml:lang="en-us">abc</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s7</uri></binding>
+			<binding name="str1"><literal xml:lang="en-us">DEF</literal></binding>
+		</result>
+
+		<result><binding name="s"><uri>http://example.org/d1</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/d2</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/d3</uri></binding></result>
+		<result><binding name="s"><uri>http://example.org/d4</uri></binding></result>
+</results>
+</sparql>


### PR DESCRIPTION
Removes tests :strdt03 and :strlang03 which fail under RDF 1.1 systems. Replaces them with :strdt03-rdf11 and :strlang03-rdf11 which use the same data and query, but updated expected result data based on RDF 1.1 semantics.

The SPARQL 1.1 test suite expects "abc"^^xsd:string and "DEF"^^xsd:string to produce an error when passed to STRDT and STRLANG, leading to ?str1 being unbound in these tests. This is because STRDT and STRLANG expect their first argument to a "simple literal". However, in RDF 1.1 "simple literals" are merely syntactic sugar for xsd:string datatyped literals. Therefore, both of these literals should be acceptable to STRDT and STRLANG, yielding values bound to ?str1.