### PR TITLE
Add tests for functions over string with characters outside the BMP.

### DIFF
--- a/sparql11/data-sparql11/functions/data5.ttl
+++ b/sparql11/data-sparql11/functions/data5.ttl
@@ -2,5 +2,13 @@
 @prefix : <http://example.org/> .
 
 # string data with characters outside the basic multilingual plane
-:s8 :str "\U0001F46A"^^xsd:string . # U+1F46A FAMILY
-:s9 :str "\U0001F468\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466"^^xsd:string . # single emoji grapheme containing: U+1F468 MAN, U+200D ZERO WIDTH JOINER, U+1F469 WOMAN, U+200D ZERO WIDTH JOINER, U+1F467 GIRL, U+200D ZERO WIDTH JOINER, U+1F466 BOY
+
+# U+1F46A FAMILY
+:s8 :str "\U0001F46A" .
+
+# single emoji grapheme containing 7 codepoints:
+# U+1F468 MAN, U+200D ZERO WIDTH JOINER,
+# U+1F469 WOMAN, U+200D ZERO WIDTH JOINER,
+# U+1F467 GIRL, U+200D ZERO WIDTH JOINER,
+# U+1F466 BOY
+:s9 :str "\U0001F468\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466" .

--- a/sparql11/data-sparql11/functions/data5.ttl
+++ b/sparql11/data-sparql11/functions/data5.ttl
@@ -1,0 +1,6 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <http://example.org/> .
+
+# string data with characters outside the basic multilingual plane
+:s8 :str "\U0001F46A"^^xsd:string . # U+1F46A FAMILY
+:s9 :str "\U0001F468\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466"^^xsd:string . # single emoji grapheme containing: U+1F468 MAN, U+200D ZERO WIDTH JOINER, U+1F469 WOMAN, U+200D ZERO WIDTH JOINER, U+1F467 GIRL, U+200D ZERO WIDTH JOINER, U+1F466 BOY

--- a/sparql11/data-sparql11/functions/encode01-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/encode01-non-bmp.srx
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sparql xmlns="http://www.w3.org/2005/sparql-results#">
 <head>
-	<variable name="s"/>
-	<variable name="str"/>
-	<variable name="encoded"/>
+    <variable name="s"/>
+    <variable name="str"/>
+    <variable name="encoded"/>
 </head>
 <results>
-		<result>
-			<binding name="s"><uri>http://example.org/s8</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">👪</literal></binding>
-			<binding name="encoded"><literal>%F0%9F%91%AA</literal></binding>
-		</result>
-		<result>
-			<binding name="s"><uri>http://example.org/s9</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">👨‍👩‍👧‍👦</literal></binding>
-			<binding name="encoded"><literal>%F0%9F%91%A8%E2%80%8D%F0%9F%91%A9%E2%80%8D%F0%9F%91%A7%E2%80%8D%F0%9F%91%A6</literal></binding>
-		</result>
+        <result>
+            <binding name="s"><uri>http://example.org/s8</uri></binding>
+            <binding name="str"><literal>👪</literal></binding>
+            <binding name="encoded"><literal>%F0%9F%91%AA</literal></binding>
+        </result>
+        <result>
+            <binding name="s"><uri>http://example.org/s9</uri></binding>
+            <binding name="str"><literal>👨‍👩‍👧‍👦</literal></binding>
+            <binding name="encoded"><literal>%F0%9F%91%A8%E2%80%8D%F0%9F%91%A9%E2%80%8D%F0%9F%91%A7%E2%80%8D%F0%9F%91%A6</literal></binding>
+        </result>
 </results>
 </sparql>

--- a/sparql11/data-sparql11/functions/encode01-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/encode01-non-bmp.srx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+<head>
+	<variable name="s"/>
+	<variable name="str"/>
+	<variable name="encoded"/>
+</head>
+<results>
+		<result>
+			<binding name="s"><uri>http://example.org/s8</uri></binding>
+			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">👪</literal></binding>
+			<binding name="encoded"><literal>%F0%9F%91%AA</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s9</uri></binding>
+			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">👨‍👩‍👧‍👦</literal></binding>
+			<binding name="encoded"><literal>%F0%9F%91%A8%E2%80%8D%F0%9F%91%A9%E2%80%8D%F0%9F%91%A7%E2%80%8D%F0%9F%91%A6</literal></binding>
+		</result>
+</results>
+</sparql>

--- a/sparql11/data-sparql11/functions/lcase01-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/lcase01-non-bmp.srx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+<head>
+	<variable name="s"/>
+	<variable name="lstr"/>
+</head>
+<results>
+		<result>
+			<binding name="s"><uri>http://example.org/s8</uri></binding>
+			<binding name="lstr"><literal>👪</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s9</uri></binding>
+			<binding name="lstr"><literal>👨‍👩‍👧‍👦</literal></binding>
+		</result>
+</results>
+</sparql>

--- a/sparql11/data-sparql11/functions/lcase01-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/lcase01-non-bmp.srx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sparql xmlns="http://www.w3.org/2005/sparql-results#">
 <head>
-	<variable name="s"/>
-	<variable name="lstr"/>
+    <variable name="s"/>
+    <variable name="lstr"/>
 </head>
 <results>
-		<result>
-			<binding name="s"><uri>http://example.org/s8</uri></binding>
-			<binding name="lstr"><literal>👪</literal></binding>
-		</result>
-		<result>
-			<binding name="s"><uri>http://example.org/s9</uri></binding>
-			<binding name="lstr"><literal>👨‍👩‍👧‍👦</literal></binding>
-		</result>
+        <result>
+            <binding name="s"><uri>http://example.org/s8</uri></binding>
+            <binding name="lstr"><literal>👪</literal></binding>
+        </result>
+        <result>
+            <binding name="s"><uri>http://example.org/s9</uri></binding>
+            <binding name="lstr"><literal>👨‍👩‍👧‍👦</literal></binding>
+        </result>
 </results>
 </sparql>

--- a/sparql11/data-sparql11/functions/length01-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/length01-non-bmp.srx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sparql xmlns="http://www.w3.org/2005/sparql-results#">
 <head>
-	<variable name="str"/>
-	<variable name="len"/>
+    <variable name="str"/>
+    <variable name="len"/>
 </head>
 <results>
-		<result>
-			<binding name="str"><literal>👪</literal></binding>
-			<binding name="len"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal></binding>
-		</result>
-		<result>
-			<binding name="str"><literal>👨‍👩‍👧‍👦</literal></binding>
-			<binding name="len"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">7</literal></binding>
-		</result>
+        <result>
+            <binding name="str"><literal>👪</literal></binding>
+            <binding name="len"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal></binding>
+        </result>
+        <result>
+            <binding name="str"><literal>👨‍👩‍👧‍👦</literal></binding>
+            <binding name="len"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">7</literal></binding>
+        </result>
 </results>
 </sparql>

--- a/sparql11/data-sparql11/functions/length01-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/length01-non-bmp.srx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+<head>
+	<variable name="str"/>
+	<variable name="len"/>
+</head>
+<results>
+		<result>
+			<binding name="str"><literal>👪</literal></binding>
+			<binding name="len"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal></binding>
+		</result>
+		<result>
+			<binding name="str"><literal>👨‍👩‍👧‍👦</literal></binding>
+			<binding name="len"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">7</literal></binding>
+		</result>
+</results>
+</sparql>

--- a/sparql11/data-sparql11/functions/manifest.ttl
+++ b/sparql11/data-sparql11/functions/manifest.ttl
@@ -24,11 +24,17 @@
 	:concat01
 	:concat02
 	:substring01
+	:substring01-non-bmp
 	:substring02
+	:substring02-non-bmp
 	:length01
+	:length01-non-bmp
 	:ucase01
+	:ucase01-non-bmp
 	:lcase01
+	:lcase01-non-bmp
 	:encode01
+	:encode01-non-bmp
 	:contains01
 	:starts01
 	:ends01
@@ -226,6 +232,16 @@
     mf:result  <substring01.srx> ;
 	.
 
+:substring01-non-bmp rdf:type mf:QueryEvaluationTest ;
+	mf:name    "SUBSTR() (3-argument) on non-BMP unicode strings" ;
+	mf:feature sparql:substr ;
+	dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <substring01.rq> ;
+           qt:data   <data5.ttl> ] ;
+    mf:result  <substring01-non-bmp.srx> ;
+	.
+
 :substring02 rdf:type mf:QueryEvaluationTest ;
 	mf:name    "SUBSTR() (2-argument)" ;
 	mf:feature sparql:substr ;
@@ -235,6 +251,16 @@
          [ qt:query  <substring02.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <substring02.srx> ;
+	.
+
+:substring02-non-bmp rdf:type mf:QueryEvaluationTest ;
+	mf:name    "SUBSTR() (2-argument) on non-BMP unicode strings" ;
+	mf:feature sparql:substr ;
+	dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <substring02.rq> ;
+           qt:data   <data5.ttl> ] ;
+    mf:result  <substring02-non-bmp.srx> ;
 	.
 
 :length01 rdf:type mf:QueryEvaluationTest ;
@@ -248,6 +274,16 @@
     mf:result  <length01.srx> ;
 	.
 
+:length01-non-bmp rdf:type mf:QueryEvaluationTest ;
+	mf:name    "STRLEN() on non-BMP unicode strings" ;
+	mf:feature sparql:strlen ;
+	dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <length01.rq> ;
+           qt:data   <data5.ttl> ] ;
+    mf:result  <length01-non-bmp.srx> ;
+	.
+
 :ucase01 rdf:type mf:QueryEvaluationTest ;
 	mf:name    "UCASE()" ;
 	mf:feature sparql:ucase ;
@@ -257,6 +293,16 @@
          [ qt:query  <ucase01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <ucase01.srx> ;
+	.
+
+:ucase01-non-bmp rdf:type mf:QueryEvaluationTest ;
+	mf:name    "UCASE() on non-BMP unicode strings" ;
+	mf:feature sparql:ucase ;
+	dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <ucase01.rq> ;
+           qt:data   <data5.ttl> ] ;
+    mf:result  <ucase01-non-bmp.srx> ;
 	.
 
 :lcase01 rdf:type mf:QueryEvaluationTest ;
@@ -270,6 +316,16 @@
     mf:result  <lcase01.srx> ;
 	.
 
+:lcase01-non-bmp rdf:type mf:QueryEvaluationTest ;
+	mf:name    "LCASE() on non-BMP unicode strings" ;
+	mf:feature sparql:lcase ;
+	dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <lcase01.rq> ;
+           qt:data   <data5.ttl> ] ;
+    mf:result  <lcase01-non-bmp.srx> ;
+	.
+
 :encode01 rdf:type mf:QueryEvaluationTest ;
 	mf:name    "ENCODE_FOR_URI()" ;
 	mf:feature sparql:encode_for_uri ;
@@ -279,6 +335,16 @@
          [ qt:query  <encode01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <encode01.srx> ;
+	.
+
+:encode01-non-bmp rdf:type mf:QueryEvaluationTest ;
+	mf:name    "ENCODE_FOR_URI() on non-BMP unicode strings" ;
+	mf:feature sparql:encode_for_uri ;
+	dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <encode01.rq> ;
+           qt:data   <data5.ttl> ] ;
+    mf:result  <encode01-non-bmp.srx> ;
 	.
 
 :contains01 rdf:type mf:QueryEvaluationTest ;

--- a/sparql11/data-sparql11/functions/manifest.ttl
+++ b/sparql11/data-sparql11/functions/manifest.ttl
@@ -1,6 +1,6 @@
 @prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix : <http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#> .
-@prefix rdfs:	<http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
 @prefix dawgt:   <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
@@ -10,803 +10,803 @@
     rdfs:label "Built-in Functions" ;
     mf:entries
     ( 
-	:strdt01
-	:strdt02
-	:strdt03-rdf11
-	:strlang01
-	:strlang02
-	:strlang03-rdf11
-	:isnumeric01
-	:abs01
-	:ceil01
-	:floor01
-	:round01
-	:concat01
-	:concat02
-	:substring01
-	:substring01-non-bmp
-	:substring02
-	:substring02-non-bmp
-	:length01
-	:length01-non-bmp
-	:ucase01
-	:ucase01-non-bmp
-	:lcase01
-	:lcase01-non-bmp
-	:encode01
-	:encode01-non-bmp
-	:contains01
-	:starts01
-	:ends01
-	:plus-1-corrected
-	:plus-2-corrected
-	:md5-01
-	:md5-02
-	:sha1-01
-	:sha1-02
-	:sha256-01
-	:sha256-02
-	:sha512-01
-	:sha512-02
-	:minutes
-	:seconds
-	:hours
-	:month
-	:year
-	:day
-	:timezone
-	:tz
-	:bnode01
-	:bnode02
-	:in01
-	:in02
-	:notin01
-	:notin02
-	:now01
-	:rand01
-	:iri01
-	:if01
-	:if02
-	:coalesce01
-	:strbefore01a
-	:strbefore02
-	:strafter01a
-	:strafter02
-	:replace01
-	:replace02
-	:replace03
-	:uuid01
-	:struuid01
+    :strdt01
+    :strdt02
+    :strdt03-rdf11
+    :strlang01
+    :strlang02
+    :strlang03-rdf11
+    :isnumeric01
+    :abs01
+    :ceil01
+    :floor01
+    :round01
+    :concat01
+    :concat02
+    :substring01
+    :substring01-non-bmp
+    :substring02
+    :substring02-non-bmp
+    :length01
+    :length01-non-bmp
+    :ucase01
+    :ucase01-non-bmp
+    :lcase01
+    :lcase01-non-bmp
+    :encode01
+    :encode01-non-bmp
+    :contains01
+    :starts01
+    :ends01
+    :plus-1-corrected
+    :plus-2-corrected
+    :md5-01
+    :md5-02
+    :sha1-01
+    :sha1-02
+    :sha256-01
+    :sha256-02
+    :sha512-01
+    :sha512-02
+    :minutes
+    :seconds
+    :hours
+    :month
+    :year
+    :day
+    :timezone
+    :tz
+    :bnode01
+    :bnode02
+    :in01
+    :in02
+    :notin01
+    :notin02
+    :now01
+    :rand01
+    :iri01
+    :if01
+    :if02
+    :coalesce01
+    :strbefore01a
+    :strbefore02
+    :strafter01a
+    :strafter02
+    :replace01
+    :replace02
+    :replace03
+    :uuid01
+    :struuid01
  ) .
 
 
 :strdt01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRDT()" ;
-	mf:feature sparql:strdt ;
+    mf:name    "STRDT()" ;
+    mf:feature sparql:strdt ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <strdt01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <strdt01.srx> ;
-	.
+    .
 
 :strdt02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRDT(STR())" ;
-	mf:feature sparql:strdt ;
+    mf:name    "STRDT(STR())" ;
+    mf:feature sparql:strdt ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <strdt02.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <strdt02.srx> ;
-	.
+    .
 
 :strdt03-rdf11 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRDT() TypeErrors (updated for RDF 1.1)" ;
-	mf:feature sparql:strdt ;
+    mf:name    "STRDT() TypeErrors (updated for RDF 1.1)" ;
+    mf:feature sparql:strdt ;
     dawgt:approval dawgt:Proposed ;
     mf:action
          [ qt:query  <strdt03.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <strdt03-rdf11.srx> ;
-	.
+    .
 
 :strlang01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRLANG()" ;
-	mf:feature sparql:strlang ;
+    mf:name    "STRLANG()" ;
+    mf:feature sparql:strlang ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <strlang01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <strlang01.srx> ;
-	.
+    .
 
 :strlang02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRLANG(STR())" ;
-	mf:feature sparql:strlang ;
+    mf:name    "STRLANG(STR())" ;
+    mf:feature sparql:strlang ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <strlang02.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <strlang02.srx> ;
-	.
+    .
 
 :strlang03-rdf11 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRLANG() TypeErrors (updated for RDF 1.1)" ;
-	mf:feature sparql:strlang ;
+    mf:name    "STRLANG() TypeErrors (updated for RDF 1.1)" ;
+    mf:feature sparql:strlang ;
     dawgt:approval dawgt:Proposed ;
     mf:action
          [ qt:query  <strlang03.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <strlang03-rdf11.srx> ;
-	.
+    .
 
 :isnumeric01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "isNumeric()" ;
-	mf:feature sparql:isnumeric ;
+    mf:name    "isNumeric()" ;
+    mf:feature sparql:isnumeric ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <isnumeric01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <isnumeric01.srx> ;
-	.
+    .
 
 :abs01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "ABS()" ;
-	mf:feature sparql:abs ;
+    mf:name    "ABS()" ;
+    mf:feature sparql:abs ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <abs01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <abs01.srx> ;
-	.
+    .
 
 :ceil01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "CEIL()" ;
-	mf:feature sparql:ceil ;
+    mf:name    "CEIL()" ;
+    mf:feature sparql:ceil ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <ceil01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <ceil01.srx> ;
-	.
+    .
 
 :floor01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "FLOOR()" ;
-	mf:feature sparql:floor ;
+    mf:name    "FLOOR()" ;
+    mf:feature sparql:floor ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <floor01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <floor01.srx> ;
-	.
+    .
 
 :round01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "ROUND()" ;
-	mf:feature sparql:round ;
+    mf:name    "ROUND()" ;
+    mf:feature sparql:round ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <round01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <round01.srx> ;
-	.
+    .
 
 :concat01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "CONCAT()" ;
-	mf:feature sparql:concat ;
+    mf:name    "CONCAT()" ;
+    mf:feature sparql:concat ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <concat01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <concat01.srx> ;
-	.
+    .
 
 :concat02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "CONCAT() 2" ;
-	mf:feature sparql:concat ;
+    mf:name    "CONCAT() 2" ;
+    mf:feature sparql:concat ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <concat02.rq> ;
            qt:data   <data2.ttl> ] ;
     mf:result  <concat02.srx> ;
-	.
+    .
 
 :substring01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SUBSTR() (3-argument)" ;
-	mf:feature sparql:substr ;
+    mf:name    "SUBSTR() (3-argument)" ;
+    mf:feature sparql:substr ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <substring01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <substring01.srx> ;
-	.
+    .
 
 :substring01-non-bmp rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SUBSTR() (3-argument) on non-BMP unicode strings" ;
-	mf:feature sparql:substr ;
-	dawgt:approval dawgt:Proposed ;
+    mf:name    "SUBSTR() (3-argument) on non-BMP unicode strings" ;
+    mf:feature sparql:substr ;
+    dawgt:approval dawgt:Proposed ;
     mf:action
          [ qt:query  <substring01.rq> ;
            qt:data   <data5.ttl> ] ;
     mf:result  <substring01-non-bmp.srx> ;
-	.
+    .
 
 :substring02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SUBSTR() (2-argument)" ;
-	mf:feature sparql:substr ;
+    mf:name    "SUBSTR() (2-argument)" ;
+    mf:feature sparql:substr ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <substring02.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <substring02.srx> ;
-	.
+    .
 
 :substring02-non-bmp rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SUBSTR() (2-argument) on non-BMP unicode strings" ;
-	mf:feature sparql:substr ;
-	dawgt:approval dawgt:Proposed ;
+    mf:name    "SUBSTR() (2-argument) on non-BMP unicode strings" ;
+    mf:feature sparql:substr ;
+    dawgt:approval dawgt:Proposed ;
     mf:action
          [ qt:query  <substring02.rq> ;
            qt:data   <data5.ttl> ] ;
     mf:result  <substring02-non-bmp.srx> ;
-	.
+    .
 
 :length01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRLEN()" ;
-	mf:feature sparql:strlen ;
+    mf:name    "STRLEN()" ;
+    mf:feature sparql:strlen ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <length01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <length01.srx> ;
-	.
+    .
 
 :length01-non-bmp rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRLEN() on non-BMP unicode strings" ;
-	mf:feature sparql:strlen ;
-	dawgt:approval dawgt:Proposed ;
+    mf:name    "STRLEN() on non-BMP unicode strings" ;
+    mf:feature sparql:strlen ;
+    dawgt:approval dawgt:Proposed ;
     mf:action
          [ qt:query  <length01.rq> ;
            qt:data   <data5.ttl> ] ;
     mf:result  <length01-non-bmp.srx> ;
-	.
+    .
 
 :ucase01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "UCASE()" ;
-	mf:feature sparql:ucase ;
+    mf:name    "UCASE()" ;
+    mf:feature sparql:ucase ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <ucase01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <ucase01.srx> ;
-	.
+    .
 
 :ucase01-non-bmp rdf:type mf:QueryEvaluationTest ;
-	mf:name    "UCASE() on non-BMP unicode strings" ;
-	mf:feature sparql:ucase ;
-	dawgt:approval dawgt:Proposed ;
+    mf:name    "UCASE() on non-BMP unicode strings" ;
+    mf:feature sparql:ucase ;
+    dawgt:approval dawgt:Proposed ;
     mf:action
          [ qt:query  <ucase01.rq> ;
            qt:data   <data5.ttl> ] ;
     mf:result  <ucase01-non-bmp.srx> ;
-	.
+    .
 
 :lcase01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "LCASE()" ;
-	mf:feature sparql:lcase ;
+    mf:name    "LCASE()" ;
+    mf:feature sparql:lcase ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <lcase01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <lcase01.srx> ;
-	.
+    .
 
 :lcase01-non-bmp rdf:type mf:QueryEvaluationTest ;
-	mf:name    "LCASE() on non-BMP unicode strings" ;
-	mf:feature sparql:lcase ;
-	dawgt:approval dawgt:Proposed ;
+    mf:name    "LCASE() on non-BMP unicode strings" ;
+    mf:feature sparql:lcase ;
+    dawgt:approval dawgt:Proposed ;
     mf:action
          [ qt:query  <lcase01.rq> ;
            qt:data   <data5.ttl> ] ;
     mf:result  <lcase01-non-bmp.srx> ;
-	.
+    .
 
 :encode01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "ENCODE_FOR_URI()" ;
-	mf:feature sparql:encode_for_uri ;
+    mf:name    "ENCODE_FOR_URI()" ;
+    mf:feature sparql:encode_for_uri ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <encode01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <encode01.srx> ;
-	.
+    .
 
 :encode01-non-bmp rdf:type mf:QueryEvaluationTest ;
-	mf:name    "ENCODE_FOR_URI() on non-BMP unicode strings" ;
-	mf:feature sparql:encode_for_uri ;
-	dawgt:approval dawgt:Proposed ;
+    mf:name    "ENCODE_FOR_URI() on non-BMP unicode strings" ;
+    mf:feature sparql:encode_for_uri ;
+    dawgt:approval dawgt:Proposed ;
     mf:action
          [ qt:query  <encode01.rq> ;
            qt:data   <data5.ttl> ] ;
     mf:result  <encode01-non-bmp.srx> ;
-	.
+    .
 
 :contains01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "CONTAINS()" ;
-	mf:feature sparql:contains ;
+    mf:name    "CONTAINS()" ;
+    mf:feature sparql:contains ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <contains01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <contains01.srx> ;
-	.
+    .
 
 :starts01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRSTARTS()" ;
-	mf:feature sparql:strstarts ;
+    mf:name    "STRSTARTS()" ;
+    mf:feature sparql:strstarts ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <starts01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <starts01.srx> ;
-	.
+    .
 
 :ends01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRENDS()" ;
-	mf:feature sparql:strends ;
+    mf:name    "STRENDS()" ;
+    mf:feature sparql:strends ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <ends01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <ends01.srx> ;
-	.
+    .
 
 :plus-1-corrected a mf:QueryEvaluationTest ;
     mf:name    "plus-1-corrected" ;
-    rdfs:comment	"plus operator on ?x + ?y on string and numeric values" ;
+    rdfs:comment    "plus operator on ?x + ?y on string and numeric values" ;
     dawgt:approval dawgt:Proposed ;
     mf:action
        [ qt:query  <plus-1-corrected.rq> ;
-	 qt:data   <data-builtin-3.ttl> ] ;
+    qt:data   <data-builtin-3.ttl> ] ;
     mf:result  <plus-1.srx> ;
     .
 
 :plus-2-corrected a mf:QueryEvaluationTest ;
     mf:name    "plus-2-corrected" ;
-    rdfs:comment	"plus operator in combination with str(), i.e.  str(?x) + str(?y), on string and numeric values" ;
+    rdfs:comment    "plus operator in combination with str(), i.e.  str(?x) + str(?y), on string and numeric values" ;
     dawgt:approval dawgt:Proposed ;
     mf:action
        [ qt:query  <plus-2-corrected.rq> ;
-	 qt:data   <data-builtin-3.ttl> ] ;
+    qt:data   <data-builtin-3.ttl> ] ;
     mf:result  <plus-2.srx> ;
     .
 
 :md5-01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "MD5()" ;
-	mf:feature sparql:md5 ;
+    mf:name    "MD5()" ;
+    mf:feature sparql:md5 ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <md5-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <md5-01.srx> ;
-	.
+    .
 
 :md5-02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "MD5() over Unicode data" ;
-	mf:feature sparql:md5 ;
+    mf:name    "MD5() over Unicode data" ;
+    mf:feature sparql:md5 ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <md5-02.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <md5-02.srx> ;
-	.
+    .
 
 :sha1-01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SHA1()" ;
-	mf:feature sparql:sha1 ;
+    mf:name    "SHA1()" ;
+    mf:feature sparql:sha1 ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <sha1-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <sha1-01.srx> ;
-	.
+    .
 
 :sha1-02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SHA1() on Unicode data" ;
-	mf:feature sparql:sha1 ;
+    mf:name    "SHA1() on Unicode data" ;
+    mf:feature sparql:sha1 ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <sha1-02.rq> ;
            qt:data   <hash-unicode.ttl> ] ;
     mf:result  <sha1-02.srx> ;
-	.
+    .
 
 :sha256-01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SHA256()" ;
-	mf:feature sparql:sha256 ;
+    mf:name    "SHA256()" ;
+    mf:feature sparql:sha256 ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <sha256-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <sha256-01.srx> ;
-	.
+    .
 
 :sha256-02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SHA256() on Unicode data" ;
-	mf:feature sparql:sha256 ;
+    mf:name    "SHA256() on Unicode data" ;
+    mf:feature sparql:sha256 ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <sha256-02.rq> ;
            qt:data   <hash-unicode.ttl> ] ;
     mf:result  <sha256-02.srx> ;
-	.
+    .
 
 :sha512-01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SHA512()" ;
-	mf:feature sparql:sha512 ;
+    mf:name    "SHA512()" ;
+    mf:feature sparql:sha512 ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <sha512-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <sha512-01.srx> ;
-	.
+    .
 
 :sha512-02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SHA512() on Unicode data" ;
-	mf:feature sparql:sha512 ;
+    mf:name    "SHA512() on Unicode data" ;
+    mf:feature sparql:sha512 ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <sha512-02.rq> ;
            qt:data   <hash-unicode.ttl> ] ;
     mf:result  <sha512-02.srx> ;
-	.
+    .
 
 :hours rdf:type mf:QueryEvaluationTest ;
-	mf:name    "HOURS()" ;
-	mf:feature sparql:hours ;
+    mf:name    "HOURS()" ;
+    mf:feature sparql:hours ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <hours-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <hours-01.srx> ;
-	.
+    .
 
 :minutes rdf:type mf:QueryEvaluationTest ;
-	mf:name    "MINUTES()" ;
-	mf:feature sparql:minutes ;
+    mf:name    "MINUTES()" ;
+    mf:feature sparql:minutes ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <minutes-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <minutes-01.srx> ;
-	.
+    .
 
 :seconds rdf:type mf:QueryEvaluationTest ;
-	mf:name    "SECONDS()" ;
-	mf:feature sparql:seconds ;
+    mf:name    "SECONDS()" ;
+    mf:feature sparql:seconds ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <seconds-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <seconds-01.srx> ;
-	.
+    .
 
 :year rdf:type mf:QueryEvaluationTest ;
-	mf:name    "YEAR()" ;
-	mf:feature sparql:year ;
+    mf:name    "YEAR()" ;
+    mf:feature sparql:year ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <year-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <year-01.srx> ;
-	.
+    .
 
 :month rdf:type mf:QueryEvaluationTest ;
-	mf:name    "MONTH()" ;
-	mf:feature sparql:month ;
+    mf:name    "MONTH()" ;
+    mf:feature sparql:month ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <month-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <month-01.srx> ;
-	.
+    .
 
 :day rdf:type mf:QueryEvaluationTest ;
-	mf:name    "DAY()" ;
-	mf:feature sparql:day ;
+    mf:name    "DAY()" ;
+    mf:feature sparql:day ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <day-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <day-01.srx> ;
-	.
+    .
 
 :timezone rdf:type mf:QueryEvaluationTest ;
-	mf:name    "TIMEZONE()" ;
-	mf:feature sparql:timezone ;
+    mf:name    "TIMEZONE()" ;
+    mf:feature sparql:timezone ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <timezone-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <timezone-01.srx> ;
-	.
+    .
 
 :tz rdf:type mf:QueryEvaluationTest ;
-	mf:name    "TZ()" ;
-	mf:feature sparql:tz ;
+    mf:name    "TZ()" ;
+    mf:feature sparql:tz ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <tz-01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <tz-01.srx> ;
-	.
+    .
 
 :bnode01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "BNODE(str)" ;
-	mf:feature sparql:bnode ;
+    mf:name    "BNODE(str)" ;
+    mf:feature sparql:bnode ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <bnode01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <bnode01.srx> ;
-	.
+    .
 
 :in01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "IN 1" ;
-	mf:feature sparql:in ;
+    mf:name    "IN 1" ;
+    mf:feature sparql:in ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <in01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <in01.srx> ;
-	.
+    .
 
 :in02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "IN 2" ;
-	mf:feature sparql:in ;
+    mf:name    "IN 2" ;
+    mf:feature sparql:in ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <in02.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <in02.srx> ;
-	.
+    .
 
 :notin01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "NOT IN 1" ;
-	mf:feature sparql:in ;
-	mf:feature sparql:not ;
+    mf:name    "NOT IN 1" ;
+    mf:feature sparql:in ;
+    mf:feature sparql:not ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <notin01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <notin01.srx> ;
-	.
+    .
 
 :notin02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "NOT IN 2" ;
-	mf:feature sparql:in ;
-	mf:feature sparql:not ;
+    mf:name    "NOT IN 2" ;
+    mf:feature sparql:in ;
+    mf:feature sparql:not ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <notin02.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <notin02.srx> ;
-	.
+    .
 
 :now01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "NOW()" ;
-	mf:feature sparql:now ;
+    mf:name    "NOW()" ;
+    mf:feature sparql:now ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <now01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <now01.srx> ;
-	.
+    .
 
 :rand01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "RAND()" ;
-	mf:feature sparql:rand ;
+    mf:name    "RAND()" ;
+    mf:feature sparql:rand ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <rand01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <rand01.srx> ;
-	.
+    .
 
 :bnode02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "BNODE()" ;
-	mf:feature sparql:bnode ;
+    mf:name    "BNODE()" ;
+    mf:feature sparql:bnode ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <bnode02.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <bnode02.srx> ;
-	.
+    .
 
 :iri01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "IRI()/URI()" ;
-	mf:feature sparql:iri ;
-	mf:feature sparql:uri ;
+    mf:name    "IRI()/URI()" ;
+    mf:feature sparql:iri ;
+    mf:feature sparql:uri ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <iri01.rq> ;
            qt:data   <data.ttl> ] ;
     mf:result  <iri01.srx> ;
-	.
+    .
 
 :if01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "IF()" ;
-	mf:feature sparql:if ;
+    mf:name    "IF()" ;
+    mf:feature sparql:if ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <if01.rq> ;
            qt:data   <data2.ttl> ] ;
     mf:result  <if01.srx> ;
-	.
+    .
 
 :if02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "IF() error propogation" ;
-	mf:feature sparql:if ;
+    mf:name    "IF() error propogation" ;
+    mf:feature sparql:if ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <if02.rq> ;
            qt:data   <data2.ttl> ] ;
     mf:result  <if02.srx> ;
-	.
+    .
 
 :coalesce01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "COALESCE()" ;
-	mf:feature sparql:coalesce ;
+    mf:name    "COALESCE()" ;
+    mf:feature sparql:coalesce ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <coalesce01.rq> ;
            qt:data   <data-coalesce.ttl> ] ;
     mf:result  <coalesce01.srx> ;
-	.
+    .
 
 :strbefore01a rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRBEFORE()" ;
-	mf:feature sparql:strbefore ;
+    mf:name    "STRBEFORE()" ;
+    mf:feature sparql:strbefore ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
     mf:action
          [ qt:query  <strbefore01.rq> ;
            qt:data   <data2.ttl> ] ;
     mf:result  <strbefore01a.srx> ;
-	.
+    .
 
 :strbefore02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRBEFORE() datatyping" ;
-	mf:feature sparql:strbefore ;
+    mf:name    "STRBEFORE() datatyping" ;
+    mf:feature sparql:strbefore ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
     mf:action
          [ qt:query  <strbefore02.rq> ;
            qt:data   <data4.ttl> ] ;
     mf:result  <strbefore02.srx> ;
-	.
+    .
 
 :strafter01a rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRAFTER()" ;
-	mf:feature sparql:strafter ;
+    mf:name    "STRAFTER()" ;
+    mf:feature sparql:strafter ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
     mf:action
          [ qt:query  <strafter01.rq> ;
            qt:data   <data2.ttl> ] ;
     mf:result  <strafter01a.srx> ;
-	.
+    .
 
 :strafter02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRAFTER() datatyping" ;
-	mf:feature sparql:strafter ;
+    mf:name    "STRAFTER() datatyping" ;
+    mf:feature sparql:strafter ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
     mf:action
          [ qt:query  <strafter02.rq> ;
            qt:data   <data4.ttl> ] ;
     mf:result  <strafter02.srx> ;
-	.
+    .
 
 :replace01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "REPLACE()" ;
-	mf:feature sparql:replace ;
+    mf:name    "REPLACE()" ;
+    mf:feature sparql:replace ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <replace01.rq> ;
            qt:data   <data3.ttl> ] ;
     mf:result  <replace01.srx> ;
-	.
+    .
 
 :replace02 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "REPLACE() with overlapping pattern" ;
-	mf:feature sparql:replace ;
+    mf:name    "REPLACE() with overlapping pattern" ;
+    mf:feature sparql:replace ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <replace02.rq> ;
            qt:data   <data3.ttl> ] ;
     mf:result  <replace02.srx> ;
-	.
+    .
 
 :replace03 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "REPLACE() with captured substring" ;
-	mf:feature sparql:replace ;
+    mf:name    "REPLACE() with captured substring" ;
+    mf:feature sparql:replace ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action
          [ qt:query  <replace03.rq> ;
            qt:data   <data3.ttl> ] ;
     mf:result  <replace03.srx> ;
-	.
+    .
 
 :uuid01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "UUID() pattern match" ;
-	mf:feature sparql:uuid ;
+    mf:name    "UUID() pattern match" ;
+    mf:feature sparql:uuid ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
     mf:action
          [ qt:query  <uuid01.rq> ;
            qt:data   <data-empty.nt> ] ;
     mf:result  <uuid01.srx> ;
-	.
+    .
 
 :struuid01 rdf:type mf:QueryEvaluationTest ;
-	mf:name    "STRUUID() pattern match" ;
-	mf:feature sparql:struuid ;
+    mf:name    "STRUUID() pattern match" ;
+    mf:feature sparql:struuid ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
     mf:action
          [ qt:query  <struuid01.rq> ;
            qt:data   <data-empty.nt> ] ;
     mf:result  <struuid01.srx> ;
-	.
+    .
 

--- a/sparql11/data-sparql11/functions/substring01-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/substring01-non-bmp.srx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+<head>
+	<variable name="s"/>
+	<variable name="str"/>
+	<variable name="substr"/>
+</head>
+<results>
+		<result>
+			<binding name="s"><uri>http://example.org/s8</uri></binding>
+			<binding name="str"><literal>👪</literal></binding>
+			<binding name="substr"><literal>👪</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s9</uri></binding>
+			<binding name="str"><literal>👨‍👩‍👧‍👦</literal></binding>
+			<binding name="substr"><literal>👨</literal></binding>
+		</result>
+</results>
+</sparql>

--- a/sparql11/data-sparql11/functions/substring01-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/substring01-non-bmp.srx
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sparql xmlns="http://www.w3.org/2005/sparql-results#">
 <head>
-	<variable name="s"/>
-	<variable name="str"/>
-	<variable name="substr"/>
+    <variable name="s"/>
+    <variable name="str"/>
+    <variable name="substr"/>
 </head>
 <results>
-		<result>
-			<binding name="s"><uri>http://example.org/s8</uri></binding>
-			<binding name="str"><literal>👪</literal></binding>
-			<binding name="substr"><literal>👪</literal></binding>
-		</result>
-		<result>
-			<binding name="s"><uri>http://example.org/s9</uri></binding>
-			<binding name="str"><literal>👨‍👩‍👧‍👦</literal></binding>
-			<binding name="substr"><literal>👨</literal></binding>
-		</result>
+        <result>
+            <binding name="s"><uri>http://example.org/s8</uri></binding>
+            <binding name="str"><literal>👪</literal></binding>
+            <binding name="substr"><literal>👪</literal></binding>
+        </result>
+        <result>
+            <binding name="s"><uri>http://example.org/s9</uri></binding>
+            <binding name="str"><literal>👨‍👩‍👧‍👦</literal></binding>
+            <binding name="substr"><literal>👨</literal></binding>
+        </result>
 </results>
 </sparql>

--- a/sparql11/data-sparql11/functions/substring02-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/substring02-non-bmp.srx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+<head>
+	<variable name="s"/>
+	<variable name="str"/>
+	<variable name="substr"/>
+</head>
+<results>
+		<result>
+			<binding name="s"><uri>http://example.org/s8</uri></binding>
+			<binding name="str"><literal>👪</literal></binding>
+			<binding name="substr"><literal></literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s9</uri></binding>
+			<binding name="str"><literal>👨‍👩‍👧‍👦</literal></binding>
+			<binding name="substr"><literal>‍👩‍👧‍👦</literal></binding>
+		</result>
+</results>
+</sparql>

--- a/sparql11/data-sparql11/functions/substring02-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/substring02-non-bmp.srx
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sparql xmlns="http://www.w3.org/2005/sparql-results#">
 <head>
-	<variable name="s"/>
-	<variable name="str"/>
-	<variable name="substr"/>
+    <variable name="s"/>
+    <variable name="str"/>
+    <variable name="substr"/>
 </head>
 <results>
-		<result>
-			<binding name="s"><uri>http://example.org/s8</uri></binding>
-			<binding name="str"><literal>👪</literal></binding>
-			<binding name="substr"><literal></literal></binding>
-		</result>
-		<result>
-			<binding name="s"><uri>http://example.org/s9</uri></binding>
-			<binding name="str"><literal>👨‍👩‍👧‍👦</literal></binding>
-			<binding name="substr"><literal>‍👩‍👧‍👦</literal></binding>
-		</result>
+        <result>
+            <binding name="s"><uri>http://example.org/s8</uri></binding>
+            <binding name="str"><literal>👪</literal></binding>
+            <binding name="substr"><literal></literal></binding>
+        </result>
+        <result>
+            <binding name="s"><uri>http://example.org/s9</uri></binding>
+            <binding name="str"><literal>👨‍👩‍👧‍👦</literal></binding>
+            <binding name="substr"><literal>‍👩‍👧‍👦</literal></binding>
+        </result>
 </results>
 </sparql>

--- a/sparql11/data-sparql11/functions/ucase01-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/ucase01-non-bmp.srx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <sparql xmlns="http://www.w3.org/2005/sparql-results#">
 <head>
-	<variable name="s"/>
-	<variable name="ustr"/>
+    <variable name="s"/>
+    <variable name="ustr"/>
 </head>
 <results>
-		<result>
-			<binding name="s"><uri>http://example.org/s8</uri></binding>
-			<binding name="ustr"><literal>👪</literal></binding>
-		</result>
-		<result>
-			<binding name="s"><uri>http://example.org/s9</uri></binding>
-			<binding name="ustr"><literal>👨‍👩‍👧‍👦</literal></binding>
-		</result>
+        <result>
+            <binding name="s"><uri>http://example.org/s8</uri></binding>
+            <binding name="ustr"><literal>👪</literal></binding>
+        </result>
+        <result>
+            <binding name="s"><uri>http://example.org/s9</uri></binding>
+            <binding name="ustr"><literal>👨‍👩‍👧‍👦</literal></binding>
+        </result>
 </results>
 </sparql>

--- a/sparql11/data-sparql11/functions/ucase01-non-bmp.srx
+++ b/sparql11/data-sparql11/functions/ucase01-non-bmp.srx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+<head>
+	<variable name="s"/>
+	<variable name="ustr"/>
+</head>
+<results>
+		<result>
+			<binding name="s"><uri>http://example.org/s8</uri></binding>
+			<binding name="ustr"><literal>👪</literal></binding>
+		</result>
+		<result>
+			<binding name="s"><uri>http://example.org/s9</uri></binding>
+			<binding name="ustr"><literal>👨‍👩‍👧‍👦</literal></binding>
+		</result>
+</results>
+</sparql>


### PR DESCRIPTION
I noticed that the existing test suite doesn't seem to test any of the string functions against data with characters outside of the Unicode Basic Multilingual Plane. I think this could be problematic for systems that use UTF-16 internally and implement string functions over code units instead of codepoints. This PR adds a data file with two test strings containing emoji characters which fall outside of the BMP (one is a single codepoint string while the other is a single grapheme comprised of 7 codepoints) and tests `ENCODE`, `LCASE`, `UCASE`, `LENGTH`, and `SUSBTR`.

Fixes #63.
