### PR TITLE
Adds three aditional blankNodePropertyList TestTurtleEval tests

### DIFF
--- a/turtle/blankNodePropertyList_as_object_containing_objectList.nt
+++ b/turtle/blankNodePropertyList_as_object_containing_objectList.nt
@@ -1,0 +1,3 @@
+<http://a.example/s> <http://a.example/p> _:b1 .
+_:b1 <http://a.example/p2> <http://a.example/o> .
+_:b1 <http://a.example/p2> <http://a.example/o2> .

--- a/turtle/blankNodePropertyList_as_object_containing_objectList.ttl
+++ b/turtle/blankNodePropertyList_as_object_containing_objectList.ttl
@@ -1,0 +1,1 @@
+<http://a.example/s> <http://a.example/p> [ <http://a.example/p2> <http://a.example/o>,<http://a.example/o2> ] .

--- a/turtle/blankNodePropertyList_as_object_containing_objectList_of_two_objects.nt
+++ b/turtle/blankNodePropertyList_as_object_containing_objectList_of_two_objects.nt
@@ -1,0 +1,3 @@
+<http://a.example/s> <http://a.example/p> _:b1 .
+_:b1 <http://a.example/p2> <http://a.example/o> .
+<http://a.example/s> <http://a.example/p> <http://a.example/o2> .

--- a/turtle/blankNodePropertyList_as_object_containing_objectList_of_two_objects.ttl
+++ b/turtle/blankNodePropertyList_as_object_containing_objectList_of_two_objects.ttl
@@ -1,0 +1,2 @@
+<http://a.example/s> <http://a.example/p> [ <http://a.example/p2> <http://a.example/o> ]
+                                          , <http://a.example/o2> .

--- a/turtle/manifest.ttl
+++ b/turtle/manifest.ttl
@@ -59,6 +59,8 @@
     <#sole_blankNodePropertyList>
     <#blankNodePropertyList_as_subject>
     <#blankNodePropertyList_as_object>
+    <#blankNodePropertyList_as_object_containing_objectList>
+    <#blankNodePropertyList_as_object_containing_objectList_of_two_objects>
     <#blankNodePropertyList_with_multiple_triples>
     <#nested_blankNodePropertyLists>
     <#blankNodePropertyList_containing_collection>
@@ -115,6 +117,7 @@
     <#lantag_with_subtag>
     <#objectList_with_two_objects>
     <#predicateObjectList_with_two_objectLists>
+    <#predicateObjectList_with_blankNodePropertyList_as_object>
     <#repeated_semis_at_end>
     <#repeated_semis_not_at_end>
 
@@ -636,6 +639,22 @@
    mf:result    <blankNodePropertyList_as_object.nt> ;
    .
 
+<#blankNodePropertyList_as_object_containing_objectList> rdf:type rdft:TestTurtleEval ;
+   mf:name      "blankNodePropertyList_as_object_containing_objectList" ;
+   rdfs:comment "blankNodePropertyList as object containing objectList <s> <p> [ <p2> <o>,<o2> ] ." ;
+   rdft:approval rdft:Approved ;
+   mf:action    <blankNodePropertyList_as_object_containing_objectList.ttl> ;
+   mf:result    <blankNodePropertyList_as_object_containing_objectList.nt> ;
+   .
+
+<#blankNodePropertyList_as_object_containing_objectList_of_two_objects> rdf:type rdft:TestTurtleEval ;
+   mf:name      "blankNodePropertyList_as_object_containing_objectList_of_two_objects" ;
+   rdfs:comment "blankNodePropertyList as object containing objectList of two objects <s> <p> [ <p2 <o> ] , <o2> ." ;
+   rdft:approval rdft:Approved ;
+   mf:action    <blankNodePropertyList_as_object_containing_objectList_of_two_objects.ttl> ;
+   mf:result    <blankNodePropertyList_as_object_containing_objectList_of_two_objects.nt> ;
+   .
+
 <#blankNodePropertyList_with_multiple_triples> rdf:type rdft:TestTurtleEval ;
    mf:name      "blankNodePropertyList_with_multiple_triples" ;
    rdfs:comment "blankNodePropertyList with multiple triples [ <s> <p> ; <s2> <p2> ]" ;
@@ -1082,6 +1101,14 @@
    rdft:approval rdft:Approved ;
    mf:action    <predicateObjectList_with_two_objectLists.ttl> ;
    mf:result    <predicateObjectList_with_two_objectLists.nt> ;
+   .
+
+<#predicateObjectList_with_blankNodePropertyList_as_object> rdf:type rdft:TestTurtleEval ;
+   mf:name      "predicateObjectList_with_blankNodePropertyList_as_object" ;
+   rdfs:comment "predicateObjectList_with_blankNodePropertyList_as_object <s> <p> [ <p2> <o> ] ; <p3> [ <p4> <o2> , <o3> ] " ;
+   rdft:approval rdft:Approved ;
+   mf:action    <predicateObjectList_with_blankNodePropertyList_as_object.ttl> ;
+   mf:result    <predicateObjectList_with_blankNodePropertyList_as_object.nt> ;
    .
 
 <#repeated_semis_at_end> rdf:type rdft:TestTurtleEval ;

--- a/turtle/predicateObjectList_with_blankNodePropertyList_as_object.nt
+++ b/turtle/predicateObjectList_with_blankNodePropertyList_as_object.nt
@@ -1,0 +1,5 @@
+<http://a.example/s> <http://a.example/p> _:b1 .
+_:b1 <http://a.example/p2> <http://a.example/o> .
+<http://a.example/s> <http://a.example/p3> _:b2 .
+_:b2 <http://a.example/p4> <http://a.example/o2> .
+_:b2 <http://a.example/p4> <http://a.example/o3> .

--- a/turtle/predicateObjectList_with_blankNodePropertyList_as_object.ttl
+++ b/turtle/predicateObjectList_with_blankNodePropertyList_as_object.ttl
@@ -1,0 +1,3 @@
+<http://a.example/s> <http://a.example/p>  [ <http://a.example/p2> <http://a.example/o> ]
+                   ; <http://a.example/p3> [ <http://a.example/p4> <http://a.example/o2>
+                                                                 , <http://a.example/o3> ] .


### PR DESCRIPTION
The three tests provide additional blankNodePropertyList tests. They
are not intended to ensure that syntax for blank node property lists
are correctly parsed when used either as a subject or as an object,
because these cases are covered by tests:

blankNodePropertyList_as_subject
blankNodePropertyList_as_object

Rather, these three new test cases check that blank nodes are created
and used (and subsequently no longer used) in the correct places in
the constructed RDF graph after parsing.

These three additional tests uncovered bugs in the rdf4h Haskell RDF
parser, that were not highlighted by any of the existing rdf-tests
tests. Fixes to bugs uncovered by these new tests:

https://github.com/robstewart57/rdf4h/commit/ff435dffd63bb5f5ff8b2eefe9d575d1fb7cbffd