### PR TITLE
Adds mf:result for three Turtle collection list tests

### DIFF
--- a/turtle/manifest.ttl
+++ b/turtle/manifest.ttl
@@ -1577,25 +1577,28 @@
    mf:action    <turtle-syntax-struct-05.ttl> ;
    .
 
-<#turtle-syntax-lists-01> rdf:type rdft:TestTurtlePositiveSyntax ;
+<#turtle-syntax-lists-01> rdf:type rdft:TestTurtleEval ;
    mf:name    "turtle-syntax-lists-01" ;
    rdfs:comment "empty list" ;
    rdft:approval rdft:Approved ;
    mf:action    <turtle-syntax-lists-01.ttl> ;
+   mf:result    <turtle-syntax-lists-01.nt> ;
    .
 
-<#turtle-syntax-lists-02> rdf:type rdft:TestTurtlePositiveSyntax ;
+<#turtle-syntax-lists-02> rdf:type rdft:TestTurtleEval ;
    mf:name    "turtle-syntax-lists-02" ;
    rdfs:comment "mixed list" ;
    rdft:approval rdft:Approved ;
    mf:action    <turtle-syntax-lists-02.ttl> ;
+   mf:result    <turtle-syntax-lists-02.nt> ;
    .
 
-<#turtle-syntax-lists-03> rdf:type rdft:TestTurtlePositiveSyntax ;
+<#turtle-syntax-lists-03> rdf:type rdft:TestTurtleEval ;
    mf:name    "turtle-syntax-lists-03" ;
    rdfs:comment "isomorphic list as subject and object" ;
    rdft:approval rdft:Approved ;
    mf:action    <turtle-syntax-lists-03.ttl> ;
+   mf:result    <turtle-syntax-lists-03.nt> ;
    .
 
 <#turtle-syntax-lists-04> rdf:type rdft:TestTurtlePositiveSyntax ;

--- a/turtle/turtle-syntax-lists-01.nt
+++ b/turtle/turtle-syntax-lists-01.nt
@@ -1,0 +1,1 @@
+<http://www.w3.org/2013/TurtleTests/s> <http://www.w3.org/2013/TurtleTests/p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .

--- a/turtle/turtle-syntax-lists-02.nt
+++ b/turtle/turtle-syntax-lists-02.nt
@@ -1,0 +1,7 @@
+<http://www.w3.org/2013/TurtleTests/s> <http://www.w3.org/2013/TurtleTests/p> _:b1 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b2 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "2" .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b3 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://www.w3.org/2013/TurtleTests/o> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .

--- a/turtle/turtle-syntax-lists-03.nt
+++ b/turtle/turtle-syntax-lists-03.nt
@@ -1,0 +1,5 @@
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b1 <http://www.w3.org/2013/TurtleTests/p> _:b2 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .


### PR DESCRIPTION
Relevant tests:

turtle-syntax-lists-01
turtle-syntax-lists-02
turtle-syntax-lists-03

These were previously TestTurtlePositiveSyntax tests. This commit
changes these 3 tests to TestTurtleEval tests, and adds the
corresponding expected NTriples results:

turtle-syntax-lists-01.nt
turtle-syntax-lists-02.nt
turtle-syntax-lists-03.nt