### PR TITLE
Take into account new baseIRI on Turtle and TriG tests

### DIFF
--- a/trig/trig-subm-01.nq
+++ b/trig/trig-subm-01.nq
@@ -1,2 +1,2 @@
-_:genid1 <http://www.w3.org/2013/TriGTests/trig-subm-01.trig#x> <http://www.w3.org/2013/TriGTests/trig-subm-01.trig#y> .
-_:genid2 <http://www.w3.org/2013/TriGTests/trig-subm-01.trig#x> <http://www.w3.org/2013/TriGTests/trig-subm-01.trig#y> <http://example/graph> .
+_:genid1 <http://w3c.github.io/rdf-tests/trig/trig-subm-01.trig#x> <http://w3c.github.io/rdf-tests/trig/trig-subm-01.trig#y> .
+_:genid2 <http://w3c.github.io/rdf-tests/trig/trig-subm-01.trig#x> <http://w3c.github.io/rdf-tests/trig/trig-subm-01.trig#y> <http://example/graph> .

--- a/trig/trig-subm-27.nq
+++ b/trig/trig-subm-27.nq
@@ -1,4 +1,4 @@
-<http://www.w3.org/2013/TriGTests/a1> <http://www.w3.org/2013/TriGTests/b1> <http://www.w3.org/2013/TriGTests/c1> .
+<http://w3c.github.io/rdf-tests/trig/a1> <http://w3c.github.io/rdf-tests/trig/b1> <http://w3c.github.io/rdf-tests/trig/c1> .
 <http://example.org/ns/a2> <http://example.org/ns/b2> <http://example.org/ns/c2> .
 <http://example.org/ns/foo/a3> <http://example.org/ns/foo/b3> <http://example.org/ns/foo/c3> .
 <http://example.org/ns/foo/bar#a4> <http://example.org/ns/foo/bar#b4> <http://example.org/ns/foo/bar#c4> .

--- a/trig/trig-subm-27.trig
+++ b/trig/trig-subm-27.trig
@@ -1,4 +1,4 @@
-# In-scope base URI is <http://www.w3.org/2013/TriGTests/trig-subm-27.trig> at this point
+# In-scope base URI is <http://w3c.github.io/rdf-tests/trig/trig-subm-27.trig> at this point
 {<a1> <b1> <c1> .}
 @base <http://example.org/ns/> .
 # In-scope base URI is http://example.org/ns/ at this point

--- a/turtle/turtle-subm-01.nt
+++ b/turtle/turtle-subm-01.nt
@@ -1,1 +1,1 @@
-_:genid1 <http://www.w3.org/2013/TurtleTests/turtle-subm-01.ttl#x> <http://www.w3.org/2013/TurtleTests/turtle-subm-01.ttl#y> .
+_:genid1 <http://w3c.github.io/rdf-tests/turtle/turtle-subm-01.ttl#x> <http://w3c.github.io/rdf-tests/turtle/turtle-subm-01.ttl#y> .

--- a/turtle/turtle-subm-27.nt
+++ b/turtle/turtle-subm-27.nt
@@ -1,4 +1,4 @@
-<http://www.w3.org/2013/TurtleTests/a1> <http://www.w3.org/2013/TurtleTests/b1> <http://www.w3.org/2013/TurtleTests/c1> .
+<http://w3c.github.io/rdf-tests/turtle/a1> <http://w3c.github.io/rdf-tests/turtle/b1> <http://w3c.github.io/rdf-tests/turtle/c1> .
 <http://example.org/ns/a2> <http://example.org/ns/b2> <http://example.org/ns/c2> .
 <http://example.org/ns/foo/a3> <http://example.org/ns/foo/b3> <http://example.org/ns/foo/c3> .
 <http://example.org/ns/foo/bar#a4> <http://example.org/ns/foo/bar#b4> <http://example.org/ns/foo/bar#c4> .

--- a/turtle/turtle-subm-27.ttl
+++ b/turtle/turtle-subm-27.ttl
@@ -1,4 +1,4 @@
-# In-scope base URI is <http://www.w3.org/2013/TurtleTests/turtle-subm-27.ttl> at this point
+# In-scope base URI is <http://w3c.github.io/rdf-tests/turtle/turtle-subm-27.ttl> at this point
 <a1> <b1> <c1> .
 @base <http://example.org/ns/> .
 # In-scope base URI is http://example.org/ns/ at this point


### PR DESCRIPTION
This changes the Turtle and TriG tests to use the new baseIRI where needed, otherwise, tests will always fail when starting from a manifest such as http://w3c.github.io/rdf-tests/trig/manifest.ttl.