### PR TITLE
Corrections for tests plus-1 and plus-2

### DIFF
--- a/sparql11/data-sparql11/functions/manifest.ttl
+++ b/sparql11/data-sparql11/functions/manifest.ttl
@@ -32,8 +32,8 @@
 	:contains01
 	:starts01
 	:ends01
-	:plus-1
-	:plus-2
+	:plus-1-corrected
+	:plus-2-corrected
 	:md5-01
 	:md5-02
 	:sha1-01
@@ -316,25 +316,21 @@
     mf:result  <ends01.srx> ;
 	.
 
-:plus-1 a mf:QueryEvaluationTest ;
-    mf:name    "plus-1" ;
+:plus-1-corrected a mf:QueryEvaluationTest ;
+    mf:name    "plus-1-corrected" ;
     rdfs:comment	"plus operator on ?x + ?y on string and numeric values" ;
     mf:action
-       [ qt:query  <plus-1.rq> ;
+       [ qt:query  <plus-1-corrected.rq> ;
 	 qt:data   <data-builtin-3.ttl> ] ;
-     dawgt:approval dawgt:Approved ;
-    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:result  <plus-1.srx> ;
     .
 
-:plus-2 a mf:QueryEvaluationTest ;
-    mf:name    "plus-2" ;
+:plus-2-corrected a mf:QueryEvaluationTest ;
+    mf:name    "plus-2-corrected" ;
     rdfs:comment	"plus operator in combination with str(), i.e.  str(?x) + str(?y), on string and numeric values" ;
     mf:action
-       [ qt:query  <plus-2.rq> ;
+       [ qt:query  <plus-2-corrected.rq> ;
 	 qt:data   <data-builtin-3.ttl> ] ;
-     dawgt:approval dawgt:Approved ;
-    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:result  <plus-2.srx> ;
     .
 

--- a/sparql11/data-sparql11/functions/plus-1-corrected.rq
+++ b/sparql11/data-sparql11/functions/plus-1-corrected.rq
@@ -1,7 +1,5 @@
 PREFIX  : <http://example/>
-
-SELECT  ?x ?y ( str(?x) + str(?y) AS ?sum)
+SELECT  ?x ?y ( ?x + ?y AS ?sum)
 WHERE
     { ?s :p ?x ; :q ?y . 
     }
-ORDER BY ?x ?y ?sum

--- a/sparql11/data-sparql11/functions/plus-2-corrected.rq
+++ b/sparql11/data-sparql11/functions/plus-2-corrected.rq
@@ -1,6 +1,6 @@
 PREFIX  : <http://example/>
-SELECT  ?x ?y ( ?x + ?y AS ?sum)
+
+SELECT  ?x ?y ( str(?x) + str(?y) AS ?sum)
 WHERE
     { ?s :p ?x ; :q ?y . 
     }
-ORDER BY ?x ?y ?sum


### PR DESCRIPTION
SPARQL 1.1 tests `functions/plus-1` and `functions/plus-2` include `ORDER BY`. Unfortunately, they sort strings against numbers.  This ordering is undefined by strict SPARQL. The results also don't identical query solutions adjacent in the ordering which is quite odd.

This PR corrects that by removing the `ORDER BY`.  The data and results are unchanged. `ORDER BY` is not a feature being tested.

Any system passing the original tests will still pass these corrected tests. 

The queries and the references in the manifest are renamed as `plus-1-corrected` and `plus-2-corrected`.

It may well be that systems are not checking the ordering when the query has `ORDER BY` in it.

Background: Apache Jena puts a total ordering on any `ORDER BY` with permitted extensions to compare literals with different datatypes (roughly, sort by lexical form then by datatype)

```
Adds queries plus-1-corrected.rq, plus-2-corrected.
Removes plus-1.rq and plus-2.rq.
Results remain the same.
```