### PR TITLE
Add w3c.json

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,5 @@
+ {
+    "group":      [82552]
+,   "contacts":   ["eric"]
+,   "repo-type":  "cg-report"
+}


### PR DESCRIPTION
@plehegar We think this is the correct group id and repo-type, but it's not clear. There's no obvious place to find the group id; @ericprud looked it up and it seems right. Might be nice if you could find it on the CG page.

As this group exists for test curation, we don't ever anticipate a final report; maybe there's a better repo type?