### PR TITLE
Fix missing named data graph in SPARQL 1.1 constructwhere04

### DIFF
--- a/sparql11/data-sparql11/construct/manifest.ttl
+++ b/sparql11/data-sparql11/construct/manifest.ttl
@@ -55,7 +55,8 @@
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-02-01#resolution_3> ;
     mf:action
-         [ qt:query  <constructwhere04.rq> ] ;
+         [ qt:query  <constructwhere04.rq> ;
+           qt:graphData <data.ttl> ] ;
     mf:result  <constructwhere04result.ttl>
     .
 


### PR DESCRIPTION
The following query from test `constructwhere04` expects data from the graph with name `data.ttl`.

```sparql
PREFIX : <http://example.org/>

CONSTRUCT
FROM <data.ttl>
WHERE { ?s ?p ?o }
```

However, the manifest does not define any data for this test.

This PR adds the proper graph data for this tests, and places it inside a named graph.