### PR TITLE
Replace the wrong type "typed-literal" by "literal" in JSON results

### DIFF
--- a/sparql11/data-sparql11/json-res/jsonres01.srj
+++ b/sparql11/data-sparql11/json-res/jsonres01.srj
@@ -17,17 +17,17 @@
       {
         "s": { "type": "uri" , "value": "http://example.org/s3" } ,
         "p": { "type": "uri" , "value": "http://example.org/p2" } ,
-        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#string" , "type": "typed-literal" , "value": "bar" }
+        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#string" , "type": "literal" , "value": "bar" }
       } ,
       {
         "s": { "type": "uri" , "value": "http://example.org/s4" } ,
         "p": { "type": "uri" , "value": "http://example.org/p4" } ,
-        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#integer" , "type": "typed-literal" , "value": "4" }
+        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#integer" , "type": "literal" , "value": "4" }
       } ,
       {
         "s": { "type": "uri" , "value": "http://example.org/s5" } ,
         "p": { "type": "uri" , "value": "http://example.org/p5" } ,
-        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#decimal" , "type": "typed-literal" , "value": "5" }
+        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#decimal" , "type": "literal" , "value": "5" }
       } ,
       {
         "s": { "type": "uri" , "value": "http://example.org/s6" } ,

--- a/sparql11/data-sparql11/json-res/jsonres02.srj
+++ b/sparql11/data-sparql11/json-res/jsonres02.srj
@@ -19,17 +19,17 @@
       {
         "s": { "type": "uri" , "value": "http://example.org/s3" } ,
         "p": { "type": "uri" , "value": "http://example.org/p2" } ,
-        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#string" , "type": "typed-literal" , "value": "bar" }
+        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#string" , "type": "literal" , "value": "bar" }
       } ,
       {
         "s": { "type": "uri" , "value": "http://example.org/s4" } ,
         "p": { "type": "uri" , "value": "http://example.org/p4" } ,
-        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#integer" , "type": "typed-literal" , "value": "4" }
+        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#integer" , "type": "literal" , "value": "4" }
       } ,
       {
         "s": { "type": "uri" , "value": "http://example.org/s5" } ,
         "p": { "type": "uri" , "value": "http://example.org/p5" } ,
-        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#decimal" , "type": "typed-literal" , "value": "5" }
+        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#decimal" , "type": "literal" , "value": "5" }
       } ,
       {
         "s": { "type": "uri" , "value": "http://example.org/s6" } ,


### PR DESCRIPTION
Replace the wrong type "typed-literal" by "literal" in JSON results (https://www.w3.org/TR/sparql11-results-json/)