### PR TITLE
xsd:string is the datatype by default and becomes implicit in SPARQL results srx srj

### DIFF
--- a/sparql11/data-sparql11/csv-tsv-res/csvtsv01.tsv
+++ b/sparql11/data-sparql11/csv-tsv-res/csvtsv01.tsv
@@ -1,7 +1,7 @@
 ?s	?p	?o
 <http://example.org/s1>	<http://example.org/p1>	<http://example.org/s2>
 <http://example.org/s2>	<http://example.org/p2>	"foo"
-<http://example.org/s3>	<http://example.org/p3>	"bar"^^<http://www.w3.org/2001/XMLSchema#string>
+<http://example.org/s3>	<http://example.org/p3>	"bar"
 <http://example.org/s4>	<http://example.org/p4>	4
 <http://example.org/s5>	<http://example.org/p5>	5.5
 <http://example.org/s6>	<http://example.org/p6>	_:b0

--- a/sparql11/data-sparql11/csv-tsv-res/csvtsv02.tsv
+++ b/sparql11/data-sparql11/csv-tsv-res/csvtsv02.tsv
@@ -1,7 +1,7 @@
 ?s	?p	?o	?p2	?o2
 <http://example.org/s1>	<http://example.org/p1>	<http://example.org/s2>	<http://example.org/p2>	"foo"
 <http://example.org/s2>	<http://example.org/p2>	"foo"		
-<http://example.org/s3>	<http://example.org/p3>	"bar"^^<http://www.w3.org/2001/XMLSchema#string>		
+<http://example.org/s3>	<http://example.org/p3>	"bar"
 <http://example.org/s4>	<http://example.org/p4>	4		
 <http://example.org/s5>	<http://example.org/p5>	5.5		
 <http://example.org/s6>	<http://example.org/p6>	_:b0		

--- a/sparql11/data-sparql11/csv-tsv-res/csvtsv03.tsv
+++ b/sparql11/data-sparql11/csv-tsv-res/csvtsv03.tsv
@@ -1,8 +1,8 @@
 ?s	?p	?o
-<http://example.org/s1>	<http://example.org/p1>	"1"^^<http://www.w3.org/2001/XMLSchema#string>
+<http://example.org/s1>	<http://example.org/p1>	"1"
 <http://example.org/s2>	<http://example.org/p2>	2.2
 <http://example.org/s3>	<http://example.org/p3>	"-3"^^<http://www.w3.org/2001/XMLSchema#negativeInteger>
-<http://example.org/s4>	<http://example.org/p4>	"4,4"^^<http://www.w3.org/2001/XMLSchema#string>
+<http://example.org/s4>	<http://example.org/p4>	"4,4"
 <http://example.org/s5>	<http://example.org/p5>	"5,5"^^<http://example.org/myCustomDatatype>
 <http://example.org/s6>	<http://example.org/p6>	1.0e6
 <http://example.org/s7>	<http://example.org/p7>	"a7"^^<http://www.w3.org/2001/XMLSchema#hexBinary>

--- a/sparql11/data-sparql11/functions/concat01.srx
+++ b/sparql11/data-sparql11/functions/concat01.srx
@@ -5,7 +5,7 @@
 </head>
 <results>
 		<result>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abcDEF</literal></binding>
+			<binding name="str"><literal>abcDEF</literal></binding>
 		</result>
 </results>
 </sparql>

--- a/sparql11/data-sparql11/functions/concat02.srx
+++ b/sparql11/data-sparql11/functions/concat02.srx
@@ -4,10 +4,10 @@
 	<variable name="str"/>
 </head>
 <results>
-	<result><binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abcabc</literal></binding></result>
-	<result><binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abcdef</literal></binding></result>
-	<result><binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">defabc</literal></binding></result>
-	<result><binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">defdef</literal></binding></result>
+	<result><binding name="str"><literal>abcabc</literal></binding></result>
+	<result><binding name="str"><literal>abcdef</literal></binding></result>
+	<result><binding name="str"><literal>defabc</literal></binding></result>
+	<result><binding name="str"><literal>defdef</literal></binding></result>
 	<result><binding name="str"><literal xml:lang="en">englishenglish</literal></binding></result>
 	<result><binding name="str"><literal xml:lang="fr">françaisfrançais</literal></binding></result>
 	<result><binding name="str"><literal xml:lang="ja">日本語日本語</literal></binding></result>

--- a/sparql11/data-sparql11/functions/contains01.srx
+++ b/sparql11/data-sparql11/functions/contains01.srx
@@ -11,7 +11,7 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
+			<binding name="str"><literal>abc</literal></binding>
 		</result>
 </results>
 </sparql>

--- a/sparql11/data-sparql11/functions/encode01.srx
+++ b/sparql11/data-sparql11/functions/encode01.srx
@@ -33,12 +33,12 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
+			<binding name="str"><literal>abc</literal></binding>
 			<binding name="encoded"><literal>abc</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">DEF</literal></binding>
+			<binding name="str"><literal>DEF</literal></binding>
 			<binding name="encoded"><literal>DEF</literal></binding>
 		</result>
 </results>

--- a/sparql11/data-sparql11/functions/ends01.srx
+++ b/sparql11/data-sparql11/functions/ends01.srx
@@ -7,7 +7,7 @@
 <results>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
+			<binding name="str"><literal>abc</literal></binding>
 		</result>
 </results>
 </sparql>

--- a/sparql11/data-sparql11/functions/if01.srx
+++ b/sparql11/data-sparql11/functions/if01.srx
@@ -15,7 +15,7 @@
     </result>
     <result>
       <binding name="o">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string">def</literal>
+        <literal>def</literal>
       </binding>
       <binding name="integer">
         <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">false</literal>
@@ -47,7 +47,7 @@
     </result>
     <result>
       <binding name="o">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal>
+        <literal>abc</literal>
       </binding>
       <binding name="integer">
         <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">false</literal>

--- a/sparql11/data-sparql11/functions/lcase01.srx
+++ b/sparql11/data-sparql11/functions/lcase01.srx
@@ -15,7 +15,7 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>
-			<binding name="lstr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">def</literal></binding>
+			<binding name="lstr"><literal>def</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s3</uri></binding>
@@ -27,7 +27,7 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="lstr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
+			<binding name="lstr"><literal>abc</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s1</uri></binding>

--- a/sparql11/data-sparql11/functions/length01.srx
+++ b/sparql11/data-sparql11/functions/length01.srx
@@ -14,7 +14,7 @@
 			<binding name="len"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">3</literal></binding>
 		</result>
 		<result>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">DEF</literal></binding>
+			<binding name="str"><literal>DEF</literal></binding>
 			<binding name="len"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">3</literal></binding>
 		</result>
 		<result>
@@ -26,7 +26,7 @@
 			<binding name="len"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">4</literal></binding>
 		</result>
 		<result>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
+			<binding name="str"><literal>abc</literal></binding>
 			<binding name="len"><literal datatype="http://www.w3.org/2001/XMLSchema#integer">3</literal></binding>
 		</result>
 		<result>

--- a/sparql11/data-sparql11/functions/plus-1.srx
+++ b/sparql11/data-sparql11/functions/plus-1.srx
@@ -43,7 +43,7 @@
     </result>
     <result>
       <binding name="x">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string">1</literal>
+        <literal>1</literal>
       </binding>
       <binding name="y">
         <literal>2</literal>
@@ -51,7 +51,7 @@
     </result>
     <result>
       <binding name="x">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string">1</literal>
+        <literal>1</literal>
       </binding>
       <binding name="y">
         <literal datatype="http://www.w3.org/2001/XMLSchema#integer">2</literal>

--- a/sparql11/data-sparql11/functions/plus-2.srx
+++ b/sparql11/data-sparql11/functions/plus-2.srx
@@ -40,7 +40,7 @@
     </result>
     <result>
       <binding name="x">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string">1</literal>
+        <literal>1</literal>
       </binding>
       <binding name="y">
         <literal>2</literal>
@@ -48,7 +48,7 @@
     </result>
     <result>
       <binding name="x">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string">1</literal>
+        <literal>1</literal>
       </binding>
       <binding name="y">
         <literal datatype="http://www.w3.org/2001/XMLSchema#integer">2</literal>

--- a/sparql11/data-sparql11/functions/replace01.srx
+++ b/sparql11/data-sparql11/functions/replace01.srx
@@ -23,11 +23,11 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s5</uri></binding>
-			<binding name="new"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
+			<binding name="new"><literal>abc</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="new"><literal datatype="http://www.w3.org/2001/XMLSchema#string">def</literal></binding>
+			<binding name="new"><literal>def</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>

--- a/sparql11/data-sparql11/functions/strafter01.srx
+++ b/sparql11/data-sparql11/functions/strafter01.srx
@@ -23,11 +23,11 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s5</uri></binding>
-			<binding name="suffix"><literal datatype="http://www.w3.org/2001/XMLSchema#string"></literal></binding>
+			<binding name="suffix"><literal></literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="suffix"><literal datatype="http://www.w3.org/2001/XMLSchema#string">f</literal></binding>
+			<binding name="suffix"><literal>f</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>

--- a/sparql11/data-sparql11/functions/strafter01a.srx
+++ b/sparql11/data-sparql11/functions/strafter01a.srx
@@ -27,7 +27,7 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="suffix"><literal datatype="http://www.w3.org/2001/XMLSchema#string">f</literal></binding>
+			<binding name="suffix"><literal>f</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>

--- a/sparql11/data-sparql11/functions/strafter02.srx
+++ b/sparql11/data-sparql11/functions/strafter02.srx
@@ -33,11 +33,11 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s3</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
-			<binding name="ab"><literal datatype="http://www.w3.org/2001/XMLSchema#string">c</literal></binding>
-			<binding name="aab"><literal datatype="http://www.w3.org/2001/XMLSchema#string">c</literal></binding>
-			<binding name="a"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
-			<binding name="abx"><literal datatype="http://www.w3.org/2001/XMLSchema#string">c</literal></binding>
+			<binding name="str"><literal>abc</literal></binding>
+			<binding name="ab"><literal>c</literal></binding>
+			<binding name="aab"><literal>c</literal></binding>
+			<binding name="a"><literal>abc</literal></binding>
+			<binding name="abx"><literal>c</literal></binding>
 			<binding name="axyzx"><literal></literal></binding>
 		</result>
 </results>

--- a/sparql11/data-sparql11/functions/strbefore01.srx
+++ b/sparql11/data-sparql11/functions/strbefore01.srx
@@ -23,11 +23,11 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s5</uri></binding>
-			<binding name="prefix"><literal datatype="http://www.w3.org/2001/XMLSchema#string"></literal></binding>
+			<binding name="prefix"><literal></literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="prefix"><literal datatype="http://www.w3.org/2001/XMLSchema#string"></literal></binding>
+			<binding name="prefix"><literal></literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>

--- a/sparql11/data-sparql11/functions/strbefore02.srx
+++ b/sparql11/data-sparql11/functions/strbefore02.srx
@@ -33,11 +33,11 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s3</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
-			<binding name="bb"><literal datatype="http://www.w3.org/2001/XMLSchema#string">a</literal></binding>
-			<binding name="bbc"><literal datatype="http://www.w3.org/2001/XMLSchema#string">a</literal></binding>
-			<binding name="b"><literal datatype="http://www.w3.org/2001/XMLSchema#string"></literal></binding>
-			<binding name="bbx"><literal datatype="http://www.w3.org/2001/XMLSchema#string">a</literal></binding>
+			<binding name="str"><literal>abc</literal></binding>
+			<binding name="bb"><literal>a</literal></binding>
+			<binding name="bbc"><literal>a</literal></binding>
+			<binding name="b"><literal></literal></binding>
+			<binding name="bbx"><literal>a</literal></binding>
 			<binding name="bxyzx"><literal></literal></binding>
 		</result>
 </results>

--- a/sparql11/data-sparql11/functions/strdt02.srx
+++ b/sparql11/data-sparql11/functions/strdt02.srx
@@ -7,7 +7,7 @@
 <results>
 		<result>
 			<binding name="s"><uri>http://example.org/s2</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">bar</literal></binding>
+			<binding name="str1"><literal>bar</literal></binding>
 		</result>
 </results>
 </sparql>

--- a/sparql11/data-sparql11/functions/strdt03-rdf11.srx
+++ b/sparql11/data-sparql11/functions/strdt03-rdf11.srx
@@ -13,24 +13,24 @@
 		
 		<result>
 			<binding name="s"><uri>http://example.org/s1</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">foo</literal></binding>
+			<binding name="str1"><literal>foo</literal></binding>
 		</result>
 		<result><binding name="s"><uri>http://example.org/s2</uri></binding></result>
 		<result>
 			<binding name="s"><uri>http://example.org/s3</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">BAZ</literal></binding>
+			<binding name="str1"><literal>BAZ</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s4</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">食べ物</literal></binding>
+			<binding name="str1"><literal>食べ物</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s5</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">100%</literal></binding>
+			<binding name="str1"><literal>100%</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
+			<binding name="str1"><literal>abc</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>

--- a/sparql11/data-sparql11/functions/strdt03.srx
+++ b/sparql11/data-sparql11/functions/strdt03.srx
@@ -13,20 +13,20 @@
 		
 		<result>
 			<binding name="s"><uri>http://example.org/s1</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">foo</literal></binding>
+			<binding name="str1"><literal>foo</literal></binding>
 		</result>
 		<result><binding name="s"><uri>http://example.org/s2</uri></binding></result>
 		<result>
 			<binding name="s"><uri>http://example.org/s3</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">BAZ</literal></binding>
+			<binding name="str1"><literal>BAZ</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s4</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">食べ物</literal></binding>
+			<binding name="str1"><literal>食べ物</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s5</uri></binding>
-			<binding name="str1"><literal datatype="http://www.w3.org/2001/XMLSchema#string">100%</literal></binding>
+			<binding name="str1"><literal>100%</literal></binding>
 		</result>
 		<result><binding name="s"><uri>http://example.org/s6</uri></binding></result>
 		<result><binding name="s"><uri>http://example.org/s7</uri></binding></result>

--- a/sparql11/data-sparql11/functions/substring01.srx
+++ b/sparql11/data-sparql11/functions/substring01.srx
@@ -18,8 +18,8 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">DEF</literal></binding>
-			<binding name="substr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">D</literal></binding>
+			<binding name="str"><literal>DEF</literal></binding>
+			<binding name="substr"><literal>D</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s3</uri></binding>
@@ -33,8 +33,8 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
-			<binding name="substr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">a</literal></binding>
+			<binding name="str"><literal>abc</literal></binding>
+			<binding name="substr"><literal>a</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s1</uri></binding>

--- a/sparql11/data-sparql11/functions/substring02.srx
+++ b/sparql11/data-sparql11/functions/substring02.srx
@@ -18,8 +18,8 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">DEF</literal></binding>
-			<binding name="substr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">EF</literal></binding>
+			<binding name="str"><literal>DEF</literal></binding>
+			<binding name="substr"><literal>EF</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s3</uri></binding>
@@ -33,8 +33,8 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
-			<binding name="substr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">bc</literal></binding>
+			<binding name="str"><literal>abc</literal></binding>
+			<binding name="substr"><literal>bc</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s1</uri></binding>

--- a/sparql11/data-sparql11/functions/ucase01.srx
+++ b/sparql11/data-sparql11/functions/ucase01.srx
@@ -15,7 +15,7 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>
-			<binding name="ustr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">DEF</literal></binding>
+			<binding name="ustr"><literal>DEF</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s3</uri></binding>
@@ -27,7 +27,7 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="ustr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">ABC</literal></binding>
+			<binding name="ustr"><literal>ABC</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s1</uri></binding>

--- a/sparql11/data-sparql11/json-res/jsonres01.srj
+++ b/sparql11/data-sparql11/json-res/jsonres01.srj
@@ -17,12 +17,12 @@
       {
         "s": { "type": "uri" , "value": "http://example.org/s3" } ,
         "p": { "type": "uri" , "value": "http://example.org/p2" } ,
-        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#string" , "type": "literal" , "value": "bar" }
+        "o": { "type": "literal" , "value": "bar" }
       } ,
       {
         "s": { "type": "uri" , "value": "http://example.org/s4" } ,
         "p": { "type": "uri" , "value": "http://example.org/p4" } ,
-        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#integer" , "type": "literal" , "value": "4" }
+        "o": { "type": "literal" , "value": "4" }
       } ,
       {
         "s": { "type": "uri" , "value": "http://example.org/s5" } ,

--- a/sparql11/data-sparql11/json-res/jsonres02.srj
+++ b/sparql11/data-sparql11/json-res/jsonres02.srj
@@ -19,7 +19,7 @@
       {
         "s": { "type": "uri" , "value": "http://example.org/s3" } ,
         "p": { "type": "uri" , "value": "http://example.org/p2" } ,
-        "o": { "datatype": "http://www.w3.org/2001/XMLSchema#string" , "type": "literal" , "value": "bar" }
+        "o": { "type": "literal" , "value": "bar" }
       } ,
       {
         "s": { "type": "uri" , "value": "http://example.org/s4" } ,


### PR DESCRIPTION
xsd:string seems to become the datatype by default and so, it becomes implicit in sparql results.

Here, I propose to modify the SPARQL results of tests in order to be in coformity with the SPARQL results generate today by the classic SPARQL services.