### PR TITLE
Removes reference to not existing tests

### DIFF
--- a/sparql11/data-r2/dataset/manifest.ttl
+++ b/sparql11/data-r2/dataset/manifest.ttl
@@ -18,10 +18,7 @@
 	:dawg-dataset-06
 	:dawg-dataset-07
 	:dawg-dataset-08
-	:dawg-dataset-09
-	:dawg-dataset-10
 	:dawg-dataset-11
-	:dawg-dataset-12
 	:dawg-dataset-09b
 	:dawg-dataset-10b
 	:dawg-dataset-12b

--- a/sparql11/data-r2/graph/manifest.ttl
+++ b/sparql11/data-r2/graph/manifest.ttl
@@ -19,7 +19,6 @@
 	:dawg-graph-07
 	:dawg-graph-08
 	:dawg-graph-09
-	:dawg-graph-10
 	:dawg-graph-10b
 	:dawg-graph-11
    ).


### PR DESCRIPTION
:dawg-graph-10 and :dawg-dataset-{09,10,12} are still included in the mf:entries lists but do not exist anymore