### PR TITLE
Add RDF/XML reports

### DIFF
--- a/rdf-xml/reports/README
+++ b/rdf-xml/reports/README
@@ -1,0 +1,11 @@
+This is a collection of individual EARL reports for
+test subjects claiming RDF/XML processor conformance.
+
+The consolodated report is saved to index.html generated
+using the earl-report Ruby gem. Run it as follows:
+
+gem install earl-report
+
+earl-report --format json -o earl.jsonld *.ttl --manifest ../manifest.ttl --base https://www.w3.org/2013/RDFXMLTests/manifest.ttl --name RDF/XML --bibRef [[RDFXML]]
+earl-report --json --format ttl -o earl.ttl earl.jsonld
+earl-report --json --format html --template template.md -o index.html earl.jsonld

--- a/rdf-xml/reports/earl.jsonld
+++ b/rdf-xml/reports/earl.jsonld
@@ -1,0 +1,4670 @@
+{
+  "@context": {
+    "@vocab": "http://www.w3.org/ns/earl#",
+    "foaf:homepage": {
+      "@type": "@id"
+    },
+    "dc": "http://purl.org/dc/terms/",
+    "doap": "http://usefulinc.com/ns/doap#",
+    "earl": "http://www.w3.org/ns/earl#",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "assertedBy": {
+      "@type": "@id"
+    },
+    "assertions": {
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "bibRef": {
+      "@id": "dc:bibliographicCitation"
+    },
+    "created": {
+      "@id": "doap:created",
+      "@type": "xsd:date"
+    },
+    "description": {
+      "@id": "rdfs:comment",
+      "@language": "en"
+    },
+    "developer": {
+      "@id": "doap:developer",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "doapDesc": {
+      "@id": "doap:description",
+      "@language": "en"
+    },
+    "generatedBy": {
+      "@type": "@id"
+    },
+    "homepage": {
+      "@id": "doap:homepage",
+      "@type": "@id"
+    },
+    "language": {
+      "@id": "doap:programming-language"
+    },
+    "license": {
+      "@id": "doap:license",
+      "@type": "@id"
+    },
+    "mode": {
+      "@type": "@id"
+    },
+    "name": {
+      "@id": "doap:name"
+    },
+    "outcome": {
+      "@type": "@id"
+    },
+    "release": {
+      "@id": "doap:release",
+      "@type": "@id"
+    },
+    "revision": {
+      "@id": "doap:revision"
+    },
+    "shortdesc": {
+      "@id": "doap:shortdesc",
+      "@language": "en"
+    },
+    "subject": {
+      "@type": "@id"
+    },
+    "test": {
+      "@type": "@id"
+    },
+    "testAction": {
+      "@id": "mf:action",
+      "@type": "@id"
+    },
+    "testResult": {
+      "@id": "mf:result",
+      "@type": "@id"
+    },
+    "title": {
+      "@id": "mf:name"
+    },
+    "entries": {
+      "@id": "mf:entries",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "testSubjects": {
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "xsd": {
+      "@id": "http://www.w3.org/2001/XMLSchema#"
+    }
+  },
+  "@id": "",
+  "@type": [
+    "doap:Project",
+    "Software"
+  ],
+  "assertions": [
+    "rdfxml-streaming-parser.js.ttl"
+  ],
+  "bibRef": "[[RDFXML]]",
+  "entries": [
+    {
+      "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "entries": [
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#amp-in-url-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#amp-in-url-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Description: the purpose of this test case is to show how one\nof XML's Predefined Entities - in this case the ampersand - is\nrepresented when it is used in the value of an rdf:about\nattribute. The ampersand is represented by its numeric\ncharacter reference as specified in:\nhttp://www.w3.org/TR/REC-xml#sec-predefined-ent In the\nassociated N-Triples file, the ampersand will be represented\nwith a single ampersand character (and not the ampersand's\nnumeric character reference). Note: when a XML/HTML browser is\nused to display this file, a single ampersand character may be\ndisplayed and not the ampersand's numeric character reference.\nIn this case, the browser may provide an alternate way to view\nthe file (such as viewing the file's source or saving to a\nfile).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/amp-in-url/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/amp-in-url/test001.nt",
+          "title": "amp-in-url-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    A simple datatype production; a language+datatype production.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/datatypes/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/datatypes/test001.nt",
+          "title": "datatypes-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    A parser is not required to know about well-formed datatyped\nliterals.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/datatypes/test002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/datatypes/test002.nt",
+          "title": "datatypes-test002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-literals-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-literals-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Does the treatment of literals conform to charmod ? Test for\nsuccess of legal Normal Form C literal\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-charmod-literals/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-charmod-literals/test001.nt",
+          "title": "rdf-charmod-literals-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    A uriref is allowed to match non-US ASCII forms conforming to\nUnicode Normal Form C. No escaping algorithm is applied.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-charmod-uris/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-charmod-uris/test001.nt",
+          "title": "rdf-charmod-uris-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    A uriref which already has % escaping is permitted. No\nunescaping algorithm is applied.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-charmod-uris/test002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-charmod-uris/test002.nt",
+          "title": "rdf-charmod-uris-test002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:li is not allowed as as an attribute\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/error001.rdf",
+          "title": "rdf-containers-syntax-vs-schema-error001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:li elements as typed nodes - a bizarre case As specified\nin\nhttp://lists.w3.org/Archives/Public/w3c-rdfcore-wg/2001Nov/0651.html\nis not an error.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/error002.rdf",
+          "title": "rdf-containers-syntax-vs-schema-error002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Simple container\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test001.nt",
+          "title": "rdf-containers-syntax-vs-schema-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:li is unaffected by other rdf:_nnn properties. This test\ncase is concerned only with defining the triples that this\nparticular example RDF/XML represents. It is not concerned\nwith whether that collection of triples violates any other\nconstraints, e.g. restrictions on the number of rdf:_1\nproperties that may be defined for a resource.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test002.nt",
+          "title": "rdf-containers-syntax-vs-schema-test002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:li elements can exist in any description element\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test003.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test003.nt",
+          "title": "rdf-containers-syntax-vs-schema-test003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:li elements match any of the property element productions\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test004.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test004.nt",
+          "title": "rdf-containers-syntax-vs-schema-test004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test006",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test006"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    containers match the typed node production\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test006.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test006.nt",
+          "title": "rdf-containers-syntax-vs-schema-test006"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test007",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test007"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:li processing within each element is independent\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test007.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test007.nt",
+          "title": "rdf-containers-syntax-vs-schema-test007"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test008",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test008"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:li processing is per element, not per resource.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test008.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test008.nt",
+          "title": "rdf-containers-syntax-vs-schema-test008"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    A surrounding rdf:RDF element is no longer mandatory.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-element-not-mandatory/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-element-not-mandatory/test001.nt",
+          "title": "rdf-element-not-mandatory-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    RDF attributes that are required to have an rdf: prefix about\naboutEach ID bagID type resource parseType\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0001.nt",
+          "title": "rdf-ns-prefix-confusion-test0001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    RDF attributes that are required to have an rdf: prefix about\naboutEach ID bagID type resource parseType\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0003.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0003.nt",
+          "title": "rdf-ns-prefix-confusion-test0003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    RDF attributes that are required to have an rdf: prefix about\naboutEach ID bagID type resource parseType\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0004.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0004.nt",
+          "title": "rdf-ns-prefix-confusion-test0004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0005",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0005"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    RDF attributes that are required to have an rdf: prefix about\naboutEach ID bagID type resource parseType\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0005.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0005.nt",
+          "title": "rdf-ns-prefix-confusion-test0005"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0006",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0006"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    RDF attributes that are required to have an rdf: prefix about\naboutEach ID bagID type resource parseType\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0006.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0006.nt",
+          "title": "rdf-ns-prefix-confusion-test0006"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0009",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0009"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Namespace qualification MUST be used for all property\nattributes.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0009.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0009.nt",
+          "title": "rdf-ns-prefix-confusion-test0009"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0010",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0010"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Non-prefixed RDF elements (NOT attributes) are allowed when a\ndefault XML element namespace is defined with an\nxmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" attribute.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0010.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0010.nt",
+          "title": "rdf-ns-prefix-confusion-test0010"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0011",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0011"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Non-prefixed RDF elements (NOT attributes) are allowed when a\ndefault XML element namespace is defined with an\nxmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" attribute.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0011.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0011.nt",
+          "title": "rdf-ns-prefix-confusion-test0011"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0012",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0012"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Non-prefixed RDF elements (NOT attributes) are allowed when a\ndefault XML element namespace is defined with an\nxmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" attribute.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0012.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0012.nt",
+          "title": "rdf-ns-prefix-confusion-test0012"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0013",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0013"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Non-prefixed RDF elements (NOT attributes) are allowed when a\ndefault XML element namespace is defined with an\nxmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" attribute.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0013.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0013.nt",
+          "title": "rdf-ns-prefix-confusion-test0013"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0014",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0014"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Non-prefixed RDF elements (NOT attributes) are allowed when a\ndefault XML element namespace is defined with an\nxmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" attribute.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0014.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0014.nt",
+          "title": "rdf-ns-prefix-confusion-test0014"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    aboutEach removed from the RDF specifications. See URI above\nfor further details.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-abouteach/error001.rdf",
+          "title": "rdfms-abouteach-error001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    aboutEach removed from the RDF specifications. See URI above\nfor further details.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-abouteach/error002.rdf",
+          "title": "rdfms-abouteach-error002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-error1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-error1"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    two elements cannot use the same ID\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/error1.rdf",
+          "title": "rdfms-difference-between-ID-and-about-error1"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test1",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test1"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    A statement with an rdf:ID creates a regular triple.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test1.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test1.nt",
+          "title": "rdfms-difference-between-ID-and-about-test1"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test2",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test2"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    This test shows the treatment of non-ASCII characters in the\nvalue of rdf:ID attribute.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test2.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test2.nt",
+          "title": "rdfms-difference-between-ID-and-about-test2"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test3",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test3"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    This test shows the treatment of non-ASCII characters in the\nvalue of rdf:about attribute.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test3.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test3.nt",
+          "title": "rdfms-difference-between-ID-and-about-test3"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-duplicate-member-props-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-duplicate-member-props-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The question posed to the RDF WG was: should an RDF document\ncontaining multiple rdf:_n properties (with the same n) on an\nelement be rejected as illegal? The WG decided that a parser\nshould accept that case as legal RDF.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-duplicate-member-props/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-duplicate-member-props/test001.nt",
+          "title": "rdfms-duplicate-member-props-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    This is not legal RDF; specifying an rdf:parseType of\n\"Literal\" and an rdf:resource attribute at the same time is an\nerror.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/error001.rdf",
+          "title": "rdfms-empty-property-elements-error001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    This is not legal RDF; specifying an rdf:parseType of\n\"Literal\" and an rdf:resource attribute at the same time is an\nerror.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/error002.rdf",
+          "title": "rdfms-empty-property-elements-error002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The rdf:resource attribute means that the value of this\nproperty element is a resource.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test001.nt",
+          "title": "rdfms-empty-property-elements-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The basic case. An empty property element just gives an empty\nliteral.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test002.nt",
+          "title": "rdfms-empty-property-elements-test002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    If the parseType indicates the value is a resource, we must\ncreate one. With no additional information, the resource is\nanonymous.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test004.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test004.nt",
+          "title": "rdfms-empty-property-elements-test004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test005",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test005"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    An empty property element just gives an empty literal. We\nreify the statement at the same time.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test005.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test005.nt",
+          "title": "rdfms-empty-property-elements-test005"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test006",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test006"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Here the parseType indicates that we should create a resource.\nWe also reify the generated statement.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test006.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test006.nt",
+          "title": "rdfms-empty-property-elements-test006"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test007",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test007"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    As test001.rdf; this uses an explicit closing tag.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test007.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test007.nt",
+          "title": "rdfms-empty-property-elements-test007"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test008",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test008"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    As test002.rdf; this uses an explicit closing tag.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test008.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test008.nt",
+          "title": "rdfms-empty-property-elements-test008"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test010",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test010"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    As test004.rdf; this uses an explicit closing tag.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test010.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test010.nt",
+          "title": "rdfms-empty-property-elements-test010"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test011",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test011"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    As test005.rdf; this uses an explicit closing tag.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test011.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test011.nt",
+          "title": "rdfms-empty-property-elements-test011"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test012",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test012"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    As test006.rdf; this uses an explicit closing tag.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test012.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test012.nt",
+          "title": "rdfms-empty-property-elements-test012"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test013",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test013"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Test of the last alternative for production [6.12],\ninterpreted according to RDFMS paragraphs 229-234:\nhttp://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test013.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test013.nt",
+          "title": "rdfms-empty-property-elements-test013"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test014",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test014"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Test of the last alternative for production [6.12],\ninterpreted according to RDFMS paragraphs 229-234:\nhttp://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test014.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test014.nt",
+          "title": "rdfms-empty-property-elements-test014"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test015",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test015"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Test of the last alternative for production [6.12],\ninterpreted according to RDFMS paragraphs 229-234:\nhttp://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229\nHere we have an explicit closing tag. This does not match any\nof the productions in the original document, but is\nindistinguishable from test014 as far as XML is concerned.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test015.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test015.nt",
+          "title": "rdfms-empty-property-elements-test015"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test016",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test016"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Like rdfms-empty-property-elements/test001.rdf but with a\nprocessing instruction as the only content of the otherwise\nempty element.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test016.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test016.nt",
+          "title": "rdfms-empty-property-elements-test016"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test017",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test017"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Like rdfms-empty-property-elements/test001.rdf but with a\ncomment as the only content of the otherwise empty element.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test017.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test017.nt",
+          "title": "rdfms-empty-property-elements-test017"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    a RDF Description with no ID or about attribute describes an\nun-named resource, aka a bNode.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test001.nt",
+          "title": "rdfms-identity-anon-resources-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    a RDF Description with no ID or about attribute describes an\nun-named resource, aka a bNode.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test002.nt",
+          "title": "rdfms-identity-anon-resources-test002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    a RDF container (in this case a Bag) without an ID attribute\ndescribes an un-named resource, aka a bNode.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test003.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test003.nt",
+          "title": "rdfms-identity-anon-resources-test003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    a RDF container (in this case an Alt) without an ID attribute\ndescribes an un-named resource, aka a bNode.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test004.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test004.nt",
+          "title": "rdfms-identity-anon-resources-test004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test005",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test005"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    a RDF container (in this case an Seq) without an ID attribute\ndescribes an un-named resource, aka a bNode.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test005.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test005.nt",
+          "title": "rdfms-identity-anon-resources-test005"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:ID on an empty property element indicates reification.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test001.nt",
+          "title": "rdfms-not-id-and-resource-attr-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:reource on an empty property element indicates the URI of\nthe object.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test002.nt",
+          "title": "rdfms-not-id-and-resource-attr-test002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:ID and rdf:resource are allowed together on empty property\nelement.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test004.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test004.nt",
+          "title": "rdfms-not-id-and-resource-attr-test004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test005",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test005"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:ID and rdf:resource are allowed together on empty property\nelement.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test005.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test005.nt",
+          "title": "rdfms-not-id-and-resource-attr-test005"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-para196-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-para196-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    test case showing that the 2nd URI in M Paragraph 196 is\npermitted as a namespace URI (and any namespace URI starting\nwith that URI)\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-para196/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-para196/test001.nt",
+          "title": "rdfms-para196-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The value of rdf:ID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error001.rdf",
+          "title": "rdfms-rdf-id-error001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The value of rdf:ID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error002.rdf",
+          "title": "rdfms-rdf-id-error002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The value of rdf:ID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error003.rdf",
+          "title": "rdfms-rdf-id-error003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The value of rdf:ID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error004.rdf",
+          "title": "rdfms-rdf-id-error004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error005",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error005"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The value of rdf:ID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error005.rdf",
+          "title": "rdfms-rdf-id-error005"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error006",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error006"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The value of rdf:bagID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error006.rdf",
+          "title": "rdfms-rdf-id-error006"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error007",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error007"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The value of rdf:bagID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error007.rdf",
+          "title": "rdfms-rdf-id-error007"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    RDF is forbidden as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-001.rdf",
+          "title": "rdfms-rdf-names-use-error-001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    ID is forbidden as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-002.rdf",
+          "title": "rdfms-rdf-names-use-error-002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    about is forbidden as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-003.rdf",
+          "title": "rdfms-rdf-names-use-error-003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    bagID is forbidden as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-004.rdf",
+          "title": "rdfms-rdf-names-use-error-004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-005",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-005"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    parseType is forbidden as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-005.rdf",
+          "title": "rdfms-rdf-names-use-error-005"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-006",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-006"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    resource is forbidden as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-006.rdf",
+          "title": "rdfms-rdf-names-use-error-006"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-007",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-007"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    nodeID is forbidden as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-007.rdf",
+          "title": "rdfms-rdf-names-use-error-007"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-008",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-008"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    li is forbidden as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-008.rdf",
+          "title": "rdfms-rdf-names-use-error-008"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-009",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-009"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    aboutEach is forbidden as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-009.rdf",
+          "title": "rdfms-rdf-names-use-error-009"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-010",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-010"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    aboutEachPrefix is forbidden as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-010.rdf",
+          "title": "rdfms-rdf-names-use-error-010"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-011",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-011"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Description is forbidden as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-011.rdf",
+          "title": "rdfms-rdf-names-use-error-011"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-012",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-012"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    RDF is forbidden as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-012.rdf",
+          "title": "rdfms-rdf-names-use-error-012"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-013",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-013"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    ID is forbidden as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-013.rdf",
+          "title": "rdfms-rdf-names-use-error-013"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-014",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-014"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    about is forbidden as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-014.rdf",
+          "title": "rdfms-rdf-names-use-error-014"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-015",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-015"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    bagID is forbidden as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-015.rdf",
+          "title": "rdfms-rdf-names-use-error-015"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-016",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-016"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    parseType is forbidden as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-016.rdf",
+          "title": "rdfms-rdf-names-use-error-016"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-017",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-017"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    resource is forbidden as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-017.rdf",
+          "title": "rdfms-rdf-names-use-error-017"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-018",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-018"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    nodeID is forbidden as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-018.rdf",
+          "title": "rdfms-rdf-names-use-error-018"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-019",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-019"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    aboutEach is forbidden as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-019.rdf",
+          "title": "rdfms-rdf-names-use-error-019"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-020",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-020"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    aboutEachPrefix is forbidden as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-020.rdf",
+          "title": "rdfms-rdf-names-use-error-020"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Description is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-001.nt",
+          "title": "rdfms-rdf-names-use-test-001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Seq is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-002.nt",
+          "title": "rdfms-rdf-names-use-test-002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Bag is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-003.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-003.nt",
+          "title": "rdfms-rdf-names-use-test-003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Alt is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-004.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-004.nt",
+          "title": "rdfms-rdf-names-use-test-004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-005",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-005"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Statement is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-005.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-005.nt",
+          "title": "rdfms-rdf-names-use-test-005"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-006",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-006"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Property is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-006.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-006.nt",
+          "title": "rdfms-rdf-names-use-test-006"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-007",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-007"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    List is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-007.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-007.nt",
+          "title": "rdfms-rdf-names-use-test-007"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-008",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-008"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    subject is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-008.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-008.nt",
+          "title": "rdfms-rdf-names-use-test-008"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-009",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-009"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    predicate is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-009.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-009.nt",
+          "title": "rdfms-rdf-names-use-test-009"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-010",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-010"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    object is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-010.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-010.nt",
+          "title": "rdfms-rdf-names-use-test-010"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-011",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-011"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    type is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-011.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-011.nt",
+          "title": "rdfms-rdf-names-use-test-011"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-012",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-012"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    value is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-012.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-012.nt",
+          "title": "rdfms-rdf-names-use-test-012"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-013",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-013"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    first is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-013.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-013.nt",
+          "title": "rdfms-rdf-names-use-test-013"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-014",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-014"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rest is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-014.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-014.nt",
+          "title": "rdfms-rdf-names-use-test-014"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-015",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-015"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    _1 is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-015.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-015.nt",
+          "title": "rdfms-rdf-names-use-test-015"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-016",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-016"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    nil is allowed as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-016.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-016.nt",
+          "title": "rdfms-rdf-names-use-test-016"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-017",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-017"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Seq is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-017.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-017.nt",
+          "title": "rdfms-rdf-names-use-test-017"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-018",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-018"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Bag is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-018.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-018.nt",
+          "title": "rdfms-rdf-names-use-test-018"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-019",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-019"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Alt is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-019.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-019.nt",
+          "title": "rdfms-rdf-names-use-test-019"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-020",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-020"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Statement is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-020.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-020.nt",
+          "title": "rdfms-rdf-names-use-test-020"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-021",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-021"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Property is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-021.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-021.nt",
+          "title": "rdfms-rdf-names-use-test-021"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-022",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-022"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    List is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-022.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-022.nt",
+          "title": "rdfms-rdf-names-use-test-022"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-023",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-023"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    subject is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-023.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-023.nt",
+          "title": "rdfms-rdf-names-use-test-023"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-024",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-024"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    predicate is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-024.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-024.nt",
+          "title": "rdfms-rdf-names-use-test-024"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-025",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-025"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    object is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-025.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-025.nt",
+          "title": "rdfms-rdf-names-use-test-025"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-026",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-026"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    type is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-026.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-026.nt",
+          "title": "rdfms-rdf-names-use-test-026"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-027",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-027"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    value is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-027.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-027.nt",
+          "title": "rdfms-rdf-names-use-test-027"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-028",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-028"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    first is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-028.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-028.nt",
+          "title": "rdfms-rdf-names-use-test-028"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-029",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-029"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rest is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-029.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-029.nt",
+          "title": "rdfms-rdf-names-use-test-029"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-030",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-030"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    _1 is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-030.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-030.nt",
+          "title": "rdfms-rdf-names-use-test-030"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-031",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-031"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    li is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-031.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-031.nt",
+          "title": "rdfms-rdf-names-use-test-031"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-032",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-032"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Seq is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-032.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-032.nt",
+          "title": "rdfms-rdf-names-use-test-032"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-033",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-033"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Bag is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-033.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-033.nt",
+          "title": "rdfms-rdf-names-use-test-033"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-034",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-034"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Alt is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-034.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-034.nt",
+          "title": "rdfms-rdf-names-use-test-034"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-035",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-035"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Statement is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-035.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-035.nt",
+          "title": "rdfms-rdf-names-use-test-035"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-036",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-036"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Property is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-036.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-036.nt",
+          "title": "rdfms-rdf-names-use-test-036"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-037",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-037"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    List is allowed as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-037.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-037.nt",
+          "title": "rdfms-rdf-names-use-test-037"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    foo is allowed with warnings as a node element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-001.nt",
+          "title": "rdfms-rdf-names-use-warn-001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    foo is allowed with warnings as a property element name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-002.nt",
+          "title": "rdfms-rdf-names-use-warn-002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    foo is allowed with warnings as a property attribute name.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-003.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-003.nt",
+          "title": "rdfms-rdf-names-use-warn-003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-reification-required-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-reification-required-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    A parser is not required to generate a bag of reified\nstatements for all description elements.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-reification-required/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-reification-required/test001.nt",
+          "title": "rdfms-reification-required-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-seq-representation-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-seq-representation-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:parseType=\"Collection\" is parsed like the nonstandard\ndaml:collection.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-seq-representation/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-seq-representation/test001.nt",
+          "title": "rdfms-seq-representation-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:nodeID can be used to label a blank node.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test001.nt",
+          "title": "rdfms-syntax-incomplete-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    rdf:nodeID can be used to label a blank node. These have file\nscope and are distinct from any unlabelled blank nodes.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test002.nt",
+          "title": "rdfms-syntax-incomplete-test002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    On an rdf:Description or typed node rdf:nodeID behaves\nsimilarly to an rdf:about.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test003.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test003.nt",
+          "title": "rdfms-syntax-incomplete-test003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    On a property element rdf:nodeID behaves similarly to\nrdf:resource.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test004.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test004.nt",
+          "title": "rdfms-syntax-incomplete-test004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The value of rdf:nodeID must match the XML Name production,\n(as modified by XML Namespaces).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error001.rdf",
+          "title": "rdfms-syntax-incomplete-error001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The value of rdf:nodeID must match the XML Name production,\n(as modified by XML Namespaces).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error002.rdf",
+          "title": "rdfms-syntax-incomplete-error002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    The value of rdf:nodeID must match the XML Name production,\n(as modified by XML Namespaces).\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error003.rdf",
+          "title": "rdfms-syntax-incomplete-error003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Cannot have rdf:nodeID and rdf:ID.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error004.rdf",
+          "title": "rdfms-syntax-incomplete-error004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error005",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error005"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Cannot have rdf:nodeID and rdf:about.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error005.rdf",
+          "title": "rdfms-syntax-incomplete-error005"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error006",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error006"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Cannot have rdf:nodeID and rdf:resource.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error006.rdf",
+          "title": "rdfms-syntax-incomplete-error006"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-uri-substructure-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-uri-substructure-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Demonstrates the Recommended partitioning of a URI into a\nnamespace part and a localname part\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-uri-substructure/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-uri-substructure/test001.nt",
+          "title": "rdfms-uri-substructure-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    In-scope xml:lang applies to element content literal values\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test003.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test003.nt",
+          "title": "rdfms-xmllang-test003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    In-scope xml:lang applies to element content literal values\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test004.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test004.nt",
+          "title": "rdfms-xmllang-test004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test005",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test005"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    In-scope xml:lang applies to element content literal values\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test005.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test005.nt",
+          "title": "rdfms-xmllang-test005"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test006",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test006"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    In-scope xml:lang applies to element content literal values\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test006.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test006.nt",
+          "title": "rdfms-xmllang-test006"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    a RDF Property may have more than one domain property\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfs-domain-and-range/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfs-domain-and-range/test001.nt",
+          "title": "rdfs-domain-and-range-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    a RDF Property may have more than one domain property\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/rdfs-domain-and-range/test002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/rdfs-domain-and-range/test002.nt",
+          "title": "rdfs-domain-and-range-test002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Unrecognized attributes in the xml namespace should be\nignored.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/unrecognised-xml-attributes/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/unrecognised-xml-attributes/test001.nt",
+          "title": "unrecognised-xml-attributes-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Unrecognized attributes in the xml namespace should be\nignored.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/unrecognised-xml-attributes/test002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/unrecognised-xml-attributes/test002.nt",
+          "title": "unrecognised-xml-attributes-test002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xml-canon-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xml-canon-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Demonstrating the canonicalisation of XMLLiterals.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xml-canon/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xml-canon/test001.nt",
+          "title": "xml-canon-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test001",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test001"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    xml:base applies to an rdf:ID on an rdf:Description element.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test001.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test001.nt",
+          "title": "xmlbase-test001"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test002",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test002"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    xml:base applies to an rdf:resource attribute.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test002.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test002.nt",
+          "title": "xmlbase-test002"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test003",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test003"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    xml:base applies to an rdf:about attribute.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test003.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test003.nt",
+          "title": "xmlbase-test003"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test004",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test004"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    xml:base applies to an rdf:ID on a property element.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test004.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test004.nt",
+          "title": "xmlbase-test004"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test006",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test006"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    xml:base scoping.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test006.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test006.nt",
+          "title": "xmlbase-test006"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test007",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test007"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    example of relative URI resolution.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test007.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test007.nt",
+          "title": "xmlbase-test007"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test008",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test008"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    example of empty same document ref resolution.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test008.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test008.nt",
+          "title": "xmlbase-test008"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test009",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test009"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Example of relative uri with absolute path resolution.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test009.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test009.nt",
+          "title": "xmlbase-test009"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test010",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test010"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Example of relative uri with net path resolution.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test010.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test010.nt",
+          "title": "xmlbase-test010"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test011",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test011"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Example of xml:base with no path component.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test011.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test011.nt",
+          "title": "xmlbase-test011"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test013",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test013"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    With an xml:base with fragment the fragment is ignored.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test013.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test013.nt",
+          "title": "xmlbase-test013"
+        },
+        {
+          "@id": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test014",
+          "@type": [
+            "http://www.w3.org/ns/rdftest#TestXMLEval",
+            "TestCase",
+            "TestCriterion"
+          ],
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              },
+              "subject": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+              "test": "https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test014"
+            }
+          ],
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Approved"
+          },
+          "rdfs:comment": "\n    Test output corrected to use correct base URL.\n  ",
+          "testAction": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test014.rdf",
+          "testResult": "https://www.w3.org/2013/RDFXMLTests/xmlbase/test014.nt",
+          "title": "xmlbase-test014"
+        }
+      ],
+      "rdfs:label": "RDF/XML Syntax tests"
+    }
+  ],
+  "generatedBy": {
+    "@id": "http://rubygems.org/gems/earl-report",
+    "@type": [
+      "doap:Project",
+      "Software"
+    ],
+    "developer": [
+      "http://greggkellogg.net/foaf#me"
+    ],
+    "doapDesc": "EarlReport generates HTML+RDFa rollups of multiple EARL reports",
+    "homepage": "https://github.com/gkellogg/earl-report",
+    "language": "Ruby",
+    "license": "http://unlicense.org",
+    "name": "earl-report",
+    "release": {
+      "@id": "https://github.com/gkellogg/earl-report/tree/0.4.6",
+      "@type": "doap:Version",
+      "created": "2018-09-28",
+      "name": "earl-report-0.4.6",
+      "revision": "0.4.6"
+    },
+    "shortdesc": "Earl Report summary generator"
+  },
+  "name": "RDF/XML",
+  "testSubjects": [
+    {
+      "@id": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+      "@type": [
+        "doap:Project",
+        "TestSubject",
+        "Software"
+      ],
+      "developer": [
+        {
+          "@id": "https://www.rubensworks.net/#me",
+          "@type": [
+            "Assertor",
+            "foaf:Person"
+          ],
+          "foaf:homepage": "https://www.rubensworks.net/",
+          "foaf:name": "Ruben Taelman <rubensworks@gmail.com>"
+        }
+      ],
+      "doapDesc": "Streaming RDF/XML parser",
+      "homepage": "https://github.com/rdfjs/rdfxml-streaming-parser.js#readme",
+      "language": "JavaScript",
+      "name": "rdfxml-streaming-parser"
+    }
+  ]
+}

--- a/rdf-xml/reports/earl.ttl
+++ b/rdf-xml/reports/earl.ttl
@@ -1,0 +1,3680 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a doap:Project,
+     earl:Software;
+   dc:bibliographicCitation "[[RDFXML]]";
+   doap:name "RDF/XML";
+   mf:entries (<https://www.w3.org/2013/RDFXMLTests/manifest.ttl>);
+   earl:assertions <http://example.org/rdfxml-streaming-parser.js.ttl>;
+   earl:generatedBy <http://rubygems.org/gems/earl-report>;
+   earl:testSubjects <https://www.npmjs.com/package/rdfxml-streaming-parser/> .
+
+# Manifests
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl> a mf:Manifest,
+     earl:Report;
+   rdfs:label "RDF/XML Syntax tests";
+   mf:entries (<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#amp-in-url-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-literals-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test006> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test007> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test008> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0005> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0006> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0009> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0010> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0011> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0012> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0013> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0014> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-error1> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test1> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test2> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test3> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-duplicate-member-props-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test005> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test006> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test007> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test008> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test010> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test011> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test012> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test013> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test014> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test015> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test016> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test017> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test005> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test005> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-para196-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error005> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error006> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error007> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-005> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-006> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-007> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-008> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-009> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-010> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-011> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-012> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-013> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-014> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-015> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-016> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-017> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-018> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-019> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-020> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-005> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-006> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-007> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-008> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-009> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-010> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-011> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-012> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-013> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-014> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-015> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-016> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-017> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-018> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-019> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-020> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-021> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-022> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-023> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-024> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-025> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-026> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-027> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-028> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-029> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-030> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-031> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-032> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-033> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-034> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-035> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-036> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-037> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-reification-required-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-seq-representation-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error005> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error006> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-uri-substructure-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test005> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test006> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xml-canon-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test001> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test002> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test003> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test004> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test006> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test007> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test008> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test009> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test010> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test011> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test013> <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test014>) .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#amp-in-url-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Description: the purpose of this test case is to show how one
+of XML's Predefined Entities - in this case the ampersand - is
+represented when it is used in the value of an rdf:about
+attribute. The ampersand is represented by its numeric
+character reference as specified in:
+http://www.w3.org/TR/REC-xml#sec-predefined-ent In the
+associated N-Triples file, the ampersand will be represented
+with a single ampersand character (and not the ampersand's
+numeric character reference). Note: when a XML/HTML browser is
+used to display this file, a single ampersand character may be
+displayed and not the ampersand's numeric character reference.
+In this case, the browser may provide an alternate way to view
+the file (such as viewing the file's source or saving to a
+file).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/amp-in-url/test001.rdf>;
+   mf:name "amp-in-url-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/amp-in-url/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#amp-in-url-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    A simple datatype production; a language+datatype production.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/datatypes/test001.rdf>;
+   mf:name "datatypes-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/datatypes/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    A parser is not required to know about well-formed datatyped
+literals.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/datatypes/test002.rdf>;
+   mf:name "datatypes-test002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/datatypes/test002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-literals-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Does the treatment of literals conform to charmod ? Test for
+success of legal Normal Form C literal
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-charmod-literals/test001.rdf>;
+   mf:name "rdf-charmod-literals-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-charmod-literals/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-literals-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    A uriref is allowed to match non-US ASCII forms conforming to
+Unicode Normal Form C. No escaping algorithm is applied.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-charmod-uris/test001.rdf>;
+   mf:name "rdf-charmod-uris-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-charmod-uris/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    A uriref which already has % escaping is permitted. No
+unescaping algorithm is applied.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-charmod-uris/test002.rdf>;
+   mf:name "rdf-charmod-uris-test002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-charmod-uris/test002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    rdf:li is not allowed as as an attribute
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/error001.rdf>;
+   mf:name "rdf-containers-syntax-vs-schema-error001";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    rdf:li elements as typed nodes - a bizarre case As specified
+in
+http://lists.w3.org/Archives/Public/w3c-rdfcore-wg/2001Nov/0651.html
+is not an error.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/error002.rdf>;
+   mf:name "rdf-containers-syntax-vs-schema-error002";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Simple container
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test001.rdf>;
+   mf:name "rdf-containers-syntax-vs-schema-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:li is unaffected by other rdf:_nnn properties. This test
+case is concerned only with defining the triples that this
+particular example RDF/XML represents. It is not concerned
+with whether that collection of triples violates any other
+constraints, e.g. restrictions on the number of rdf:_1
+properties that may be defined for a resource.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test002.rdf>;
+   mf:name "rdf-containers-syntax-vs-schema-test002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:li elements can exist in any description element
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test003.rdf>;
+   mf:name "rdf-containers-syntax-vs-schema-test003";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test003.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:li elements match any of the property element productions
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test004.rdf>;
+   mf:name "rdf-containers-syntax-vs-schema-test004";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test004.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test006> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    containers match the typed node production
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test006.rdf>;
+   mf:name "rdf-containers-syntax-vs-schema-test006";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test006.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test006>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test007> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:li processing within each element is independent
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test007.rdf>;
+   mf:name "rdf-containers-syntax-vs-schema-test007";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test007.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test007>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test008> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:li processing is per element, not per resource.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test008.rdf>;
+   mf:name "rdf-containers-syntax-vs-schema-test008";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-containers-syntax-vs-schema/test008.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test008>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    A surrounding rdf:RDF element is no longer mandatory.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-element-not-mandatory/test001.rdf>;
+   mf:name "rdf-element-not-mandatory-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-element-not-mandatory/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    RDF attributes that are required to have an rdf: prefix about
+aboutEach ID bagID type resource parseType
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0001.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    RDF attributes that are required to have an rdf: prefix about
+aboutEach ID bagID type resource parseType
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0003.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0003";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0003.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    RDF attributes that are required to have an rdf: prefix about
+aboutEach ID bagID type resource parseType
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0004.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0004";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0004.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0005> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    RDF attributes that are required to have an rdf: prefix about
+aboutEach ID bagID type resource parseType
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0005.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0005";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0005.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0005>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0006> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    RDF attributes that are required to have an rdf: prefix about
+aboutEach ID bagID type resource parseType
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0006.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0006";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0006.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0006>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0009> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Namespace qualification MUST be used for all property
+attributes.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0009.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0009";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0009.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0009>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0010> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Non-prefixed RDF elements (NOT attributes) are allowed when a
+default XML element namespace is defined with an
+xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" attribute.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0010.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0010";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0010.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0010>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0011> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Non-prefixed RDF elements (NOT attributes) are allowed when a
+default XML element namespace is defined with an
+xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" attribute.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0011.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0011";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0011.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0011>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0012> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Non-prefixed RDF elements (NOT attributes) are allowed when a
+default XML element namespace is defined with an
+xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" attribute.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0012.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0012";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0012.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0012>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0013> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Non-prefixed RDF elements (NOT attributes) are allowed when a
+default XML element namespace is defined with an
+xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" attribute.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0013.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0013";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0013.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0013>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0014> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Non-prefixed RDF elements (NOT attributes) are allowed when a
+default XML element namespace is defined with an
+xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" attribute.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0014.rdf>;
+   mf:name "rdf-ns-prefix-confusion-test0014";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdf-ns-prefix-confusion/test0014.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0014>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    aboutEach removed from the RDF specifications. See URI above
+for further details.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-abouteach/error001.rdf>;
+   mf:name "rdfms-abouteach-error001";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    aboutEach removed from the RDF specifications. See URI above
+for further details.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-abouteach/error002.rdf>;
+   mf:name "rdfms-abouteach-error002";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-error1> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    two elements cannot use the same ID
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/error1.rdf>;
+   mf:name "rdfms-difference-between-ID-and-about-error1";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-error1>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test1> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    A statement with an rdf:ID creates a regular triple.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test1.rdf>;
+   mf:name "rdfms-difference-between-ID-and-about-test1";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test1.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test1>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test2> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    This test shows the treatment of non-ASCII characters in the
+value of rdf:ID attribute.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test2.rdf>;
+   mf:name "rdfms-difference-between-ID-and-about-test2";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test2.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test2>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test3> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    This test shows the treatment of non-ASCII characters in the
+value of rdf:about attribute.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test3.rdf>;
+   mf:name "rdfms-difference-between-ID-and-about-test3";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-difference-between-ID-and-about/test3.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test3>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-duplicate-member-props-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    The question posed to the RDF WG was: should an RDF document
+containing multiple rdf:_n properties (with the same n) on an
+element be rejected as illegal? The WG decided that a parser
+should accept that case as legal RDF.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-duplicate-member-props/test001.rdf>;
+   mf:name "rdfms-duplicate-member-props-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-duplicate-member-props/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-duplicate-member-props-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    This is not legal RDF; specifying an rdf:parseType of
+"Literal" and an rdf:resource attribute at the same time is an
+error.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/error001.rdf>;
+   mf:name "rdfms-empty-property-elements-error001";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    This is not legal RDF; specifying an rdf:parseType of
+"Literal" and an rdf:resource attribute at the same time is an
+error.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/error002.rdf>;
+   mf:name "rdfms-empty-property-elements-error002";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    The rdf:resource attribute means that the value of this
+property element is a resource.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test001.rdf>;
+   mf:name "rdfms-empty-property-elements-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    The basic case. An empty property element just gives an empty
+literal.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test002.rdf>;
+   mf:name "rdfms-empty-property-elements-test002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    If the parseType indicates the value is a resource, we must
+create one. With no additional information, the resource is
+anonymous.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test004.rdf>;
+   mf:name "rdfms-empty-property-elements-test004";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test004.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test005> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    An empty property element just gives an empty literal. We
+reify the statement at the same time.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test005.rdf>;
+   mf:name "rdfms-empty-property-elements-test005";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test005.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test005>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test006> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Here the parseType indicates that we should create a resource.
+We also reify the generated statement.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test006.rdf>;
+   mf:name "rdfms-empty-property-elements-test006";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test006.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test006>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test007> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    As test001.rdf; this uses an explicit closing tag.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test007.rdf>;
+   mf:name "rdfms-empty-property-elements-test007";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test007.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test007>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test008> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    As test002.rdf; this uses an explicit closing tag.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test008.rdf>;
+   mf:name "rdfms-empty-property-elements-test008";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test008.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test008>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test010> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    As test004.rdf; this uses an explicit closing tag.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test010.rdf>;
+   mf:name "rdfms-empty-property-elements-test010";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test010.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test010>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test011> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    As test005.rdf; this uses an explicit closing tag.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test011.rdf>;
+   mf:name "rdfms-empty-property-elements-test011";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test011.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test011>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test012> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    As test006.rdf; this uses an explicit closing tag.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test012.rdf>;
+   mf:name "rdfms-empty-property-elements-test012";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test012.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test012>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test013> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Test of the last alternative for production [6.12],
+interpreted according to RDFMS paragraphs 229-234:
+http://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test013.rdf>;
+   mf:name "rdfms-empty-property-elements-test013";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test013.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test013>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test014> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Test of the last alternative for production [6.12],
+interpreted according to RDFMS paragraphs 229-234:
+http://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test014.rdf>;
+   mf:name "rdfms-empty-property-elements-test014";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test014.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test014>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test015> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Test of the last alternative for production [6.12],
+interpreted according to RDFMS paragraphs 229-234:
+http://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229
+Here we have an explicit closing tag. This does not match any
+of the productions in the original document, but is
+indistinguishable from test014 as far as XML is concerned.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test015.rdf>;
+   mf:name "rdfms-empty-property-elements-test015";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test015.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test015>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test016> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Like rdfms-empty-property-elements/test001.rdf but with a
+processing instruction as the only content of the otherwise
+empty element.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test016.rdf>;
+   mf:name "rdfms-empty-property-elements-test016";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test016.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test016>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test017> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Like rdfms-empty-property-elements/test001.rdf but with a
+comment as the only content of the otherwise empty element.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test017.rdf>;
+   mf:name "rdfms-empty-property-elements-test017";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-empty-property-elements/test017.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test017>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    a RDF Description with no ID or about attribute describes an
+un-named resource, aka a bNode.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test001.rdf>;
+   mf:name "rdfms-identity-anon-resources-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    a RDF Description with no ID or about attribute describes an
+un-named resource, aka a bNode.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test002.rdf>;
+   mf:name "rdfms-identity-anon-resources-test002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    a RDF container (in this case a Bag) without an ID attribute
+describes an un-named resource, aka a bNode.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test003.rdf>;
+   mf:name "rdfms-identity-anon-resources-test003";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test003.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    a RDF container (in this case an Alt) without an ID attribute
+describes an un-named resource, aka a bNode.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test004.rdf>;
+   mf:name "rdfms-identity-anon-resources-test004";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test004.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test005> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    a RDF container (in this case an Seq) without an ID attribute
+describes an un-named resource, aka a bNode.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test005.rdf>;
+   mf:name "rdfms-identity-anon-resources-test005";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-identity-anon-resources/test005.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test005>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:ID on an empty property element indicates reification.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test001.rdf>;
+   mf:name "rdfms-not-id-and-resource-attr-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:reource on an empty property element indicates the URI of
+the object.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test002.rdf>;
+   mf:name "rdfms-not-id-and-resource-attr-test002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:ID and rdf:resource are allowed together on empty property
+element.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test004.rdf>;
+   mf:name "rdfms-not-id-and-resource-attr-test004";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test004.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test005> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:ID and rdf:resource are allowed together on empty property
+element.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test005.rdf>;
+   mf:name "rdfms-not-id-and-resource-attr-test005";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-not-id-and-resource-attr/test005.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test005>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-para196-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    test case showing that the 2nd URI in M Paragraph 196 is
+permitted as a namespace URI (and any namespace URI starting
+with that URI)
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-para196/test001.rdf>;
+   mf:name "rdfms-para196-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-para196/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-para196-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    The value of rdf:ID must match the XML Name production, (as
+modified by XML Namespaces).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error001.rdf>;
+   mf:name "rdfms-rdf-id-error001";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    The value of rdf:ID must match the XML Name production, (as
+modified by XML Namespaces).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error002.rdf>;
+   mf:name "rdfms-rdf-id-error002";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    The value of rdf:ID must match the XML Name production, (as
+modified by XML Namespaces).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error003.rdf>;
+   mf:name "rdfms-rdf-id-error003";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    The value of rdf:ID must match the XML Name production, (as
+modified by XML Namespaces).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error004.rdf>;
+   mf:name "rdfms-rdf-id-error004";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error005> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    The value of rdf:ID must match the XML Name production, (as
+modified by XML Namespaces).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error005.rdf>;
+   mf:name "rdfms-rdf-id-error005";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error005>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error006> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    The value of rdf:bagID must match the XML Name production, (as
+modified by XML Namespaces).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error006.rdf>;
+   mf:name "rdfms-rdf-id-error006";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error006>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error007> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    The value of rdf:bagID must match the XML Name production, (as
+modified by XML Namespaces).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-id/error007.rdf>;
+   mf:name "rdfms-rdf-id-error007";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error007>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    RDF is forbidden as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-001.rdf>;
+   mf:name "rdfms-rdf-names-use-error-001";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    ID is forbidden as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-002.rdf>;
+   mf:name "rdfms-rdf-names-use-error-002";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    about is forbidden as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-003.rdf>;
+   mf:name "rdfms-rdf-names-use-error-003";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    bagID is forbidden as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-004.rdf>;
+   mf:name "rdfms-rdf-names-use-error-004";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-005> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    parseType is forbidden as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-005.rdf>;
+   mf:name "rdfms-rdf-names-use-error-005";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-005>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-006> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    resource is forbidden as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-006.rdf>;
+   mf:name "rdfms-rdf-names-use-error-006";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-006>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-007> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    nodeID is forbidden as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-007.rdf>;
+   mf:name "rdfms-rdf-names-use-error-007";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-007>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-008> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    li is forbidden as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-008.rdf>;
+   mf:name "rdfms-rdf-names-use-error-008";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-008>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-009> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    aboutEach is forbidden as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-009.rdf>;
+   mf:name "rdfms-rdf-names-use-error-009";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-009>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-010> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    aboutEachPrefix is forbidden as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-010.rdf>;
+   mf:name "rdfms-rdf-names-use-error-010";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-010>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-011> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    Description is forbidden as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-011.rdf>;
+   mf:name "rdfms-rdf-names-use-error-011";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-011>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-012> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    RDF is forbidden as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-012.rdf>;
+   mf:name "rdfms-rdf-names-use-error-012";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-012>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-013> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    ID is forbidden as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-013.rdf>;
+   mf:name "rdfms-rdf-names-use-error-013";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-013>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-014> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    about is forbidden as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-014.rdf>;
+   mf:name "rdfms-rdf-names-use-error-014";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-014>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-015> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    bagID is forbidden as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-015.rdf>;
+   mf:name "rdfms-rdf-names-use-error-015";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-015>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-016> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    parseType is forbidden as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-016.rdf>;
+   mf:name "rdfms-rdf-names-use-error-016";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-016>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-017> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    resource is forbidden as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-017.rdf>;
+   mf:name "rdfms-rdf-names-use-error-017";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-017>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-018> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    nodeID is forbidden as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-018.rdf>;
+   mf:name "rdfms-rdf-names-use-error-018";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-018>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-019> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    aboutEach is forbidden as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-019.rdf>;
+   mf:name "rdfms-rdf-names-use-error-019";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-019>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-020> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    aboutEachPrefix is forbidden as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/error-020.rdf>;
+   mf:name "rdfms-rdf-names-use-error-020";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-020>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Description is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-001.rdf>;
+   mf:name "rdfms-rdf-names-use-test-001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Seq is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-002.rdf>;
+   mf:name "rdfms-rdf-names-use-test-002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Bag is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-003.rdf>;
+   mf:name "rdfms-rdf-names-use-test-003";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-003.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Alt is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-004.rdf>;
+   mf:name "rdfms-rdf-names-use-test-004";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-004.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-005> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Statement is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-005.rdf>;
+   mf:name "rdfms-rdf-names-use-test-005";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-005.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-005>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-006> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Property is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-006.rdf>;
+   mf:name "rdfms-rdf-names-use-test-006";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-006.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-006>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-007> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    List is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-007.rdf>;
+   mf:name "rdfms-rdf-names-use-test-007";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-007.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-007>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-008> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    subject is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-008.rdf>;
+   mf:name "rdfms-rdf-names-use-test-008";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-008.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-008>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-009> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    predicate is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-009.rdf>;
+   mf:name "rdfms-rdf-names-use-test-009";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-009.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-009>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-010> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    object is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-010.rdf>;
+   mf:name "rdfms-rdf-names-use-test-010";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-010.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-010>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-011> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    type is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-011.rdf>;
+   mf:name "rdfms-rdf-names-use-test-011";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-011.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-011>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-012> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    value is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-012.rdf>;
+   mf:name "rdfms-rdf-names-use-test-012";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-012.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-012>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-013> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    first is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-013.rdf>;
+   mf:name "rdfms-rdf-names-use-test-013";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-013.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-013>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-014> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rest is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-014.rdf>;
+   mf:name "rdfms-rdf-names-use-test-014";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-014.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-014>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-015> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    _1 is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-015.rdf>;
+   mf:name "rdfms-rdf-names-use-test-015";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-015.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-015>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-016> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    nil is allowed as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-016.rdf>;
+   mf:name "rdfms-rdf-names-use-test-016";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-016.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-016>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-017> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Seq is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-017.rdf>;
+   mf:name "rdfms-rdf-names-use-test-017";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-017.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-017>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-018> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Bag is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-018.rdf>;
+   mf:name "rdfms-rdf-names-use-test-018";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-018.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-018>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-019> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Alt is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-019.rdf>;
+   mf:name "rdfms-rdf-names-use-test-019";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-019.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-019>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-020> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Statement is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-020.rdf>;
+   mf:name "rdfms-rdf-names-use-test-020";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-020.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-020>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-021> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Property is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-021.rdf>;
+   mf:name "rdfms-rdf-names-use-test-021";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-021.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-021>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-022> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    List is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-022.rdf>;
+   mf:name "rdfms-rdf-names-use-test-022";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-022.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-022>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-023> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    subject is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-023.rdf>;
+   mf:name "rdfms-rdf-names-use-test-023";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-023.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-023>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-024> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    predicate is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-024.rdf>;
+   mf:name "rdfms-rdf-names-use-test-024";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-024.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-024>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-025> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    object is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-025.rdf>;
+   mf:name "rdfms-rdf-names-use-test-025";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-025.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-025>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-026> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    type is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-026.rdf>;
+   mf:name "rdfms-rdf-names-use-test-026";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-026.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-026>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-027> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    value is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-027.rdf>;
+   mf:name "rdfms-rdf-names-use-test-027";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-027.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-027>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-028> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    first is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-028.rdf>;
+   mf:name "rdfms-rdf-names-use-test-028";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-028.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-028>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-029> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rest is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-029.rdf>;
+   mf:name "rdfms-rdf-names-use-test-029";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-029.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-029>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-030> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    _1 is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-030.rdf>;
+   mf:name "rdfms-rdf-names-use-test-030";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-030.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-030>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-031> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    li is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-031.rdf>;
+   mf:name "rdfms-rdf-names-use-test-031";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-031.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-031>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-032> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Seq is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-032.rdf>;
+   mf:name "rdfms-rdf-names-use-test-032";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-032.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-032>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-033> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Bag is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-033.rdf>;
+   mf:name "rdfms-rdf-names-use-test-033";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-033.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-033>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-034> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Alt is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-034.rdf>;
+   mf:name "rdfms-rdf-names-use-test-034";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-034.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-034>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-035> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Statement is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-035.rdf>;
+   mf:name "rdfms-rdf-names-use-test-035";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-035.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-035>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-036> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Property is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-036.rdf>;
+   mf:name "rdfms-rdf-names-use-test-036";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-036.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-036>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-037> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    List is allowed as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-037.rdf>;
+   mf:name "rdfms-rdf-names-use-test-037";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/test-037.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-037>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    foo is allowed with warnings as a node element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-001.rdf>;
+   mf:name "rdfms-rdf-names-use-warn-001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    foo is allowed with warnings as a property element name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-002.rdf>;
+   mf:name "rdfms-rdf-names-use-warn-002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    foo is allowed with warnings as a property attribute name.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-003.rdf>;
+   mf:name "rdfms-rdf-names-use-warn-003";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-rdf-names-use/warn-003.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-reification-required-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    A parser is not required to generate a bag of reified
+statements for all description elements.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-reification-required/test001.rdf>;
+   mf:name "rdfms-reification-required-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-reification-required/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-reification-required-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-seq-representation-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:parseType="Collection" is parsed like the nonstandard
+daml:collection.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-seq-representation/test001.rdf>;
+   mf:name "rdfms-seq-representation-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-seq-representation/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-seq-representation-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:nodeID can be used to label a blank node.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test001.rdf>;
+   mf:name "rdfms-syntax-incomplete-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    rdf:nodeID can be used to label a blank node. These have file
+scope and are distinct from any unlabelled blank nodes.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test002.rdf>;
+   mf:name "rdfms-syntax-incomplete-test002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    On an rdf:Description or typed node rdf:nodeID behaves
+similarly to an rdf:about.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test003.rdf>;
+   mf:name "rdfms-syntax-incomplete-test003";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test003.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    On a property element rdf:nodeID behaves similarly to
+rdf:resource.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test004.rdf>;
+   mf:name "rdfms-syntax-incomplete-test004";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/test004.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    The value of rdf:nodeID must match the XML Name production,
+(as modified by XML Namespaces).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error001.rdf>;
+   mf:name "rdfms-syntax-incomplete-error001";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    The value of rdf:nodeID must match the XML Name production,
+(as modified by XML Namespaces).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error002.rdf>;
+   mf:name "rdfms-syntax-incomplete-error002";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    The value of rdf:nodeID must match the XML Name production,
+(as modified by XML Namespaces).
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error003.rdf>;
+   mf:name "rdfms-syntax-incomplete-error003";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    Cannot have rdf:nodeID and rdf:ID.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error004.rdf>;
+   mf:name "rdfms-syntax-incomplete-error004";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error005> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    Cannot have rdf:nodeID and rdf:about.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error005.rdf>;
+   mf:name "rdfms-syntax-incomplete-error005";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error005>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error006> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax>;
+   rdfs:comment """
+    Cannot have rdf:nodeID and rdf:resource.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-syntax-incomplete/error006.rdf>;
+   mf:name "rdfms-syntax-incomplete-error006";
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error006>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-uri-substructure-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Demonstrates the Recommended partitioning of a URI into a
+namespace part and a localname part
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-uri-substructure/test001.rdf>;
+   mf:name "rdfms-uri-substructure-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-uri-substructure/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-uri-substructure-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    In-scope xml:lang applies to element content literal values
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test003.rdf>;
+   mf:name "rdfms-xmllang-test003";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test003.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    In-scope xml:lang applies to element content literal values
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test004.rdf>;
+   mf:name "rdfms-xmllang-test004";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test004.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test005> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    In-scope xml:lang applies to element content literal values
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test005.rdf>;
+   mf:name "rdfms-xmllang-test005";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test005.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test005>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test006> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    In-scope xml:lang applies to element content literal values
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test006.rdf>;
+   mf:name "rdfms-xmllang-test006";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfms-xmllang/test006.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test006>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    a RDF Property may have more than one domain property
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfs-domain-and-range/test001.rdf>;
+   mf:name "rdfs-domain-and-range-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfs-domain-and-range/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    a RDF Property may have more than one domain property
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/rdfs-domain-and-range/test002.rdf>;
+   mf:name "rdfs-domain-and-range-test002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/rdfs-domain-and-range/test002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Unrecognized attributes in the xml namespace should be
+ignored.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/unrecognised-xml-attributes/test001.rdf>;
+   mf:name "unrecognised-xml-attributes-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/unrecognised-xml-attributes/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Unrecognized attributes in the xml namespace should be
+ignored.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/unrecognised-xml-attributes/test002.rdf>;
+   mf:name "unrecognised-xml-attributes-test002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/unrecognised-xml-attributes/test002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xml-canon-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Demonstrating the canonicalisation of XMLLiterals.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xml-canon/test001.rdf>;
+   mf:name "xml-canon-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xml-canon/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xml-canon-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test001> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    xml:base applies to an rdf:ID on an rdf:Description element.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test001.rdf>;
+   mf:name "xmlbase-test001";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test001.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test001>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test002> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    xml:base applies to an rdf:resource attribute.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test002.rdf>;
+   mf:name "xmlbase-test002";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test002.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test002>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test003> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    xml:base applies to an rdf:about attribute.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test003.rdf>;
+   mf:name "xmlbase-test003";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test003.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test003>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test004> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    xml:base applies to an rdf:ID on a property element.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test004.rdf>;
+   mf:name "xmlbase-test004";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test004.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test004>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test006> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    xml:base scoping.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test006.rdf>;
+   mf:name "xmlbase-test006";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test006.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test006>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test007> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    example of relative URI resolution.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test007.rdf>;
+   mf:name "xmlbase-test007";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test007.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test007>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test008> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    example of empty same document ref resolution.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test008.rdf>;
+   mf:name "xmlbase-test008";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test008.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test008>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test009> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Example of relative uri with absolute path resolution.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test009.rdf>;
+   mf:name "xmlbase-test009";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test009.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test009>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test010> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Example of relative uri with net path resolution.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test010.rdf>;
+   mf:name "xmlbase-test010";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test010.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test010>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test011> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Example of xml:base with no path component.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test011.rdf>;
+   mf:name "xmlbase-test011";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test011.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test011>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test013> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    With an xml:base with fragment the fragment is ignored.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test013.rdf>;
+   mf:name "xmlbase-test013";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test013.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test013>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test014> a earl:TestCriterion,
+     earl:TestCase,
+     <http://www.w3.org/ns/rdftest#TestXMLEval>;
+   rdfs:comment """
+    Test output corrected to use correct base URL.
+  """;
+   mf:action <https://www.w3.org/2013/RDFXMLTests/xmlbase/test014.rdf>;
+   mf:name "xmlbase-test014";
+   mf:result <https://www.w3.org/2013/RDFXMLTests/xmlbase/test014.nt>;
+   earl:assertions [
+     a earl:Assertion;
+     earl:assertedBy <https://www.rubensworks.net/#me>;
+     earl:mode earl:automatic;
+     earl:result [
+       a earl:TestResult;
+       earl:outcome earl:passed
+     ];
+     earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+     earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test014>
+   ];
+   <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Approved> .
+
+# Test Subjects
+
+<https://www.npmjs.com/package/rdfxml-streaming-parser/> a earl:TestSubject,
+     doap:Project,
+     earl:Software;
+   doap:description "Streaming RDF/XML parser"@en;
+   doap:developer <https://www.rubensworks.net/#me>;
+   doap:homepage <https://github.com/rdfjs/rdfxml-streaming-parser.js#readme>;
+   doap:name "rdfxml-streaming-parser";
+   doap:programming-language "JavaScript" .
+
+<https://www.rubensworks.net/#me> a foaf:Person,
+     earl:Assertor;
+   foaf:homepage <https://www.rubensworks.net/>;
+   foaf:name "Ruben Taelman <rubensworks@gmail.com>" .
+
+# Report Generation Software
+
+<http://rubygems.org/gems/earl-report> a doap:Project,
+     earl:Software;
+   doap:description "EarlReport generates HTML+RDFa rollups of multiple EARL reports"@en;
+   doap:developer <http://greggkellogg.net/foaf#me>;
+   doap:homepage <https://github.com/gkellogg/earl-report>;
+   doap:license <http://unlicense.org>;
+   doap:name "earl-report";
+   doap:programming-language "Ruby";
+   doap:release <https://github.com/gkellogg/earl-report/tree/0.4.6>;
+   doap:shortdesc "Earl Report summary generator"@en .
+
+<https://github.com/gkellogg/earl-report/tree/0.4.6> a doap:Version;
+   doap:created "2018-09-28"^^xsd:date;
+   doap:name "earl-report-0.4.6";
+   doap:revision "0.4.6" .

--- a/rdf-xml/reports/index.html
+++ b/rdf-xml/reports/index.html
@@ -1,0 +1,2877 @@
+<!DOCTYPE html>
+<html prefix='earl: http://www.w3.org/ns/earl# doap: http://usefulinc.com/ns/doap# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#'>
+<head>
+<meta content='text/html;charset=utf-8' http-equiv='Content-Type' />
+<link href='earl.ttl' rel='alternate' />
+<link href='earl.jsonld' rel='alternate' />
+<link href='rdfxml-streaming-parser.js.ttl' rel='related' />
+<title>
+RDF/XML
+Implementation Report
+</title>
+<script class='remove' src='../../local-biblio.js'></script>
+<script class='remove' src='https://www.w3.org/Tools/respec/respec-w3c-common' type='text/javascript'></script>
+<script type='text/javascript'>
+  //<![CDATA[
+    var respecConfig = {
+        // extend the bibliography entries
+        localBiblio: localBibliography,
+    
+        // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
+        specStatus:           "base",
+        copyrightStart:       "2010",
+        doRDFa:               "1.1",
+    
+        // the specification's short name, as in http://www.w3.org/TR/short-name/
+        shortName:            "rdf-syntax-grammar",
+        //subtitle:             "RDF/XML Implementation Conformance Report",
+        // if you wish the publication date to be other than today, set this
+        publishDate:  "2018/10/09",
+    
+        // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+        // and its maturity status
+        //previousPublishDate:  "2011-10-23",
+        //previousMaturity:     "ED",
+        //previousDiffURI:      "http://json-ld.org/spec/ED/json-ld-syntax/20111023/index.html",
+        //diffTool:             "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+    
+        // if there a publicly available Editor's Draft, this is the link
+        //edDraftURI:           "",
+    
+        // if this is a LCWD, uncomment and set the end of its review period
+        // lcEnd: "2009-08-05",
+    
+        // editors, add as many as you like
+        // only "name" is required
+        editors:  [
+            { name: "Gregg Kellogg", url: "http://greggkellogg.net/",
+              company: "Kellogg Associates" },
+            { name: "Andy Seaborne",
+              company: "The Apache Software Foundation"}
+        ],
+    
+        // authors, add as many as you like.
+        // This is optional, uncomment if you have authors as well as editors.
+        // only "name" is required. Same format as editors.
+        //authors:  [
+        //RDF Working Group],
+    
+        // name of the WG
+        wg:           "RDF Working Group",
+    
+        // URI of the public WG page
+        wgURI:        "http://www.w3.org/2011/rdf-wg/",
+    
+        // name (with the @w3c.org) of the public mailing to which comments are due
+        wgPublicList: "public-rdf-comments",
+    
+        // URI of the patent status for this WG, for Rec-track documents
+        // !!!! IMPORTANT !!!!
+        // This is important for Rec-track documents, do not copy a patent URI from a random
+        // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
+        // Team Contact.
+        wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/46168/status",
+        alternateFormats: [
+          {uri: "earl.ttl", label: "Turtle"},
+          {uri: "earl.jsonld", label: "JSON-LD"}
+        ],
+    };
+  //]]>
+</script>
+<style type='text/css'>
+  /*<![CDATA[*/
+    span[property='dc:description'] { display: none; }
+    td.PASS { color: green; }
+    td.FAIL { color: red; }
+    table.report {
+      border-width: 1px;
+      border-spacing: 2px;
+      border-style: outset;
+      border-color: gray;
+      border-collapse: separate;
+      background-color: white;
+    }
+    table.report th {
+      border-width: 1px;
+      padding: 1px;
+      border-style: inset;
+      border-color: gray;
+      background-color: white;
+      -moz-border-radius: ;
+    }
+    table.report td {
+      border-width: 1px;
+      padding: 1px;
+      border-style: inset;
+      border-color: gray;
+      background-color: white;
+      -moz-border-radius: ;
+    }
+    tr.summary {font-weight: bold;}
+    td.passed-all {color: green;}
+    td.passed-most {color: darkorange;}
+    td.passed-some {color: red;}
+  /*]]>*/
+</style>
+</head>
+<body prefix='earl: http://www.w3.org/ns/earl# doap: http://usefulinc.com/ns/doap# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#'>
+<section about='' id='abstract' typeof='doap:Project Software'>
+<p>
+This document report test subject conformance for and related specifications for
+<span property='doap:name'>RDF/XML</span>
+<span property='dc:bibliographicCitation'>[[RDFXML]]</span>
+according to the requirements of the Evaluation and Report Language (EARL) 1.0 Schema [[EARL10-SCHEMA]].
+</p>
+<p>
+This report is also available in alternate formats:
+<a href='earl.ttl' rel='xhv:alternate'>
+Turtle
+</a>
+and
+<a href='earl.jsonld' rel='xhv:alternate'>
+JSON-LD
+</a>
+</p>
+</section>
+<section id='sodt'></section>
+<section>
+<h2 id="instructions-for-submitting-implementation-reports">Instructions for submitting implementation reports</h2>
+
+<p>Tests should be run using the test manifests defined in the 
+  <a href="#test-manifests">Test Manifests</a> Section.</p>
+
+<p>The assumed base URI for the tests is <code>&lt;http://example/base/&gt;</code> if needed.</p>
+
+<p>Reports should be submitted in Turtle format to <a href="mailto:public-rdf-comments@w3.org">public-rdf-comments@w3.org</a>
+  and include an <code>earl:Assertion</code>
+  for each test, referencing the test resource from the associated manifest
+  and the test subject being reported upon. An example test entry is be the following:</p>
+
+<pre><code>  [ a earl:Assertion;&#x000A;    earl:assertedBy &lt;https://www.rubensworks.net/#me&gt;;&#x000A;    earl:subject &lt;https://www.npmjs.com/package/rdfxml-streaming-parser/&gt;;&#x000A;    earl:test &lt;https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001&gt;;&#x000A;    earl:result [&#x000A;      a earl:TestResult;&#x000A;      earl:outcome earl:passed;&#x000A;      dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime];&#x000A;    earl:mode earl:automatic ] .&#x000A;</code></pre>
+
+<p>The Test Subject should be defined as a <code>doap:Project</code>, including the name,
+  homepage and developer(s) of the software (see [[DOAP]]). Optionally, including the
+  project description and programming language. An example test subject description is the following:</p>
+
+<pre><code>  &lt;&gt; foaf:primaryTopic &lt;https://www.npmjs.com/package/rdfxml-streaming-parser/&gt;;&#x000A;      dc:issued "2018-10-08T23:16:03.823Z"^^xsd:dateTime;&#x000A;      foaf:maker &lt;https://www.rubensworks.net/#me&gt;.&#x000A;&#x000A;  &lt;https://www.npmjs.com/package/rdfxml-streaming-parser/&gt; a earl:Software, earl:TestSubject, doap:Project;&#x000A;      doap:name "rdfxml-streaming-parser";&#x000A;      dc:title "rdfxml-streaming-parser";&#x000A;      doap:homepage &lt;https://github.com/rdfjs/rdfxml-streaming-parser.js#readme&gt;;&#x000A;      doap:license &lt;http://opensource.org/licenses/MIT&gt;;&#x000A;      doap:programming-language "JavaScript";&#x000A;      doap:implements &lt;https://www.w3.org/TR/rdf-syntax-grammar/&gt;;&#x000A;      doap:category &lt;http://dbpedia.org/resource/Resource_Description_Framework&gt;;&#x000A;      doap:download-page &lt;https://npmjs.org/package/rdfxml-streaming-parser&gt;;&#x000A;      doap:bug-database &lt;https://github.com/rdfjs/rdfxml-streaming-parser.js/issues&gt;;&#x000A;      doap:developer &lt;https://www.rubensworks.net/#me&gt;;&#x000A;      doap:maintainer &lt;https://www.rubensworks.net/#me&gt;;&#x000A;      doap:documenter &lt;https://www.rubensworks.net/#me&gt;;&#x000A;      doap:maker &lt;https://www.rubensworks.net/#me&gt;;&#x000A;      dc:creator &lt;https://www.rubensworks.net/#me&gt;;&#x000A;      dc:description "Streaming RDF/XML parser"@en;&#x000A;      doap:description "Streaming RDF/XML parser"@en.&#x000A;</code></pre>
+
+<p>The software developer, either an organization or one or more individuals SHOULD be
+  referenced from <code>doap:developer</code> using [[FOAF]]. For example:</p>
+
+<pre><code>  &lt;https://www.rubensworks.net/#me&gt; a foaf:Person, earl:Assertor;&#x000A;      foaf:name "Ruben Taelman &lt;rubensworks@gmail.com&gt;";&#x000A;      foaf:homepage &lt;https://www.rubensworks.net/&gt;.&#x000A;</code></pre>
+
+<p>See <a href="https://www.w3.org/2011/rdf-wg/wiki/RDF_Test_Suites">RDF Test Suite Wiki</a>
+  for more information.</p>
+</section>
+<section>
+<h2>
+Test Manifests
+</h2>
+<section resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl' typeof='mf:Manifest Report'>
+<h2>RDF/XML Tests</h2>
+<table class='report'>
+<tr>
+<th>
+Test
+</th>
+<th>
+<a href='#subj_0'>rdfxml-streaming-parser</a>
+</th>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#amp-in-url-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_amp-in-url-test001'>amp-in-url-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#amp-in-url-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_datatypes-test001'>datatypes-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_datatypes-test002'>datatypes-test002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-literals-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-charmod-literals-test001'>rdf-charmod-literals-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-literals-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-charmod-uris-test001'>rdf-charmod-uris-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-charmod-uris-test002'>rdf-charmod-uris-test002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error001' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-containers-syntax-vs-schema-error001'>rdf-containers-syntax-vs-schema-error001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error002' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-containers-syntax-vs-schema-error002'>rdf-containers-syntax-vs-schema-error002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-containers-syntax-vs-schema-test001'>rdf-containers-syntax-vs-schema-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-containers-syntax-vs-schema-test002'>rdf-containers-syntax-vs-schema-test002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test003' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-containers-syntax-vs-schema-test003'>rdf-containers-syntax-vs-schema-test003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test004' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-containers-syntax-vs-schema-test004'>rdf-containers-syntax-vs-schema-test004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test006' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-containers-syntax-vs-schema-test006'>rdf-containers-syntax-vs-schema-test006</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test006' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test007' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-containers-syntax-vs-schema-test007'>rdf-containers-syntax-vs-schema-test007</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test007' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test008' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-containers-syntax-vs-schema-test008'>rdf-containers-syntax-vs-schema-test008</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test008' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-element-not-mandatory-test001'>rdf-element-not-mandatory-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0001'>rdf-ns-prefix-confusion-test0001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0003' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0003'>rdf-ns-prefix-confusion-test0003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0004' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0004'>rdf-ns-prefix-confusion-test0004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0005' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0005'>rdf-ns-prefix-confusion-test0005</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0005' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0006' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0006'>rdf-ns-prefix-confusion-test0006</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0006' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0009' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0009'>rdf-ns-prefix-confusion-test0009</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0009' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0010' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0010'>rdf-ns-prefix-confusion-test0010</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0010' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0011' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0011'>rdf-ns-prefix-confusion-test0011</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0011' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0012' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0012'>rdf-ns-prefix-confusion-test0012</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0012' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0013' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0013'>rdf-ns-prefix-confusion-test0013</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0013' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0014' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdf-ns-prefix-confusion-test0014'>rdf-ns-prefix-confusion-test0014</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0014' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error001' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-abouteach-error001'>rdfms-abouteach-error001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error002' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-abouteach-error002'>rdfms-abouteach-error002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-error1' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-difference-between-ID-and-about-error1'>rdfms-difference-between-ID-and-about-error1</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-error1' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test1' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-difference-between-ID-and-about-test1'>rdfms-difference-between-ID-and-about-test1</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test1' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test2' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-difference-between-ID-and-about-test2'>rdfms-difference-between-ID-and-about-test2</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test2' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test3' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-difference-between-ID-and-about-test3'>rdfms-difference-between-ID-and-about-test3</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test3' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-duplicate-member-props-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-duplicate-member-props-test001'>rdfms-duplicate-member-props-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-duplicate-member-props-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error001' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-error001'>rdfms-empty-property-elements-error001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error002' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-error002'>rdfms-empty-property-elements-error002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test001'>rdfms-empty-property-elements-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test002'>rdfms-empty-property-elements-test002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test004' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test004'>rdfms-empty-property-elements-test004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test005' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test005'>rdfms-empty-property-elements-test005</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test005' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test006' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test006'>rdfms-empty-property-elements-test006</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test006' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test007' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test007'>rdfms-empty-property-elements-test007</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test007' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test008' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test008'>rdfms-empty-property-elements-test008</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test008' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test010' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test010'>rdfms-empty-property-elements-test010</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test010' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test011' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test011'>rdfms-empty-property-elements-test011</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test011' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test012' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test012'>rdfms-empty-property-elements-test012</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test012' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test013' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test013'>rdfms-empty-property-elements-test013</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test013' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test014' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test014'>rdfms-empty-property-elements-test014</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test014' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test015' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test015'>rdfms-empty-property-elements-test015</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test015' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test016' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test016'>rdfms-empty-property-elements-test016</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test016' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test017' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-empty-property-elements-test017'>rdfms-empty-property-elements-test017</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test017' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-identity-anon-resources-test001'>rdfms-identity-anon-resources-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-identity-anon-resources-test002'>rdfms-identity-anon-resources-test002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test003' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-identity-anon-resources-test003'>rdfms-identity-anon-resources-test003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test004' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-identity-anon-resources-test004'>rdfms-identity-anon-resources-test004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test005' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-identity-anon-resources-test005'>rdfms-identity-anon-resources-test005</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test005' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-not-id-and-resource-attr-test001'>rdfms-not-id-and-resource-attr-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-not-id-and-resource-attr-test002'>rdfms-not-id-and-resource-attr-test002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test004' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-not-id-and-resource-attr-test004'>rdfms-not-id-and-resource-attr-test004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test005' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-not-id-and-resource-attr-test005'>rdfms-not-id-and-resource-attr-test005</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test005' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-para196-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-para196-test001'>rdfms-para196-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-para196-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error001' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-id-error001'>rdfms-rdf-id-error001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error002' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-id-error002'>rdfms-rdf-id-error002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error003' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-id-error003'>rdfms-rdf-id-error003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error004' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-id-error004'>rdfms-rdf-id-error004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error005' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-id-error005'>rdfms-rdf-id-error005</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error005' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error006' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-id-error006'>rdfms-rdf-id-error006</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error006' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error007' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-id-error007'>rdfms-rdf-id-error007</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error007' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-001' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-001'>rdfms-rdf-names-use-error-001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-002' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-002'>rdfms-rdf-names-use-error-002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-003' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-003'>rdfms-rdf-names-use-error-003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-004' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-004'>rdfms-rdf-names-use-error-004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-005' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-005'>rdfms-rdf-names-use-error-005</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-005' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-006' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-006'>rdfms-rdf-names-use-error-006</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-006' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-007' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-007'>rdfms-rdf-names-use-error-007</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-007' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-008' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-008'>rdfms-rdf-names-use-error-008</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-008' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-009' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-009'>rdfms-rdf-names-use-error-009</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-009' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-010' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-010'>rdfms-rdf-names-use-error-010</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-010' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-011' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-011'>rdfms-rdf-names-use-error-011</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-011' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-012' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-012'>rdfms-rdf-names-use-error-012</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-012' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-013' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-013'>rdfms-rdf-names-use-error-013</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-013' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-014' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-014'>rdfms-rdf-names-use-error-014</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-014' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-015' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-015'>rdfms-rdf-names-use-error-015</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-015' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-016' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-016'>rdfms-rdf-names-use-error-016</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-016' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-017' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-017'>rdfms-rdf-names-use-error-017</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-017' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-018' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-018'>rdfms-rdf-names-use-error-018</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-018' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-019' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-019'>rdfms-rdf-names-use-error-019</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-019' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-020' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-error-020'>rdfms-rdf-names-use-error-020</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-020' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-001'>rdfms-rdf-names-use-test-001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-002'>rdfms-rdf-names-use-test-002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-003' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-003'>rdfms-rdf-names-use-test-003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-004' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-004'>rdfms-rdf-names-use-test-004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-005' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-005'>rdfms-rdf-names-use-test-005</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-005' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-006' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-006'>rdfms-rdf-names-use-test-006</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-006' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-007' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-007'>rdfms-rdf-names-use-test-007</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-007' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-008' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-008'>rdfms-rdf-names-use-test-008</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-008' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-009' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-009'>rdfms-rdf-names-use-test-009</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-009' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-010' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-010'>rdfms-rdf-names-use-test-010</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-010' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-011' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-011'>rdfms-rdf-names-use-test-011</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-011' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-012' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-012'>rdfms-rdf-names-use-test-012</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-012' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-013' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-013'>rdfms-rdf-names-use-test-013</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-013' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-014' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-014'>rdfms-rdf-names-use-test-014</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-014' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-015' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-015'>rdfms-rdf-names-use-test-015</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-015' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-016' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-016'>rdfms-rdf-names-use-test-016</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-016' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-017' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-017'>rdfms-rdf-names-use-test-017</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-017' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-018' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-018'>rdfms-rdf-names-use-test-018</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-018' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-019' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-019'>rdfms-rdf-names-use-test-019</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-019' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-020' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-020'>rdfms-rdf-names-use-test-020</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-020' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-021' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-021'>rdfms-rdf-names-use-test-021</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-021' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-022' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-022'>rdfms-rdf-names-use-test-022</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-022' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-023' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-023'>rdfms-rdf-names-use-test-023</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-023' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-024' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-024'>rdfms-rdf-names-use-test-024</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-024' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-025' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-025'>rdfms-rdf-names-use-test-025</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-025' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-026' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-026'>rdfms-rdf-names-use-test-026</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-026' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-027' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-027'>rdfms-rdf-names-use-test-027</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-027' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-028' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-028'>rdfms-rdf-names-use-test-028</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-028' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-029' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-029'>rdfms-rdf-names-use-test-029</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-029' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-030' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-030'>rdfms-rdf-names-use-test-030</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-030' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-031' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-031'>rdfms-rdf-names-use-test-031</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-031' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-032' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-032'>rdfms-rdf-names-use-test-032</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-032' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-033' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-033'>rdfms-rdf-names-use-test-033</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-033' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-034' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-034'>rdfms-rdf-names-use-test-034</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-034' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-035' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-035'>rdfms-rdf-names-use-test-035</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-035' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-036' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-036'>rdfms-rdf-names-use-test-036</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-036' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-037' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-test-037'>rdfms-rdf-names-use-test-037</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-037' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-warn-001'>rdfms-rdf-names-use-warn-001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-warn-002'>rdfms-rdf-names-use-warn-002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-003' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-rdf-names-use-warn-003'>rdfms-rdf-names-use-warn-003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-reification-required-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-reification-required-test001'>rdfms-reification-required-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-reification-required-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-seq-representation-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-seq-representation-test001'>rdfms-seq-representation-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-seq-representation-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-syntax-incomplete-test001'>rdfms-syntax-incomplete-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-syntax-incomplete-test002'>rdfms-syntax-incomplete-test002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test003' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-syntax-incomplete-test003'>rdfms-syntax-incomplete-test003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test004' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-syntax-incomplete-test004'>rdfms-syntax-incomplete-test004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error001' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-syntax-incomplete-error001'>rdfms-syntax-incomplete-error001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error002' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-syntax-incomplete-error002'>rdfms-syntax-incomplete-error002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error003' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-syntax-incomplete-error003'>rdfms-syntax-incomplete-error003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error004' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-syntax-incomplete-error004'>rdfms-syntax-incomplete-error004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error005' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-syntax-incomplete-error005'>rdfms-syntax-incomplete-error005</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error005' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error006' typeof='http://www.w3.org/ns/rdftest#TestXMLNegativeSyntax TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-syntax-incomplete-error006'>rdfms-syntax-incomplete-error006</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error006' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-uri-substructure-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-uri-substructure-test001'>rdfms-uri-substructure-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-uri-substructure-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test003' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-xmllang-test003'>rdfms-xmllang-test003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test004' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-xmllang-test004'>rdfms-xmllang-test004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test005' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-xmllang-test005'>rdfms-xmllang-test005</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test005' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test006' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfms-xmllang-test006'>rdfms-xmllang-test006</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test006' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfs-domain-and-range-test001'>rdfs-domain-and-range-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_rdfs-domain-and-range-test002'>rdfs-domain-and-range-test002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_unrecognised-xml-attributes-test001'>unrecognised-xml-attributes-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_unrecognised-xml-attributes-test002'>unrecognised-xml-attributes-test002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xml-canon-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xml-canon-test001'>xml-canon-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xml-canon-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test001' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test001'>xmlbase-test001</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test001' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test002' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test002'>xmlbase-test002</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test002' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test003' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test003'>xmlbase-test003</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test003' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test004' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test004'>xmlbase-test004</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test004' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test006' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test006'>xmlbase-test006</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test006' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test007' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test007'>xmlbase-test007</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test007' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test008' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test008'>xmlbase-test008</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test008' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test009' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test009'>xmlbase-test009</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test009' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test010' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test010'>xmlbase-test010</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test010' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test011' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test011'>xmlbase-test011</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test011' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test013' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test013'>xmlbase-test013</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test013' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr inlist='inlist' rel='mf:entries' resource='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test014' typeof='http://www.w3.org/ns/rdftest#TestXMLEval TestCase TestCriterion'>
+<td>
+<a href='#test_xmlbase-test014'>xmlbase-test014</a>
+</td>
+<td class='PASS' property='earl:assertions' typeof='Assertion'>
+<link href='https://www.rubensworks.net/#me' property='earl:assertedBy' />
+<link href='https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test014' property='earl:test' />
+<link href='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='earl:subject' />
+<link href='earl:automatic' property='earl:mode' />
+<span property='earl:result' typeof='TestResult'>
+<span property='earl:outcome' resource='earl:passed'>
+PASS
+</span>
+</span>
+</td>
+</tr>
+<tr class='summary'>
+<td>
+Percentage passed out of 162 Tests
+</td>
+<td class='passed-all'>
+100.0%
+</td>
+</tr>
+</table>
+</section>
+</section>
+<section class='appendix'>
+<h2>
+Test Subjects
+</h2>
+<p>
+This report was tested using the following test subjects:
+</p>
+<dl>
+<dt id='subj_0'>
+<a href='https://www.npmjs.com/package/rdfxml-streaming-parser/'>
+<span about='https://www.npmjs.com/package/rdfxml-streaming-parser/' property='doap:name'>rdfxml-streaming-parser</span>
+</a>
+</dt>
+<dd property='earl:testSubjects' resource='https://www.npmjs.com/package/rdfxml-streaming-parser/' typeof='doap:Project TestSubject Software'>
+<dl>
+<dt>Description</dt>
+<dd lang='en' property='doap:description'>Streaming RDF/XML parser</dd>
+<dt>Programming Language</dt>
+<dd property='doap:programming-language'>JavaScript</dd>
+<dt>Home Page</dt>
+<dd property='doap:homepage'>
+<a href='https://github.com/rdfjs/rdfxml-streaming-parser.js#readme'>
+https://github.com/rdfjs/rdfxml-streaming-parser.js#readme
+</a>
+</dd>
+<dt>Developer</dt>
+<dd rel='doap:developer'>
+<div resource='https://www.rubensworks.net/#me' typeof='Assertor foaf:Person'>
+<a href='https://www.rubensworks.net/#me'>
+<span property='foaf:name'>Ruben Taelman &lt;rubensworks@gmail.com&gt;</span>
+</a>
+</div>
+</dd>
+<dt>
+Test Suite Compliance
+</dt>
+<dd>
+<table class='report'>
+<tbody>
+<tr>
+<td class='passed-all'>
+162/162 (100.0%)
+</td>
+</tr>
+</tbody>
+</table>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+<section class='appendix' rel='xhv:related earl:assertions'>
+<h2>
+Individual Test Results
+</h2>
+<p>
+Individual test results used to construct this report are available here:
+</p>
+<ul>
+<li>
+<a class='source' href='rdfxml-streaming-parser.js.ttl'>rdfxml-streaming-parser.js.ttl</a>
+</li>
+</ul>
+</section>
+<section id='appendix' property='earl:generatedBy' resource='http://rubygems.org/gems/earl-report' typeof='[&quot;doap:Project&quot;, &quot;Software&quot;]'>
+<h2>
+Report Generation Software
+</h2>
+<p>
+This report generated by
+<span property='doap:name'><a href='http://rubygems.org/gems/earl-report'>earl-report</a></span>
+<meta content='Earl Report summary generator' lang='en' property='doap:shortdesc' />
+<meta content='EarlReport generates HTML+RDFa rollups of multiple EARL reports' lang='en' property='doap:description' />
+version
+<span property='doap:release' resource='https://github.com/gkellogg/earl-report/tree/0.4.6' typeof='doap:Version'>
+<span property='doap:revision'>0.4.6</span>
+<meta content='earl-report-0.4.6' property='doap:name' />
+<meta content='2018-09-28' datatype='xsd:date' property='doap:created' />
+</span>
+an
+<a href='http://unlicense.org' property='doap:license'>Unlicensed</a>
+<span property='doap:programming-language'>Ruby</span>
+application. More information is available at
+<a href='https://github.com/gkellogg/earl-report' property='doap:homepage'>https://github.com/gkellogg/earl-report</a>
+.
+</p>
+<p property='doap:developer' resource='http://greggkellogg.net/foaf#me' typeof='foaf:Person'>
+This software is provided by
+<a href='http://greggkellogg.net/' property='foaf:homepage'><span aboue='http://greggkellogg.net/foaf#me' property='foaf:name'>Gregg Kellogg</span></a>
+in hopes that it might make the lives of conformance testers easier.
+</p>
+</section>
+</body>
+</html>

--- a/rdf-xml/reports/rdfxml-streaming-parser.js.ttl
+++ b/rdf-xml/reports/rdfxml-streaming-parser.js.ttl
@@ -1,0 +1,2463 @@
+@prefix dc: <http://purl.org/dc/terms/>.
+@prefix doap: <http://usefulinc.com/ns/doap#>.
+@prefix earl: <http://www.w3.org/ns/earl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rdft: <http://www.w3.org/ns/rdftest#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<> foaf:primaryTopic <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    dc:issued "2018-10-08T23:16:03.823Z"^^xsd:dateTime;
+    foaf:maker <https://www.rubensworks.net/#me>.
+<https://www.npmjs.com/package/rdfxml-streaming-parser/> a earl:Software, earl:TestSubject, doap:Project;
+    doap:name "rdfxml-streaming-parser";
+    dc:title "rdfxml-streaming-parser";
+    doap:homepage <https://github.com/rdfjs/rdfxml-streaming-parser.js#readme>;
+    doap:license <http://opensource.org/licenses/MIT>;
+    doap:programming-language "JavaScript";
+    doap:implements <https://www.w3.org/TR/rdf-syntax-grammar/>;
+    doap:category <http://dbpedia.org/resource/Resource_Description_Framework>;
+    doap:download-page <https://npmjs.org/package/rdfxml-streaming-parser>;
+    doap:bug-database <https://github.com/rdfjs/rdfxml-streaming-parser.js/issues>;
+    doap:developer <https://www.rubensworks.net/#me>;
+    doap:maintainer <https://www.rubensworks.net/#me>;
+    doap:documenter <https://www.rubensworks.net/#me>;
+    doap:maker <https://www.rubensworks.net/#me>;
+    dc:creator <https://www.rubensworks.net/#me>;
+    dc:description "Streaming RDF/XML parser"@en;
+    doap:description "Streaming RDF/XML parser"@en.
+<https://www.rubensworks.net/#me> a foaf:Person, earl:Assertor;
+    foaf:name "Ruben Taelman <rubensworks@gmail.com>";
+    foaf:homepage <https://www.rubensworks.net/>.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#amp-in-url-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "amp-in-url-test001";
+    dc:description "\n    Description: the purpose of this test case is to show how one\nof XML's Predefined Entities - in this case the ampersand - is\nrepresented when it is used in the value of an rdf:about\nattribute. The ampersand is represented by its numeric\ncharacter reference as specified in:\nhttp://www.w3.org/TR/REC-xml#sec-predefined-ent In the\nassociated N-Triples file, the ampersand will be represented\nwith a single ampersand character (and not the ampersand's\nnumeric character reference). Note: when a XML/HTML browser is\nused to display this file, a single ampersand character may be\ndisplayed and not the ampersand's numeric character reference.\nIn this case, the browser may provide an alternate way to view\nthe file (such as viewing the file's source or saving to a\nfile).\n  ";
+    earl:assertions _:assertions0.
+_:assertions0 rdf:first _:assertion0;
+    rdf:rest rdf:nil.
+_:assertion0 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#amp-in-url-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result0.
+_:result0 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "datatypes-test001";
+    dc:description "\n    A simple datatype production; a language+datatype production.\n  ";
+    earl:assertions _:assertions1.
+_:assertions1 rdf:first _:assertion1;
+    rdf:rest rdf:nil.
+_:assertion1 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result1.
+_:result1 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test002> a earl:TestCriterion, earl:TestCase;
+    dc:title "datatypes-test002";
+    dc:description "\n    A parser is not required to know about well-formed datatyped\nliterals.\n  ";
+    earl:assertions _:assertions2.
+_:assertions2 rdf:first _:assertion2;
+    rdf:rest rdf:nil.
+_:assertion2 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#datatypes-test002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result2.
+_:result2 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-literals-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-charmod-literals-test001";
+    dc:description "\n    Does the treatment of literals conform to charmod ? Test for\nsuccess of legal Normal Form C literal\n  ";
+    earl:assertions _:assertions3.
+_:assertions3 rdf:first _:assertion3;
+    rdf:rest rdf:nil.
+_:assertion3 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-literals-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result3.
+_:result3 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-charmod-uris-test001";
+    dc:description "\n    A uriref is allowed to match non-US ASCII forms conforming to\nUnicode Normal Form C. No escaping algorithm is applied.\n  ";
+    earl:assertions _:assertions4.
+_:assertions4 rdf:first _:assertion4;
+    rdf:rest rdf:nil.
+_:assertion4 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result4.
+_:result4 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-charmod-uris-test002";
+    dc:description "\n    A uriref which already has % escaping is permitted. No\nunescaping algorithm is applied.\n  ";
+    earl:assertions _:assertions5.
+_:assertions5 rdf:first _:assertion5;
+    rdf:rest rdf:nil.
+_:assertion5 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-charmod-uris-test002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result5.
+_:result5 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-containers-syntax-vs-schema-error001";
+    dc:description "\n    rdf:li is not allowed as as an attribute\n  ";
+    earl:assertions _:assertions6.
+_:assertions6 rdf:first _:assertion6;
+    rdf:rest rdf:nil.
+_:assertion6 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result6.
+_:result6 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-containers-syntax-vs-schema-error002";
+    dc:description "\n    rdf:li elements as typed nodes - a bizarre case As specified\nin\nhttp://lists.w3.org/Archives/Public/w3c-rdfcore-wg/2001Nov/0651.html\nis not an error.\n  ";
+    earl:assertions _:assertions7.
+_:assertions7 rdf:first _:assertion7;
+    rdf:rest rdf:nil.
+_:assertion7 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-error002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result7.
+_:result7 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-containers-syntax-vs-schema-test001";
+    dc:description "\n    Simple container\n  ";
+    earl:assertions _:assertions8.
+_:assertions8 rdf:first _:assertion8;
+    rdf:rest rdf:nil.
+_:assertion8 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result8.
+_:result8 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-containers-syntax-vs-schema-test002";
+    dc:description "\n    rdf:li is unaffected by other rdf:_nnn properties. This test\ncase is concerned only with defining the triples that this\nparticular example RDF/XML represents. It is not concerned\nwith whether that collection of triples violates any other\nconstraints, e.g. restrictions on the number of rdf:_1\nproperties that may be defined for a resource.\n  ";
+    earl:assertions _:assertions9.
+_:assertions9 rdf:first _:assertion9;
+    rdf:rest rdf:nil.
+_:assertion9 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result9.
+_:result9 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test003> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-containers-syntax-vs-schema-test003";
+    dc:description "\n    rdf:li elements can exist in any description element\n  ";
+    earl:assertions _:assertions10.
+_:assertions10 rdf:first _:assertion10;
+    rdf:rest rdf:nil.
+_:assertion10 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result10.
+_:result10 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-containers-syntax-vs-schema-test004";
+    dc:description "\n    rdf:li elements match any of the property element productions\n  ";
+    earl:assertions _:assertions11.
+_:assertions11 rdf:first _:assertion11;
+    rdf:rest rdf:nil.
+_:assertion11 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result11.
+_:result11 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test006> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-containers-syntax-vs-schema-test006";
+    dc:description "\n    containers match the typed node production\n  ";
+    earl:assertions _:assertions12.
+_:assertions12 rdf:first _:assertion12;
+    rdf:rest rdf:nil.
+_:assertion12 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test006>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result12.
+_:result12 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test007> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-containers-syntax-vs-schema-test007";
+    dc:description "\n    rdf:li processing within each element is independent\n  ";
+    earl:assertions _:assertions13.
+_:assertions13 rdf:first _:assertion13;
+    rdf:rest rdf:nil.
+_:assertion13 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test007>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result13.
+_:result13 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test008> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-containers-syntax-vs-schema-test008";
+    dc:description "\n    rdf:li processing is per element, not per resource.\n  ";
+    earl:assertions _:assertions14.
+_:assertions14 rdf:first _:assertion14;
+    rdf:rest rdf:nil.
+_:assertion14 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-containers-syntax-vs-schema-test008>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result14.
+_:result14 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-element-not-mandatory-test001";
+    dc:description "\n    A surrounding rdf:RDF element is no longer mandatory.\n  ";
+    earl:assertions _:assertions15.
+_:assertions15 rdf:first _:assertion15;
+    rdf:rest rdf:nil.
+_:assertion15 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result15.
+_:result15 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0001";
+    dc:description "\n    RDF attributes that are required to have an rdf: prefix about\naboutEach ID bagID type resource parseType\n  ";
+    earl:assertions _:assertions16.
+_:assertions16 rdf:first _:assertion16;
+    rdf:rest rdf:nil.
+_:assertion16 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result16.
+_:result16 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0003> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0003";
+    dc:description "\n    RDF attributes that are required to have an rdf: prefix about\naboutEach ID bagID type resource parseType\n  ";
+    earl:assertions _:assertions17.
+_:assertions17 rdf:first _:assertion17;
+    rdf:rest rdf:nil.
+_:assertion17 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result17.
+_:result17 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0004";
+    dc:description "\n    RDF attributes that are required to have an rdf: prefix about\naboutEach ID bagID type resource parseType\n  ";
+    earl:assertions _:assertions18.
+_:assertions18 rdf:first _:assertion18;
+    rdf:rest rdf:nil.
+_:assertion18 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result18.
+_:result18 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0005> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0005";
+    dc:description "\n    RDF attributes that are required to have an rdf: prefix about\naboutEach ID bagID type resource parseType\n  ";
+    earl:assertions _:assertions19.
+_:assertions19 rdf:first _:assertion19;
+    rdf:rest rdf:nil.
+_:assertion19 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0005>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result19.
+_:result19 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0006> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0006";
+    dc:description "\n    RDF attributes that are required to have an rdf: prefix about\naboutEach ID bagID type resource parseType\n  ";
+    earl:assertions _:assertions20.
+_:assertions20 rdf:first _:assertion20;
+    rdf:rest rdf:nil.
+_:assertion20 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0006>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result20.
+_:result20 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0009> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0009";
+    dc:description "\n    Namespace qualification MUST be used for all property\nattributes.\n  ";
+    earl:assertions _:assertions21.
+_:assertions21 rdf:first _:assertion21;
+    rdf:rest rdf:nil.
+_:assertion21 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0009>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result21.
+_:result21 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0010> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0010";
+    dc:description "\n    Non-prefixed RDF elements (NOT attributes) are allowed when a\ndefault XML element namespace is defined with an\nxmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" attribute.\n  ";
+    earl:assertions _:assertions22.
+_:assertions22 rdf:first _:assertion22;
+    rdf:rest rdf:nil.
+_:assertion22 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0010>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result22.
+_:result22 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0011> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0011";
+    dc:description "\n    Non-prefixed RDF elements (NOT attributes) are allowed when a\ndefault XML element namespace is defined with an\nxmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" attribute.\n  ";
+    earl:assertions _:assertions23.
+_:assertions23 rdf:first _:assertion23;
+    rdf:rest rdf:nil.
+_:assertion23 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0011>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result23.
+_:result23 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0012> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0012";
+    dc:description "\n    Non-prefixed RDF elements (NOT attributes) are allowed when a\ndefault XML element namespace is defined with an\nxmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" attribute.\n  ";
+    earl:assertions _:assertions24.
+_:assertions24 rdf:first _:assertion24;
+    rdf:rest rdf:nil.
+_:assertion24 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0012>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result24.
+_:result24 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0013> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0013";
+    dc:description "\n    Non-prefixed RDF elements (NOT attributes) are allowed when a\ndefault XML element namespace is defined with an\nxmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" attribute.\n  ";
+    earl:assertions _:assertions25.
+_:assertions25 rdf:first _:assertion25;
+    rdf:rest rdf:nil.
+_:assertion25 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0013>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result25.
+_:result25 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0014> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdf-ns-prefix-confusion-test0014";
+    dc:description "\n    Non-prefixed RDF elements (NOT attributes) are allowed when a\ndefault XML element namespace is defined with an\nxmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" attribute.\n  ";
+    earl:assertions _:assertions26.
+_:assertions26 rdf:first _:assertion26;
+    rdf:rest rdf:nil.
+_:assertion26 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-ns-prefix-confusion-test0014>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result26.
+_:result26 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-abouteach-error001";
+    dc:description "\n    aboutEach removed from the RDF specifications. See URI above\nfor further details.\n  ";
+    earl:assertions _:assertions27.
+_:assertions27 rdf:first _:assertion27;
+    rdf:rest rdf:nil.
+_:assertion27 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result27.
+_:result27 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-abouteach-error002";
+    dc:description "\n    aboutEach removed from the RDF specifications. See URI above\nfor further details.\n  ";
+    earl:assertions _:assertions28.
+_:assertions28 rdf:first _:assertion28;
+    rdf:rest rdf:nil.
+_:assertion28 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-abouteach-error002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result28.
+_:result28 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-error1> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-difference-between-ID-and-about-error1";
+    dc:description "\n    two elements cannot use the same ID\n  ";
+    earl:assertions _:assertions29.
+_:assertions29 rdf:first _:assertion29;
+    rdf:rest rdf:nil.
+_:assertion29 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-error1>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result29.
+_:result29 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test1> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-difference-between-ID-and-about-test1";
+    dc:description "\n    A statement with an rdf:ID creates a regular triple.\n  ";
+    earl:assertions _:assertions30.
+_:assertions30 rdf:first _:assertion30;
+    rdf:rest rdf:nil.
+_:assertion30 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test1>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result30.
+_:result30 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test2> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-difference-between-ID-and-about-test2";
+    dc:description "\n    This test shows the treatment of non-ASCII characters in the\nvalue of rdf:ID attribute.\n  ";
+    earl:assertions _:assertions31.
+_:assertions31 rdf:first _:assertion31;
+    rdf:rest rdf:nil.
+_:assertion31 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test2>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result31.
+_:result31 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test3> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-difference-between-ID-and-about-test3";
+    dc:description "\n    This test shows the treatment of non-ASCII characters in the\nvalue of rdf:about attribute.\n  ";
+    earl:assertions _:assertions32.
+_:assertions32 rdf:first _:assertion32;
+    rdf:rest rdf:nil.
+_:assertion32 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-difference-between-ID-and-about-test3>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result32.
+_:result32 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-duplicate-member-props-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-duplicate-member-props-test001";
+    dc:description "\n    The question posed to the RDF WG was: should an RDF document\ncontaining multiple rdf:_n properties (with the same n) on an\nelement be rejected as illegal? The WG decided that a parser\nshould accept that case as legal RDF.\n  ";
+    earl:assertions _:assertions33.
+_:assertions33 rdf:first _:assertion33;
+    rdf:rest rdf:nil.
+_:assertion33 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-duplicate-member-props-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result33.
+_:result33 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-error001";
+    dc:description "\n    This is not legal RDF; specifying an rdf:parseType of\n\"Literal\" and an rdf:resource attribute at the same time is an\nerror.\n  ";
+    earl:assertions _:assertions34.
+_:assertions34 rdf:first _:assertion34;
+    rdf:rest rdf:nil.
+_:assertion34 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result34.
+_:result34 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-error002";
+    dc:description "\n    This is not legal RDF; specifying an rdf:parseType of\n\"Literal\" and an rdf:resource attribute at the same time is an\nerror.\n  ";
+    earl:assertions _:assertions35.
+_:assertions35 rdf:first _:assertion35;
+    rdf:rest rdf:nil.
+_:assertion35 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-error002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result35.
+_:result35 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test001";
+    dc:description "\n    The rdf:resource attribute means that the value of this\nproperty element is a resource.\n  ";
+    earl:assertions _:assertions36.
+_:assertions36 rdf:first _:assertion36;
+    rdf:rest rdf:nil.
+_:assertion36 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result36.
+_:result36 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test002";
+    dc:description "\n    The basic case. An empty property element just gives an empty\nliteral.\n  ";
+    earl:assertions _:assertions37.
+_:assertions37 rdf:first _:assertion37;
+    rdf:rest rdf:nil.
+_:assertion37 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result37.
+_:result37 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test004";
+    dc:description "\n    If the parseType indicates the value is a resource, we must\ncreate one. With no additional information, the resource is\nanonymous.\n  ";
+    earl:assertions _:assertions38.
+_:assertions38 rdf:first _:assertion38;
+    rdf:rest rdf:nil.
+_:assertion38 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result38.
+_:result38 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test005> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test005";
+    dc:description "\n    An empty property element just gives an empty literal. We\nreify the statement at the same time.\n  ";
+    earl:assertions _:assertions39.
+_:assertions39 rdf:first _:assertion39;
+    rdf:rest rdf:nil.
+_:assertion39 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test005>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result39.
+_:result39 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test006> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test006";
+    dc:description "\n    Here the parseType indicates that we should create a resource.\nWe also reify the generated statement.\n  ";
+    earl:assertions _:assertions40.
+_:assertions40 rdf:first _:assertion40;
+    rdf:rest rdf:nil.
+_:assertion40 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test006>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result40.
+_:result40 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test007> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test007";
+    dc:description "\n    As test001.rdf; this uses an explicit closing tag.\n  ";
+    earl:assertions _:assertions41.
+_:assertions41 rdf:first _:assertion41;
+    rdf:rest rdf:nil.
+_:assertion41 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test007>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result41.
+_:result41 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test008> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test008";
+    dc:description "\n    As test002.rdf; this uses an explicit closing tag.\n  ";
+    earl:assertions _:assertions42.
+_:assertions42 rdf:first _:assertion42;
+    rdf:rest rdf:nil.
+_:assertion42 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test008>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result42.
+_:result42 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test010> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test010";
+    dc:description "\n    As test004.rdf; this uses an explicit closing tag.\n  ";
+    earl:assertions _:assertions43.
+_:assertions43 rdf:first _:assertion43;
+    rdf:rest rdf:nil.
+_:assertion43 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test010>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result43.
+_:result43 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test011> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test011";
+    dc:description "\n    As test005.rdf; this uses an explicit closing tag.\n  ";
+    earl:assertions _:assertions44.
+_:assertions44 rdf:first _:assertion44;
+    rdf:rest rdf:nil.
+_:assertion44 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test011>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result44.
+_:result44 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test012> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test012";
+    dc:description "\n    As test006.rdf; this uses an explicit closing tag.\n  ";
+    earl:assertions _:assertions45.
+_:assertions45 rdf:first _:assertion45;
+    rdf:rest rdf:nil.
+_:assertion45 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test012>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result45.
+_:result45 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test013> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test013";
+    dc:description "\n    Test of the last alternative for production [6.12],\ninterpreted according to RDFMS paragraphs 229-234:\nhttp://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229\n  ";
+    earl:assertions _:assertions46.
+_:assertions46 rdf:first _:assertion46;
+    rdf:rest rdf:nil.
+_:assertion46 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test013>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result46.
+_:result46 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test014> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test014";
+    dc:description "\n    Test of the last alternative for production [6.12],\ninterpreted according to RDFMS paragraphs 229-234:\nhttp://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229\n  ";
+    earl:assertions _:assertions47.
+_:assertions47 rdf:first _:assertion47;
+    rdf:rest rdf:nil.
+_:assertion47 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test014>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result47.
+_:result47 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test015> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test015";
+    dc:description "\n    Test of the last alternative for production [6.12],\ninterpreted according to RDFMS paragraphs 229-234:\nhttp://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229\nHere we have an explicit closing tag. This does not match any\nof the productions in the original document, but is\nindistinguishable from test014 as far as XML is concerned.\n  ";
+    earl:assertions _:assertions48.
+_:assertions48 rdf:first _:assertion48;
+    rdf:rest rdf:nil.
+_:assertion48 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test015>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result48.
+_:result48 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test016> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test016";
+    dc:description "\n    Like rdfms-empty-property-elements/test001.rdf but with a\nprocessing instruction as the only content of the otherwise\nempty element.\n  ";
+    earl:assertions _:assertions49.
+_:assertions49 rdf:first _:assertion49;
+    rdf:rest rdf:nil.
+_:assertion49 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test016>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result49.
+_:result49 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test017> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-empty-property-elements-test017";
+    dc:description "\n    Like rdfms-empty-property-elements/test001.rdf but with a\ncomment as the only content of the otherwise empty element.\n  ";
+    earl:assertions _:assertions50.
+_:assertions50 rdf:first _:assertion50;
+    rdf:rest rdf:nil.
+_:assertion50 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-empty-property-elements-test017>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result50.
+_:result50 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-identity-anon-resources-test001";
+    dc:description "\n    a RDF Description with no ID or about attribute describes an\nun-named resource, aka a bNode.\n  ";
+    earl:assertions _:assertions51.
+_:assertions51 rdf:first _:assertion51;
+    rdf:rest rdf:nil.
+_:assertion51 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result51.
+_:result51 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-identity-anon-resources-test002";
+    dc:description "\n    a RDF Description with no ID or about attribute describes an\nun-named resource, aka a bNode.\n  ";
+    earl:assertions _:assertions52.
+_:assertions52 rdf:first _:assertion52;
+    rdf:rest rdf:nil.
+_:assertion52 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result52.
+_:result52 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test003> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-identity-anon-resources-test003";
+    dc:description "\n    a RDF container (in this case a Bag) without an ID attribute\ndescribes an un-named resource, aka a bNode.\n  ";
+    earl:assertions _:assertions53.
+_:assertions53 rdf:first _:assertion53;
+    rdf:rest rdf:nil.
+_:assertion53 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result53.
+_:result53 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-identity-anon-resources-test004";
+    dc:description "\n    a RDF container (in this case an Alt) without an ID attribute\ndescribes an un-named resource, aka a bNode.\n  ";
+    earl:assertions _:assertions54.
+_:assertions54 rdf:first _:assertion54;
+    rdf:rest rdf:nil.
+_:assertion54 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result54.
+_:result54 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test005> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-identity-anon-resources-test005";
+    dc:description "\n    a RDF container (in this case an Seq) without an ID attribute\ndescribes an un-named resource, aka a bNode.\n  ";
+    earl:assertions _:assertions55.
+_:assertions55 rdf:first _:assertion55;
+    rdf:rest rdf:nil.
+_:assertion55 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-identity-anon-resources-test005>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result55.
+_:result55 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-not-id-and-resource-attr-test001";
+    dc:description "\n    rdf:ID on an empty property element indicates reification.\n  ";
+    earl:assertions _:assertions56.
+_:assertions56 rdf:first _:assertion56;
+    rdf:rest rdf:nil.
+_:assertion56 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result56.
+_:result56 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-not-id-and-resource-attr-test002";
+    dc:description "\n    rdf:reource on an empty property element indicates the URI of\nthe object.\n  ";
+    earl:assertions _:assertions57.
+_:assertions57 rdf:first _:assertion57;
+    rdf:rest rdf:nil.
+_:assertion57 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result57.
+_:result57 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-not-id-and-resource-attr-test004";
+    dc:description "\n    rdf:ID and rdf:resource are allowed together on empty property\nelement.\n  ";
+    earl:assertions _:assertions58.
+_:assertions58 rdf:first _:assertion58;
+    rdf:rest rdf:nil.
+_:assertion58 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result58.
+_:result58 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test005> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-not-id-and-resource-attr-test005";
+    dc:description "\n    rdf:ID and rdf:resource are allowed together on empty property\nelement.\n  ";
+    earl:assertions _:assertions59.
+_:assertions59 rdf:first _:assertion59;
+    rdf:rest rdf:nil.
+_:assertion59 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-not-id-and-resource-attr-test005>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result59.
+_:result59 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-para196-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-para196-test001";
+    dc:description "\n    test case showing that the 2nd URI in M Paragraph 196 is\npermitted as a namespace URI (and any namespace URI starting\nwith that URI)\n  ";
+    earl:assertions _:assertions60.
+_:assertions60 rdf:first _:assertion60;
+    rdf:rest rdf:nil.
+_:assertion60 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-para196-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result60.
+_:result60 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-id-error001";
+    dc:description "\n    The value of rdf:ID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ";
+    earl:assertions _:assertions61.
+_:assertions61 rdf:first _:assertion61;
+    rdf:rest rdf:nil.
+_:assertion61 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result61.
+_:result61 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-id-error002";
+    dc:description "\n    The value of rdf:ID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ";
+    earl:assertions _:assertions62.
+_:assertions62 rdf:first _:assertion62;
+    rdf:rest rdf:nil.
+_:assertion62 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result62.
+_:result62 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error003> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-id-error003";
+    dc:description "\n    The value of rdf:ID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ";
+    earl:assertions _:assertions63.
+_:assertions63 rdf:first _:assertion63;
+    rdf:rest rdf:nil.
+_:assertion63 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result63.
+_:result63 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-id-error004";
+    dc:description "\n    The value of rdf:ID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ";
+    earl:assertions _:assertions64.
+_:assertions64 rdf:first _:assertion64;
+    rdf:rest rdf:nil.
+_:assertion64 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result64.
+_:result64 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error005> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-id-error005";
+    dc:description "\n    The value of rdf:ID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ";
+    earl:assertions _:assertions65.
+_:assertions65 rdf:first _:assertion65;
+    rdf:rest rdf:nil.
+_:assertion65 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error005>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result65.
+_:result65 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error006> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-id-error006";
+    dc:description "\n    The value of rdf:bagID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ";
+    earl:assertions _:assertions66.
+_:assertions66 rdf:first _:assertion66;
+    rdf:rest rdf:nil.
+_:assertion66 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error006>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result66.
+_:result66 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error007> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-id-error007";
+    dc:description "\n    The value of rdf:bagID must match the XML Name production, (as\nmodified by XML Namespaces).\n  ";
+    earl:assertions _:assertions67.
+_:assertions67 rdf:first _:assertion67;
+    rdf:rest rdf:nil.
+_:assertion67 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-id-error007>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result67.
+_:result67 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-001";
+    dc:description "\n    RDF is forbidden as a node element name.\n  ";
+    earl:assertions _:assertions68.
+_:assertions68 rdf:first _:assertion68;
+    rdf:rest rdf:nil.
+_:assertion68 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result68.
+_:result68 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-002";
+    dc:description "\n    ID is forbidden as a node element name.\n  ";
+    earl:assertions _:assertions69.
+_:assertions69 rdf:first _:assertion69;
+    rdf:rest rdf:nil.
+_:assertion69 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result69.
+_:result69 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-003> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-003";
+    dc:description "\n    about is forbidden as a node element name.\n  ";
+    earl:assertions _:assertions70.
+_:assertions70 rdf:first _:assertion70;
+    rdf:rest rdf:nil.
+_:assertion70 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result70.
+_:result70 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-004";
+    dc:description "\n    bagID is forbidden as a node element name.\n  ";
+    earl:assertions _:assertions71.
+_:assertions71 rdf:first _:assertion71;
+    rdf:rest rdf:nil.
+_:assertion71 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result71.
+_:result71 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-005> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-005";
+    dc:description "\n    parseType is forbidden as a node element name.\n  ";
+    earl:assertions _:assertions72.
+_:assertions72 rdf:first _:assertion72;
+    rdf:rest rdf:nil.
+_:assertion72 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-005>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result72.
+_:result72 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-006> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-006";
+    dc:description "\n    resource is forbidden as a node element name.\n  ";
+    earl:assertions _:assertions73.
+_:assertions73 rdf:first _:assertion73;
+    rdf:rest rdf:nil.
+_:assertion73 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-006>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result73.
+_:result73 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-007> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-007";
+    dc:description "\n    nodeID is forbidden as a node element name.\n  ";
+    earl:assertions _:assertions74.
+_:assertions74 rdf:first _:assertion74;
+    rdf:rest rdf:nil.
+_:assertion74 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-007>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result74.
+_:result74 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-008> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-008";
+    dc:description "\n    li is forbidden as a node element name.\n  ";
+    earl:assertions _:assertions75.
+_:assertions75 rdf:first _:assertion75;
+    rdf:rest rdf:nil.
+_:assertion75 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-008>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result75.
+_:result75 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-009> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-009";
+    dc:description "\n    aboutEach is forbidden as a node element name.\n  ";
+    earl:assertions _:assertions76.
+_:assertions76 rdf:first _:assertion76;
+    rdf:rest rdf:nil.
+_:assertion76 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-009>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result76.
+_:result76 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-010> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-010";
+    dc:description "\n    aboutEachPrefix is forbidden as a node element name.\n  ";
+    earl:assertions _:assertions77.
+_:assertions77 rdf:first _:assertion77;
+    rdf:rest rdf:nil.
+_:assertion77 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-010>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result77.
+_:result77 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-011> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-011";
+    dc:description "\n    Description is forbidden as a property element name.\n  ";
+    earl:assertions _:assertions78.
+_:assertions78 rdf:first _:assertion78;
+    rdf:rest rdf:nil.
+_:assertion78 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-011>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result78.
+_:result78 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-012> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-012";
+    dc:description "\n    RDF is forbidden as a property element name.\n  ";
+    earl:assertions _:assertions79.
+_:assertions79 rdf:first _:assertion79;
+    rdf:rest rdf:nil.
+_:assertion79 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-012>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result79.
+_:result79 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-013> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-013";
+    dc:description "\n    ID is forbidden as a property element name.\n  ";
+    earl:assertions _:assertions80.
+_:assertions80 rdf:first _:assertion80;
+    rdf:rest rdf:nil.
+_:assertion80 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-013>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result80.
+_:result80 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-014> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-014";
+    dc:description "\n    about is forbidden as a property element name.\n  ";
+    earl:assertions _:assertions81.
+_:assertions81 rdf:first _:assertion81;
+    rdf:rest rdf:nil.
+_:assertion81 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-014>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result81.
+_:result81 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-015> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-015";
+    dc:description "\n    bagID is forbidden as a property element name.\n  ";
+    earl:assertions _:assertions82.
+_:assertions82 rdf:first _:assertion82;
+    rdf:rest rdf:nil.
+_:assertion82 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-015>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result82.
+_:result82 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-016> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-016";
+    dc:description "\n    parseType is forbidden as a property element name.\n  ";
+    earl:assertions _:assertions83.
+_:assertions83 rdf:first _:assertion83;
+    rdf:rest rdf:nil.
+_:assertion83 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-016>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result83.
+_:result83 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-017> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-017";
+    dc:description "\n    resource is forbidden as a property element name.\n  ";
+    earl:assertions _:assertions84.
+_:assertions84 rdf:first _:assertion84;
+    rdf:rest rdf:nil.
+_:assertion84 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-017>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result84.
+_:result84 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-018> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-018";
+    dc:description "\n    nodeID is forbidden as a property element name.\n  ";
+    earl:assertions _:assertions85.
+_:assertions85 rdf:first _:assertion85;
+    rdf:rest rdf:nil.
+_:assertion85 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-018>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result85.
+_:result85 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-019> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-019";
+    dc:description "\n    aboutEach is forbidden as a property element name.\n  ";
+    earl:assertions _:assertions86.
+_:assertions86 rdf:first _:assertion86;
+    rdf:rest rdf:nil.
+_:assertion86 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-019>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result86.
+_:result86 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-020> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-error-020";
+    dc:description "\n    aboutEachPrefix is forbidden as a property element name.\n  ";
+    earl:assertions _:assertions87.
+_:assertions87 rdf:first _:assertion87;
+    rdf:rest rdf:nil.
+_:assertion87 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-error-020>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result87.
+_:result87 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-001";
+    dc:description "\n    Description is allowed as a node element name.\n  ";
+    earl:assertions _:assertions88.
+_:assertions88 rdf:first _:assertion88;
+    rdf:rest rdf:nil.
+_:assertion88 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result88.
+_:result88 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-002";
+    dc:description "\n    Seq is allowed as a node element name.\n  ";
+    earl:assertions _:assertions89.
+_:assertions89 rdf:first _:assertion89;
+    rdf:rest rdf:nil.
+_:assertion89 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result89.
+_:result89 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-003> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-003";
+    dc:description "\n    Bag is allowed as a node element name.\n  ";
+    earl:assertions _:assertions90.
+_:assertions90 rdf:first _:assertion90;
+    rdf:rest rdf:nil.
+_:assertion90 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result90.
+_:result90 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-004";
+    dc:description "\n    Alt is allowed as a node element name.\n  ";
+    earl:assertions _:assertions91.
+_:assertions91 rdf:first _:assertion91;
+    rdf:rest rdf:nil.
+_:assertion91 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result91.
+_:result91 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-005> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-005";
+    dc:description "\n    Statement is allowed as a node element name.\n  ";
+    earl:assertions _:assertions92.
+_:assertions92 rdf:first _:assertion92;
+    rdf:rest rdf:nil.
+_:assertion92 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-005>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result92.
+_:result92 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-006> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-006";
+    dc:description "\n    Property is allowed as a node element name.\n  ";
+    earl:assertions _:assertions93.
+_:assertions93 rdf:first _:assertion93;
+    rdf:rest rdf:nil.
+_:assertion93 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-006>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result93.
+_:result93 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-007> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-007";
+    dc:description "\n    List is allowed as a node element name.\n  ";
+    earl:assertions _:assertions94.
+_:assertions94 rdf:first _:assertion94;
+    rdf:rest rdf:nil.
+_:assertion94 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-007>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result94.
+_:result94 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-008> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-008";
+    dc:description "\n    subject is allowed as a node element name.\n  ";
+    earl:assertions _:assertions95.
+_:assertions95 rdf:first _:assertion95;
+    rdf:rest rdf:nil.
+_:assertion95 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-008>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result95.
+_:result95 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-009> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-009";
+    dc:description "\n    predicate is allowed as a node element name.\n  ";
+    earl:assertions _:assertions96.
+_:assertions96 rdf:first _:assertion96;
+    rdf:rest rdf:nil.
+_:assertion96 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-009>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result96.
+_:result96 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-010> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-010";
+    dc:description "\n    object is allowed as a node element name.\n  ";
+    earl:assertions _:assertions97.
+_:assertions97 rdf:first _:assertion97;
+    rdf:rest rdf:nil.
+_:assertion97 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-010>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result97.
+_:result97 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-011> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-011";
+    dc:description "\n    type is allowed as a node element name.\n  ";
+    earl:assertions _:assertions98.
+_:assertions98 rdf:first _:assertion98;
+    rdf:rest rdf:nil.
+_:assertion98 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-011>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result98.
+_:result98 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-012> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-012";
+    dc:description "\n    value is allowed as a node element name.\n  ";
+    earl:assertions _:assertions99.
+_:assertions99 rdf:first _:assertion99;
+    rdf:rest rdf:nil.
+_:assertion99 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-012>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result99.
+_:result99 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-013> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-013";
+    dc:description "\n    first is allowed as a node element name.\n  ";
+    earl:assertions _:assertions100.
+_:assertions100 rdf:first _:assertion100;
+    rdf:rest rdf:nil.
+_:assertion100 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-013>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result100.
+_:result100 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-014> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-014";
+    dc:description "\n    rest is allowed as a node element name.\n  ";
+    earl:assertions _:assertions101.
+_:assertions101 rdf:first _:assertion101;
+    rdf:rest rdf:nil.
+_:assertion101 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-014>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result101.
+_:result101 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-015> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-015";
+    dc:description "\n    _1 is allowed as a node element name.\n  ";
+    earl:assertions _:assertions102.
+_:assertions102 rdf:first _:assertion102;
+    rdf:rest rdf:nil.
+_:assertion102 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-015>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result102.
+_:result102 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-016> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-016";
+    dc:description "\n    nil is allowed as a node element name.\n  ";
+    earl:assertions _:assertions103.
+_:assertions103 rdf:first _:assertion103;
+    rdf:rest rdf:nil.
+_:assertion103 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-016>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result103.
+_:result103 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-017> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-017";
+    dc:description "\n    Seq is allowed as a property element name.\n  ";
+    earl:assertions _:assertions104.
+_:assertions104 rdf:first _:assertion104;
+    rdf:rest rdf:nil.
+_:assertion104 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-017>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result104.
+_:result104 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-018> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-018";
+    dc:description "\n    Bag is allowed as a property element name.\n  ";
+    earl:assertions _:assertions105.
+_:assertions105 rdf:first _:assertion105;
+    rdf:rest rdf:nil.
+_:assertion105 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-018>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result105.
+_:result105 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-019> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-019";
+    dc:description "\n    Alt is allowed as a property element name.\n  ";
+    earl:assertions _:assertions106.
+_:assertions106 rdf:first _:assertion106;
+    rdf:rest rdf:nil.
+_:assertion106 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-019>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result106.
+_:result106 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-020> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-020";
+    dc:description "\n    Statement is allowed as a property element name.\n  ";
+    earl:assertions _:assertions107.
+_:assertions107 rdf:first _:assertion107;
+    rdf:rest rdf:nil.
+_:assertion107 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-020>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result107.
+_:result107 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-021> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-021";
+    dc:description "\n    Property is allowed as a property element name.\n  ";
+    earl:assertions _:assertions108.
+_:assertions108 rdf:first _:assertion108;
+    rdf:rest rdf:nil.
+_:assertion108 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-021>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result108.
+_:result108 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-022> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-022";
+    dc:description "\n    List is allowed as a property element name.\n  ";
+    earl:assertions _:assertions109.
+_:assertions109 rdf:first _:assertion109;
+    rdf:rest rdf:nil.
+_:assertion109 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-022>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result109.
+_:result109 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-023> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-023";
+    dc:description "\n    subject is allowed as a property element name.\n  ";
+    earl:assertions _:assertions110.
+_:assertions110 rdf:first _:assertion110;
+    rdf:rest rdf:nil.
+_:assertion110 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-023>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result110.
+_:result110 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-024> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-024";
+    dc:description "\n    predicate is allowed as a property element name.\n  ";
+    earl:assertions _:assertions111.
+_:assertions111 rdf:first _:assertion111;
+    rdf:rest rdf:nil.
+_:assertion111 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-024>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result111.
+_:result111 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-025> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-025";
+    dc:description "\n    object is allowed as a property element name.\n  ";
+    earl:assertions _:assertions112.
+_:assertions112 rdf:first _:assertion112;
+    rdf:rest rdf:nil.
+_:assertion112 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-025>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result112.
+_:result112 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-026> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-026";
+    dc:description "\n    type is allowed as a property element name.\n  ";
+    earl:assertions _:assertions113.
+_:assertions113 rdf:first _:assertion113;
+    rdf:rest rdf:nil.
+_:assertion113 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-026>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result113.
+_:result113 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-027> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-027";
+    dc:description "\n    value is allowed as a property element name.\n  ";
+    earl:assertions _:assertions114.
+_:assertions114 rdf:first _:assertion114;
+    rdf:rest rdf:nil.
+_:assertion114 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-027>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result114.
+_:result114 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-028> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-028";
+    dc:description "\n    first is allowed as a property element name.\n  ";
+    earl:assertions _:assertions115.
+_:assertions115 rdf:first _:assertion115;
+    rdf:rest rdf:nil.
+_:assertion115 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-028>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result115.
+_:result115 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-029> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-029";
+    dc:description "\n    rest is allowed as a property element name.\n  ";
+    earl:assertions _:assertions116.
+_:assertions116 rdf:first _:assertion116;
+    rdf:rest rdf:nil.
+_:assertion116 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-029>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result116.
+_:result116 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-030> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-030";
+    dc:description "\n    _1 is allowed as a property element name.\n  ";
+    earl:assertions _:assertions117.
+_:assertions117 rdf:first _:assertion117;
+    rdf:rest rdf:nil.
+_:assertion117 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-030>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result117.
+_:result117 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-031> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-031";
+    dc:description "\n    li is allowed as a property element name.\n  ";
+    earl:assertions _:assertions118.
+_:assertions118 rdf:first _:assertion118;
+    rdf:rest rdf:nil.
+_:assertion118 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-031>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result118.
+_:result118 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-032> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-032";
+    dc:description "\n    Seq is allowed as a property element name.\n  ";
+    earl:assertions _:assertions119.
+_:assertions119 rdf:first _:assertion119;
+    rdf:rest rdf:nil.
+_:assertion119 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-032>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result119.
+_:result119 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-033> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-033";
+    dc:description "\n    Bag is allowed as a property element name.\n  ";
+    earl:assertions _:assertions120.
+_:assertions120 rdf:first _:assertion120;
+    rdf:rest rdf:nil.
+_:assertion120 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-033>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result120.
+_:result120 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-034> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-034";
+    dc:description "\n    Alt is allowed as a property element name.\n  ";
+    earl:assertions _:assertions121.
+_:assertions121 rdf:first _:assertion121;
+    rdf:rest rdf:nil.
+_:assertion121 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-034>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result121.
+_:result121 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-035> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-035";
+    dc:description "\n    Statement is allowed as a property element name.\n  ";
+    earl:assertions _:assertions122.
+_:assertions122 rdf:first _:assertion122;
+    rdf:rest rdf:nil.
+_:assertion122 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-035>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result122.
+_:result122 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-036> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-036";
+    dc:description "\n    Property is allowed as a property element name.\n  ";
+    earl:assertions _:assertions123.
+_:assertions123 rdf:first _:assertion123;
+    rdf:rest rdf:nil.
+_:assertion123 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-036>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result123.
+_:result123 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-037> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-test-037";
+    dc:description "\n    List is allowed as a property element name.\n  ";
+    earl:assertions _:assertions124.
+_:assertions124 rdf:first _:assertion124;
+    rdf:rest rdf:nil.
+_:assertion124 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-test-037>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result124.
+_:result124 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-warn-001";
+    dc:description "\n    foo is allowed with warnings as a node element name.\n  ";
+    earl:assertions _:assertions125.
+_:assertions125 rdf:first _:assertion125;
+    rdf:rest rdf:nil.
+_:assertion125 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result125.
+_:result125 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-warn-002";
+    dc:description "\n    foo is allowed with warnings as a property element name.\n  ";
+    earl:assertions _:assertions126.
+_:assertions126 rdf:first _:assertion126;
+    rdf:rest rdf:nil.
+_:assertion126 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result126.
+_:result126 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-003> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-rdf-names-use-warn-003";
+    dc:description "\n    foo is allowed with warnings as a property attribute name.\n  ";
+    earl:assertions _:assertions127.
+_:assertions127 rdf:first _:assertion127;
+    rdf:rest rdf:nil.
+_:assertion127 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-rdf-names-use-warn-003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result127.
+_:result127 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-reification-required-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-reification-required-test001";
+    dc:description "\n    A parser is not required to generate a bag of reified\nstatements for all description elements.\n  ";
+    earl:assertions _:assertions128.
+_:assertions128 rdf:first _:assertion128;
+    rdf:rest rdf:nil.
+_:assertion128 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-reification-required-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result128.
+_:result128 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-seq-representation-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-seq-representation-test001";
+    dc:description "\n    rdf:parseType=\"Collection\" is parsed like the nonstandard\ndaml:collection.\n  ";
+    earl:assertions _:assertions129.
+_:assertions129 rdf:first _:assertion129;
+    rdf:rest rdf:nil.
+_:assertion129 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-seq-representation-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result129.
+_:result129 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-syntax-incomplete-test001";
+    dc:description "\n    rdf:nodeID can be used to label a blank node.\n  ";
+    earl:assertions _:assertions130.
+_:assertions130 rdf:first _:assertion130;
+    rdf:rest rdf:nil.
+_:assertion130 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result130.
+_:result130 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-syntax-incomplete-test002";
+    dc:description "\n    rdf:nodeID can be used to label a blank node. These have file\nscope and are distinct from any unlabelled blank nodes.\n  ";
+    earl:assertions _:assertions131.
+_:assertions131 rdf:first _:assertion131;
+    rdf:rest rdf:nil.
+_:assertion131 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result131.
+_:result131 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test003> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-syntax-incomplete-test003";
+    dc:description "\n    On an rdf:Description or typed node rdf:nodeID behaves\nsimilarly to an rdf:about.\n  ";
+    earl:assertions _:assertions132.
+_:assertions132 rdf:first _:assertion132;
+    rdf:rest rdf:nil.
+_:assertion132 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result132.
+_:result132 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-syntax-incomplete-test004";
+    dc:description "\n    On a property element rdf:nodeID behaves similarly to\nrdf:resource.\n  ";
+    earl:assertions _:assertions133.
+_:assertions133 rdf:first _:assertion133;
+    rdf:rest rdf:nil.
+_:assertion133 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-test004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result133.
+_:result133 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-syntax-incomplete-error001";
+    dc:description "\n    The value of rdf:nodeID must match the XML Name production,\n(as modified by XML Namespaces).\n  ";
+    earl:assertions _:assertions134.
+_:assertions134 rdf:first _:assertion134;
+    rdf:rest rdf:nil.
+_:assertion134 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result134.
+_:result134 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-syntax-incomplete-error002";
+    dc:description "\n    The value of rdf:nodeID must match the XML Name production,\n(as modified by XML Namespaces).\n  ";
+    earl:assertions _:assertions135.
+_:assertions135 rdf:first _:assertion135;
+    rdf:rest rdf:nil.
+_:assertion135 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result135.
+_:result135 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error003> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-syntax-incomplete-error003";
+    dc:description "\n    The value of rdf:nodeID must match the XML Name production,\n(as modified by XML Namespaces).\n  ";
+    earl:assertions _:assertions136.
+_:assertions136 rdf:first _:assertion136;
+    rdf:rest rdf:nil.
+_:assertion136 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result136.
+_:result136 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-syntax-incomplete-error004";
+    dc:description "\n    Cannot have rdf:nodeID and rdf:ID.\n  ";
+    earl:assertions _:assertions137.
+_:assertions137 rdf:first _:assertion137;
+    rdf:rest rdf:nil.
+_:assertion137 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result137.
+_:result137 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error005> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-syntax-incomplete-error005";
+    dc:description "\n    Cannot have rdf:nodeID and rdf:about.\n  ";
+    earl:assertions _:assertions138.
+_:assertions138 rdf:first _:assertion138;
+    rdf:rest rdf:nil.
+_:assertion138 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error005>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result138.
+_:result138 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error006> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-syntax-incomplete-error006";
+    dc:description "\n    Cannot have rdf:nodeID and rdf:resource.\n  ";
+    earl:assertions _:assertions139.
+_:assertions139 rdf:first _:assertion139;
+    rdf:rest rdf:nil.
+_:assertion139 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-syntax-incomplete-error006>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result139.
+_:result139 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-uri-substructure-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-uri-substructure-test001";
+    dc:description "\n    Demonstrates the Recommended partitioning of a URI into a\nnamespace part and a localname part\n  ";
+    earl:assertions _:assertions140.
+_:assertions140 rdf:first _:assertion140;
+    rdf:rest rdf:nil.
+_:assertion140 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-uri-substructure-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result140.
+_:result140 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test003> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-xmllang-test003";
+    dc:description "\n    In-scope xml:lang applies to element content literal values\n  ";
+    earl:assertions _:assertions141.
+_:assertions141 rdf:first _:assertion141;
+    rdf:rest rdf:nil.
+_:assertion141 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result141.
+_:result141 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test004> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-xmllang-test004";
+    dc:description "\n    In-scope xml:lang applies to element content literal values\n  ";
+    earl:assertions _:assertions142.
+_:assertions142 rdf:first _:assertion142;
+    rdf:rest rdf:nil.
+_:assertion142 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result142.
+_:result142 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test005> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-xmllang-test005";
+    dc:description "\n    In-scope xml:lang applies to element content literal values\n  ";
+    earl:assertions _:assertions143.
+_:assertions143 rdf:first _:assertion143;
+    rdf:rest rdf:nil.
+_:assertion143 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test005>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result143.
+_:result143 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test006> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfms-xmllang-test006";
+    dc:description "\n    In-scope xml:lang applies to element content literal values\n  ";
+    earl:assertions _:assertions144.
+_:assertions144 rdf:first _:assertion144;
+    rdf:rest rdf:nil.
+_:assertion144 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfms-xmllang-test006>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result144.
+_:result144 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfs-domain-and-range-test001";
+    dc:description "\n    a RDF Property may have more than one domain property\n  ";
+    earl:assertions _:assertions145.
+_:assertions145 rdf:first _:assertion145;
+    rdf:rest rdf:nil.
+_:assertion145 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result145.
+_:result145 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test002> a earl:TestCriterion, earl:TestCase;
+    dc:title "rdfs-domain-and-range-test002";
+    dc:description "\n    a RDF Property may have more than one domain property\n  ";
+    earl:assertions _:assertions146.
+_:assertions146 rdf:first _:assertion146;
+    rdf:rest rdf:nil.
+_:assertion146 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdfs-domain-and-range-test002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result146.
+_:result146 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "unrecognised-xml-attributes-test001";
+    dc:description "\n    Unrecognized attributes in the xml namespace should be\nignored.\n  ";
+    earl:assertions _:assertions147.
+_:assertions147 rdf:first _:assertion147;
+    rdf:rest rdf:nil.
+_:assertion147 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result147.
+_:result147 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test002> a earl:TestCriterion, earl:TestCase;
+    dc:title "unrecognised-xml-attributes-test002";
+    dc:description "\n    Unrecognized attributes in the xml namespace should be\nignored.\n  ";
+    earl:assertions _:assertions148.
+_:assertions148 rdf:first _:assertion148;
+    rdf:rest rdf:nil.
+_:assertion148 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#unrecognised-xml-attributes-test002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result148.
+_:result148 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xml-canon-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "xml-canon-test001";
+    dc:description "\n    Demonstrating the canonicalisation of XMLLiterals.\n  ";
+    earl:assertions _:assertions149.
+_:assertions149 rdf:first _:assertion149;
+    rdf:rest rdf:nil.
+_:assertion149 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xml-canon-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result149.
+_:result149 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test001> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test001";
+    dc:description "\n    xml:base applies to an rdf:ID on an rdf:Description element.\n  ";
+    earl:assertions _:assertions150.
+_:assertions150 rdf:first _:assertion150;
+    rdf:rest rdf:nil.
+_:assertion150 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test001>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result150.
+_:result150 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test002> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test002";
+    dc:description "\n    xml:base applies to an rdf:resource attribute.\n  ";
+    earl:assertions _:assertions151.
+_:assertions151 rdf:first _:assertion151;
+    rdf:rest rdf:nil.
+_:assertion151 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test002>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result151.
+_:result151 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test003> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test003";
+    dc:description "\n    xml:base applies to an rdf:about attribute.\n  ";
+    earl:assertions _:assertions152.
+_:assertions152 rdf:first _:assertion152;
+    rdf:rest rdf:nil.
+_:assertion152 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test003>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result152.
+_:result152 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test004> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test004";
+    dc:description "\n    xml:base applies to an rdf:ID on a property element.\n  ";
+    earl:assertions _:assertions153.
+_:assertions153 rdf:first _:assertion153;
+    rdf:rest rdf:nil.
+_:assertion153 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test004>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result153.
+_:result153 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test006> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test006";
+    dc:description "\n    xml:base scoping.\n  ";
+    earl:assertions _:assertions154.
+_:assertions154 rdf:first _:assertion154;
+    rdf:rest rdf:nil.
+_:assertion154 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test006>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result154.
+_:result154 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test007> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test007";
+    dc:description "\n    example of relative URI resolution.\n  ";
+    earl:assertions _:assertions155.
+_:assertions155 rdf:first _:assertion155;
+    rdf:rest rdf:nil.
+_:assertion155 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test007>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result155.
+_:result155 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test008> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test008";
+    dc:description "\n    example of empty same document ref resolution.\n  ";
+    earl:assertions _:assertions156.
+_:assertions156 rdf:first _:assertion156;
+    rdf:rest rdf:nil.
+_:assertion156 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test008>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result156.
+_:result156 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test009> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test009";
+    dc:description "\n    Example of relative uri with absolute path resolution.\n  ";
+    earl:assertions _:assertions157.
+_:assertions157 rdf:first _:assertion157;
+    rdf:rest rdf:nil.
+_:assertion157 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test009>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result157.
+_:result157 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test010> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test010";
+    dc:description "\n    Example of relative uri with net path resolution.\n  ";
+    earl:assertions _:assertions158.
+_:assertions158 rdf:first _:assertion158;
+    rdf:rest rdf:nil.
+_:assertion158 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test010>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result158.
+_:result158 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test011> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test011";
+    dc:description "\n    Example of xml:base with no path component.\n  ";
+    earl:assertions _:assertions159.
+_:assertions159 rdf:first _:assertion159;
+    rdf:rest rdf:nil.
+_:assertion159 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test011>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result159.
+_:result159 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test013> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test013";
+    dc:description "\n    With an xml:base with fragment the fragment is ignored.\n  ";
+    earl:assertions _:assertions160.
+_:assertions160 rdf:first _:assertion160;
+    rdf:rest rdf:nil.
+_:assertion160 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test013>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result160.
+_:result160 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.
+<https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test014> a earl:TestCriterion, earl:TestCase;
+    dc:title "xmlbase-test014";
+    dc:description "\n    Test output corrected to use correct base URL.\n  ";
+    earl:assertions _:assertions161.
+_:assertions161 rdf:first _:assertion161;
+    rdf:rest rdf:nil.
+_:assertion161 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#xmlbase-test014>;
+    earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result161.
+_:result161 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime.

--- a/rdf-xml/reports/template.md
+++ b/rdf-xml/reports/template.md
@@ -1,0 +1,374 @@
+-# This template is used for generating a rollup EARL report. It expects to be
+-# called with a single _tests_ local with the following structure
+-#
+-#  {
+-#    "@context": {...},
+-#    "@id": "",
+-#    "@type": "earl:Software",
+-#    "name": "...",
+-#    "bibRef": "[[...]]",
+-#    "assertions": ["rdfxml-streaming-parser.js.ttl"],
+-#    "testSubjects": [
+-#      {
+-#        "@id": "https://www.npmjs.com/package/rdfxml-streaming-parser/",
+-#        "@type": "earl:TestSubject",
+-#        "name": "rdfxml-streaming-parser"
+-#      },
+-#      ...
+-#    ],
+-#    "tests": [{
+-#      "@id": "http://www.w3.org/2013/TurtleTests/manifest.ttl#turtle-syntax-file-01",
+-#      "@type": ["earl:TestCriterion", "earl:TestCase"],
+-#      "title": "subm-test-00",
+-#      "description": "Blank subject",
+-#      "testAction": "http://www.w3.org/2013/TurtleTests/turtle-syntax-file-01.ttl",
+-#      "testResult": "http://www.w3.org/2013/TurtleTests/turtle-syntax-file-01.out"
+-#      "mode": "earl:automatic",
+-#      "assertions": [
+-#        {
+-#          "@type": "earl:Assertion",
+-#          "assertedBy": "http://greggkellogg.net/foaf#me",
+-#          "test": "http://svn.apache.org/repos/asf/jena/Experimental/riot-reader/testing/RIOT/Lang/TurtleSubm/manifest.ttl#testeval00",
+-#          "subject": "http://rubygems.org/gems/rdf-turtle",
+-#          "result": {
+-#            "@type": "earl:TestResult",
+-#            "outcome": "earl:passed"
+-#          }
+-#        }
+-#      ]
+-#    }]
+-#  }
+- require 'cgi'
+
+!!! 5
+%html{:prefix => "earl: http://www.w3.org/ns/earl# doap: http://usefulinc.com/ns/doap# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#"}
+  - test_info = {}
+  - test_refs = {}
+  - subject_refs = {}
+  - passed_tests = []
+  - subjects = tests['testSubjects'].sort_by {|s| s['name'].to_s.downcase}
+  - subjects.each_with_index do |subject, index|
+    - subject_refs[subject['@id']] = "subj_#{index}"
+  %head
+    %meta{"http-equiv" => "Content-Type", :content => "text/html;charset=utf-8"}
+    %link{:rel => "alternate", :href => "earl.ttl"}
+    %link{:rel => "alternate", :href => "earl.jsonld"}
+    - tests['assertions'].each do |file|
+      %link{:rel => "related", :href => file}
+    %title
+      = tests['name']
+      Implementation Report
+    %script.remove{:src => "../../local-biblio.js"}
+    %script.remove{:type => "text/javascript", :src => "https://www.w3.org/Tools/respec/respec-w3c-common"}
+    :javascript
+      var respecConfig = {
+          // extend the bibliography entries
+          localBiblio: localBibliography,
+
+          // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
+          specStatus:           "base",
+          copyrightStart:       "2010",
+          doRDFa:               "1.1",
+
+          // the specification's short name, as in http://www.w3.org/TR/short-name/
+          shortName:            "rdf-syntax-grammar",
+          //subtitle:             "RDF/XML Implementation Conformance Report",
+          // if you wish the publication date to be other than today, set this
+          publishDate:  "#{Time.now.strftime("%Y/%m/%d")}",
+
+          // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+          // and its maturity status
+          //previousPublishDate:  "2011-10-23",
+          //previousMaturity:     "ED",
+          //previousDiffURI:      "http://json-ld.org/spec/ED/json-ld-syntax/20111023/index.html",
+          //diffTool:             "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+
+          // if there a publicly available Editor's Draft, this is the link
+          //edDraftURI:           "",
+
+          // if this is a LCWD, uncomment and set the end of its review period
+          // lcEnd: "2009-08-05",
+
+          // editors, add as many as you like
+          // only "name" is required
+          editors:  [
+              { name: "Gregg Kellogg", url: "http://greggkellogg.net/",
+                company: "Kellogg Associates" },
+              { name: "Andy Seaborne",
+                company: "The Apache Software Foundation"}
+          ],
+
+          // authors, add as many as you like.
+          // This is optional, uncomment if you have authors as well as editors.
+          // only "name" is required. Same format as editors.
+          //authors:  [
+          //RDF Working Group],
+
+          // name of the WG
+          wg:           "RDF Working Group",
+
+          // URI of the public WG page
+          wgURI:        "http://www.w3.org/2011/rdf-wg/",
+
+          // name (with the @w3c.org) of the public mailing to which comments are due
+          wgPublicList: "public-rdf-comments",
+
+          // URI of the patent status for this WG, for Rec-track documents
+          // !!!! IMPORTANT !!!!
+          // This is important for Rec-track documents, do not copy a patent URI from a random
+          // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
+          // Team Contact.
+          wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/46168/status",
+          alternateFormats: [
+            {uri: "earl.ttl", label: "Turtle"},
+            {uri: "earl.jsonld", label: "JSON-LD"}
+          ],
+      };
+    :css
+      span[property='dc:description'] { display: none; }
+      td.PASS { color: green; }
+      td.FAIL { color: red; }
+      table.report {
+        border-width: 1px;
+        border-spacing: 2px;
+        border-style: outset;
+        border-color: gray;
+        border-collapse: separate;
+        background-color: white;
+      }
+      table.report th {
+        border-width: 1px;
+        padding: 1px;
+        border-style: inset;
+        border-color: gray;
+        background-color: white;
+        -moz-border-radius: ;
+      }
+      table.report td {
+        border-width: 1px;
+        padding: 1px;
+        border-style: inset;
+        border-color: gray;
+        background-color: white;
+        -moz-border-radius: ;
+      }
+      tr.summary {font-weight: bold;}
+      td.passed-all {color: green;}
+      td.passed-most {color: darkorange;}
+      td.passed-some {color: red;}
+  %body{:prefix => "earl: http://www.w3.org/ns/earl# doap: http://usefulinc.com/ns/doap# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#"}
+    %section#abstract{:about => tests['@id'], :typeof => [tests['@type']].flatten.join(" ")}
+      %p
+        This document report test subject conformance for and related specifications for
+        %span{:property => "doap:name"}<=tests['name']
+        %span{:property => "dc:bibliographicCitation"}<
+          = tests['bibRef']
+        according to the requirements of the Evaluation and Report Language (EARL) 1.0 Schema [[EARL10-SCHEMA]].
+      %p
+        This report is also available in alternate formats:
+        %a{:rel => "xhv:alternate", :href => "earl.ttl"}
+          Turtle
+        and
+        %a{:rel => "xhv:alternate", :href => "earl.jsonld"}
+          JSON-LD
+    %section#sodt
+    %section
+      :markdown
+        ## Instructions for submitting implementation reports
+
+          Tests should be run using the test manifests defined in the 
+          [Test Manifests](#test-manifests) Section.
+
+          The assumed base URI for the tests is `<http://example/base/>` if needed.
+
+          Reports should be submitted in Turtle format to [public-rdf-comments@w3.org](mailto:public-rdf-comments@w3.org)
+          and include an `earl:Assertion`
+          for each test, referencing the test resource from the associated manifest
+          and the test subject being reported upon. An example test entry is be the following:
+
+              [ a earl:Assertion;
+                earl:assertedBy <https://www.rubensworks.net/#me>;
+                earl:subject <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+                earl:test <https://www.w3.org/2013/RDFXMLTests/manifest.ttl#rdf-element-not-mandatory-test001>;
+                earl:result [
+                  a earl:TestResult;
+                  earl:outcome earl:passed;
+                  dc:date "2018-10-08T23:16:03.823Z"^^xsd:dateTime];
+                earl:mode earl:automatic ] .
+
+          The Test Subject should be defined as a `doap:Project`, including the name,
+          homepage and developer(s) of the software (see [[DOAP]]). Optionally, including the
+          project description and programming language. An example test subject description is the following:
+
+              <> foaf:primaryTopic <https://www.npmjs.com/package/rdfxml-streaming-parser/>;
+                  dc:issued "2018-10-08T23:16:03.823Z"^^xsd:dateTime;
+                  foaf:maker <https://www.rubensworks.net/#me>.
+
+              <https://www.npmjs.com/package/rdfxml-streaming-parser/> a earl:Software, earl:TestSubject, doap:Project;
+                  doap:name "rdfxml-streaming-parser";
+                  dc:title "rdfxml-streaming-parser";
+                  doap:homepage <https://github.com/rdfjs/rdfxml-streaming-parser.js#readme>;
+                  doap:license <http://opensource.org/licenses/MIT>;
+                  doap:programming-language "JavaScript";
+                  doap:implements <https://www.w3.org/TR/rdf-syntax-grammar/>;
+                  doap:category <http://dbpedia.org/resource/Resource_Description_Framework>;
+                  doap:download-page <https://npmjs.org/package/rdfxml-streaming-parser>;
+                  doap:bug-database <https://github.com/rdfjs/rdfxml-streaming-parser.js/issues>;
+                  doap:developer <https://www.rubensworks.net/#me>;
+                  doap:maintainer <https://www.rubensworks.net/#me>;
+                  doap:documenter <https://www.rubensworks.net/#me>;
+                  doap:maker <https://www.rubensworks.net/#me>;
+                  dc:creator <https://www.rubensworks.net/#me>;
+                  dc:description "Streaming RDF/XML parser"@en;
+                  doap:description "Streaming RDF/XML parser"@en.
+
+          The software developer, either an organization or one or more individuals SHOULD be
+          referenced from `doap:developer` using [[FOAF]]. For example:
+
+              <https://www.rubensworks.net/#me> a foaf:Person, earl:Assertor;
+                  foaf:name "Ruben Taelman <rubensworks@gmail.com>";
+                  foaf:homepage <https://www.rubensworks.net/>.
+
+          See [RDF Test Suite Wiki](https://www.w3.org/2011/rdf-wg/wiki/RDF_Test_Suites)
+          for more information.
+    %section
+      %h2
+        Test Manifests
+      - tests['entries'].each_with_index do |manifest, ndx2|
+        - test_cases = manifest['entries']
+        %section{:typeof => manifest['@type'].join(" "), :resource => manifest['@id']}
+          %h2<="RDF/XML Tests"
+          - [manifest['description']].flatten.compact.each do |desc|
+            %p<
+              ~ CGI.escapeHTML desc.to_s
+          %table.report
+            - skip_subject = {}
+            - passed_tests[ndx2] = []
+            %tr
+              %th
+                Test
+              - subjects.each_with_index do |subject, index|
+                -# If subject is untested for every test in this manifest, skip it
+                - skip_subject[subject['@id']] = manifest['entries'].all? {|t| t['assertions'][index]['result']['outcome'] == 'earl:untested'}
+                - unless skip_subject[subject['@id']]
+                  %th
+                    %a{:href => '#' + subject_refs[subject['@id']]}<=Array(subject['name']).first
+            - test_cases.each do |test|
+              - tid = 'test_' + (test['@id'][0,2] == '_:' ? test['@id'][2..-1] : test['@id'].split('#').last)
+              - (test_info[tid] ||= []) << test
+              - test_refs[test['@id']] = tid
+              %tr{:rel => "mf:entries", :typeof => test['@type'].join(" "), :resource => test['@id'], :inlist => true}
+                %td
+                  %a{:href => "##{tid}"}<
+                    ~ CGI.escapeHTML test['title'].to_s
+                - subjects.each_with_index do |subject, ndx|
+                  - next if skip_subject[subject['@id']]
+                  - assertion = test['assertions'].detect {|a| a['subject'] == subject['@id']}
+                  - pass_fail = assertion['result']['outcome'].split(':').last.upcase.sub(/(PASS|FAIL)ED$/, '\1')
+                  - passed_tests[ndx2][ndx] = (passed_tests[ndx2][ndx] || 0) + (pass_fail == 'PASS' ? 1 : 0)
+                  %td{:class => pass_fail, :property => "earl:assertions", :typeof => assertion['@type']}
+                    - if assertion['assertedBy']
+                      %link{:property => "earl:assertedBy", :href => assertion['assertedBy']}
+                    %link{:property => "earl:test", :href => assertion['test']}
+                    %link{:property => "earl:subject", :href => assertion['subject']}
+                    - if assertion['mode']
+                      %link{:property => 'earl:mode', :href => assertion['mode']}
+                    %span{:property => "earl:result", :typeof => assertion['result']['@type']}
+                      %span{:property => 'earl:outcome', :resource => assertion['result']['outcome']}
+                        = pass_fail
+            %tr.summary
+              %td
+                = "Percentage passed out of #{manifest['entries'].length} Tests"
+              - passed_tests[ndx2].compact.each do |r|
+                - pct = (r * 100.0) / manifest['entries'].length
+                %td{:class => (pct == 100.0 ? 'passed-all' : (pct >= 95.0 ? 'passed-most' : 'passed-some'))}
+                  = "#{'%.1f' % pct}%"
+    %section.appendix
+      %h2
+        Test Subjects
+      %p
+        This report was tested using the following test subjects:
+      %dl
+        - subjects.each_with_index do |subject, index|
+          %dt{:id => subject_refs[subject['@id']]}
+            %a{:href => subject['@id']}
+              %span{:about => subject['@id'], :property => "doap:name"}<= Array(subject['name']).first
+          %dd{:property => "earl:testSubjects", :resource => subject['@id'], :typeof => [subject['@type']].flatten.join(" ")}
+            %dl
+              - if subject['doapDesc']
+                %dt= "Description"
+                %dd{:property => "doap:description", :lang => 'en'}<
+                  ~ CGI.escapeHTML subject['doapDesc'].to_s
+              - if subject['language']
+                %dt= "Programming Language"
+                %dd{:property => "doap:programming-language"}<
+                  ~ CGI.escapeHTML subject['language'].to_s
+              - if subject['homepage']
+                %dt= "Home Page"
+                %dd{:property => "doap:homepage"}
+                  %a{:href=> subject['homepage']}
+                    ~ CGI.escapeHTML subject['homepage'].to_s
+              - if subject['developer']
+                %dt= "Developer"
+                - subject['developer'].each do |dev|
+                  %dd{:rel => "doap:developer"}
+                    %div{:resource => dev['@id'], :typeof => [dev['@type']].flatten.join(" ")}
+                      - if dev.has_key?('@id')
+                        %a{:href => dev['@id']}
+                          %span{:property => "foaf:name"}<
+                            ~ CGI.escapeHTML dev['foaf:name'].to_s
+                      - else
+                        %span{:property => "foaf:name"}<
+                          ~ CGI.escapeHTML dev['foaf:name'].to_s
+              %dt
+                Test Suite Compliance
+              %dd
+                %table.report
+                  %tbody
+                    - tests['entries'].each_with_index do |manifest, ndx|
+                      - passed = passed_tests[ndx][index].to_i
+                      - next if passed == 0
+                      - total = manifest['entries'].length
+                      - pct = (passed * 100.0) / total
+                      %tr
+                        %td{:class => (pct == 100.0 ? 'passed-all' : (pct >= 85.0 ? 'passed-most' : 'passed-some'))}
+                          = "#{passed}/#{total} (#{'%.1f' % pct}%)"
+    - unless tests['assertions'].empty?
+      %section.appendix{:rel => "xhv:related earl:assertions"}
+        %h2
+          Individual Test Results
+        %p
+          Individual test results used to construct this report are available here:
+        %ul
+          - tests['assertions'].each do |file|
+            %li
+              %a.source{:href => file}<= file
+    %section#appendix{:property => "earl:generatedBy", :resource => tests['generatedBy']['@id'], :typeof => tests['generatedBy']['@type']}
+      %h2
+        Report Generation Software
+      - doap = tests['generatedBy']
+      - rel = doap['release']
+      %p
+        This report generated by
+        %span{:property => "doap:name"}<
+          %a{:href => tests['generatedBy']['@id']}<
+            = doap['name']
+        %meta{:property => "doap:shortdesc", :content => doap['shortdesc'], :lang => 'en'}
+        %meta{:property => "doap:description", :content => doap['doapDesc'], :lang => 'en'}
+        version
+        %span{:property => "doap:release", :resource => rel['@id'], :typeof => 'doap:Version'}
+          %span{:property => "doap:revision"}<=rel['revision']
+          %meta{:property => "doap:name", :content => rel['name']}
+          %meta{:property => "doap:created", :content => rel['created'], :datatype => "xsd:date"}
+        an
+        %a{:property => "doap:license", :href => doap['license']}<="Unlicensed"
+        %span{:property => "doap:programming-language"}<="Ruby"
+        application. More information is available at
+        %a{:property => "doap:homepage", :href => doap['homepage']}<=doap['homepage']
+        = "."
+      %p{:property => "doap:developer", :resource => "http://greggkellogg.net/foaf#me", :typeof => "foaf:Person"}
+        This software is provided by
+        %a{:property => "foaf:homepage", :href => "http://greggkellogg.net/"}<
+          %span{:aboue => "http://greggkellogg.net/foaf#me", :property => "foaf:name"}<
+            Gregg Kellogg
+        in hopes that it might make the lives of conformance testers easier.


### PR DESCRIPTION
This PR adds the EARL report for a [JavaScript-based RDF/XML parser](https://github.com/rdfjs/rdfxml-streaming-parser.js).

As there does not seem to be a report index available yet for RDF/XML, I've initialized one with this PR.