### PR TITLE
Update data-r2 to be SPARQL 1.1 compatible

### DIFF
--- a/sparql11/data-r2/basic/term-6.rq
+++ b/sparql11/data-r2/basic/term-6.rq
@@ -1,5 +1,10 @@
 PREFIX :     <http://example.org/ns#>
 PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
 
-# DOT is part of the decimal.
-SELECT * { :x ?p 456. }
+# SPARQL 1.0 - abbreviated decimal did not need to have digit after the DOT.
+
+# Updated for SPARQL 1.1 (RDF 1.1, XSD 1.1)
+SELECT * { :x ?p "456."^^xsd:decimal }
+
+# SPARQL 1.0 : DOT is part of the decimal.
+## SELECT * { :x ?p 456. }

--- a/sparql11/data-r2/basic/term-7.rq
+++ b/sparql11/data-r2/basic/term-7.rq
@@ -1,5 +1,11 @@
 PREFIX :     <http://example.org/ns#>
 PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+# Duplicate of term-6.rq
 
-# DOT is part of the decimal.
-SELECT * { :x ?p 456. . }
+# SPARQL 1.0 - abbreviated decimal did not need to have digit after the DOT.
+
+# Updated for SPARQL 1.1 (RDF 1.1, XSD 1.1)
+SELECT * { :x ?p "456."^^xsd:decimal }
+
+# SPARQL 1.0 : DOT is part of the decimal.
+## SELECT * { :x ?p 456. }

--- a/sparql11/data-r2/distinct/distinct-all.srx
+++ b/sparql11/data-r2/distinct/distinct-all.srx
@@ -1,80 +1,12 @@
 <?xml version="1.0"?>
-<sparql
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema#"
-    xmlns="http://www.w3.org/2005/sparql-results#" >
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
   <head>
     <variable name="v"/>
   </head>
   <results>
     <result>
       <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string">ABC</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#float">1.3e0</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#double">1.3e0</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal xml:lang="en">ABC</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">+1</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
         <literal datatype="http://www.w3.org/2001/XMLSchema#decimal">01.0</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal>ABC</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">01</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string"></literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#double">1.0e0</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#decimal">+1.0</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal xml:lang="en">abc</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
       </binding>
     </result>
     <result>
@@ -84,7 +16,67 @@
     </result>
     <result>
       <binding name="v">
+        <literal></literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#double">1.3e0</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">01</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal>ABC</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
         <literal datatype="http://www.w3.org/2001/XMLSchema#decimal">1.0</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#decimal">+1.0</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#double">1.0e0</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#float">1.3e0</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">+1</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal xml:lang="en">ABC</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal>abc</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal xml:lang="en">abc</literal>
       </binding>
     </result>
     <result>
@@ -95,16 +87,6 @@
     <result>
       <binding name="v">
         <uri>http://example/z1</uri>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal>abc</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal></literal>
       </binding>
     </result>
   </results>

--- a/sparql11/data-r2/distinct/distinct-str.srx
+++ b/sparql11/data-r2/distinct/distinct-str.srx
@@ -1,25 +1,17 @@
 <?xml version="1.0"?>
-<sparql
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema#"
-    xmlns="http://www.w3.org/2005/sparql-results#" >
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
   <head>
     <variable name="v"/>
   </head>
   <results>
     <result>
       <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string">ABC</literal>
+        <literal xml:lang="en"></literal>
       </binding>
     </result>
     <result>
       <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal xml:lang="en">ABC</literal>
+        <literal></literal>
       </binding>
     </result>
     <result>
@@ -29,17 +21,7 @@
     </result>
     <result>
       <binding name="v">
-        <literal datatype="http://www.w3.org/2001/XMLSchema#string"></literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal xml:lang="en">abc</literal>
-      </binding>
-    </result>
-    <result>
-      <binding name="v">
-        <literal xml:lang="en"></literal>
+        <literal xml:lang="en">ABC</literal>
       </binding>
     </result>
     <result>
@@ -49,7 +31,7 @@
     </result>
     <result>
       <binding name="v">
-        <literal></literal>
+        <literal xml:lang="en">abc</literal>
       </binding>
     </result>
   </results>

--- a/sparql11/data-r2/expr-builtin/result-datatype-2.srx
+++ b/sparql11/data-r2/expr-builtin/result-datatype-2.srx
@@ -1,15 +1,22 @@
 <?xml version="1.0"?>
-<sparql
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema#"
-    xmlns="http://www.w3.org/2005/sparql-results#" >
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
   <head>
     <variable name="x"/>
   </head>
-  <results ordered="false" distinct="false">
+  <results>
     <result>
       <binding name="x">
-        <uri>http://example/x1</uri>
+        <uri>http://example/x4</uri>
+      </binding>
+    </result>
+    <result>
+      <binding name="x">
+        <uri>http://example/x5</uri>
+      </binding>
+    </result>
+    <result>
+      <binding name="x">
+        <uri>http://example/x3</uri>
       </binding>
     </result>
     <result>
@@ -19,12 +26,7 @@
     </result>
     <result>
       <binding name="x">
-        <uri>http://example/x4</uri>
-      </binding>
-    </result>
-    <result>
-      <binding name="x">
-        <uri>http://example/x5</uri>
+        <uri>http://example/x1</uri>
       </binding>
     </result>
   </results>

--- a/sparql11/data-r2/optional-filter/manifest.ttl
+++ b/sparql11/data-r2/optional-filter/manifest.ttl
@@ -9,8 +9,17 @@
     rdfs:label "OPTIONAL FILTER" ;
     rdfs:comment "OPTIONAL with inner and outer FILTERs" ;
     mf:entries
-    (:dawg-optional-filter-001 :dawg-optional-filter-002 :dawg-optional-filter-003 :dawg-optional-filter-004 :dawg-optional-filter-005-simplified :dawg-optional-filter-005-not-simplified).
-
+    (
+        :dawg-optional-filter-001
+        :dawg-optional-filter-002
+        :dawg-optional-filter-003
+        :dawg-optional-filter-004
+        ## Ambiguity in SPARQL 1.0
+        ##:dawg-optional-filter-005-simplified
+        ## Preferred reading and SPARQL 1.1:
+        :dawg-optional-filter-005-not-simplified
+    ).
+    
 :dawg-optional-filter-001 a mf:QueryEvaluationTest ;
       mf:name    "OPTIONAL-FILTER" ;
       rdfs:comment "FILTER inside an OPTIONAL does not block an entire solution" ;

--- a/sparql11/data-r2/syntax-sparql1/syntax-lit-08.rq
+++ b/sparql11/data-r2/syntax-sparql1/syntax-lit-08.rq
@@ -1,3 +1,8 @@
 BASE   <http://example.org/>
 PREFIX :  <#> 
-SELECT * WHERE { :x :p 123. . }
+
+## Legal in SPARQL 1.0
+##SELECT * WHERE { :x :p 123. . }
+
+## SPARQL 1.1 (and RDF 1.1 Turtle, and XSD 1.1).
+SELECT * WHERE { :x :p 123.0 . }

--- a/sparql11/data-r2/syntax-sparql2/syntax-esc-04.rq
+++ b/sparql11/data-r2/syntax-sparql2/syntax-esc-04.rq
@@ -1,3 +1,5 @@
 PREFIX : <http://example/> 
 SELECT *
-WHERE { <\u0078> :\u0070 ?xx\u0078 }
+## Community: \ u escapes in URIs and strings only.
+## U+0078 is 'x'
+WHERE { <\u0078> :p "xx\u0078" }

--- a/sparql11/data-r2/syntax-sparql2/syntax-esc-05.rq
+++ b/sparql11/data-r2/syntax-sparql2/syntax-esc-05.rq
@@ -1,5 +1,5 @@
 PREFIX : <http://example/> 
 SELECT *
-# Comments can contain \ u
+## Community: \ u escapes in URIs and strings only.
 # <\u0078> :\u0070 ?xx\u0078
-WHERE { <\u0078> :\u0070 ?xx\u0078 }
+WHERE { <\u0078> :p "xx\u0078" }


### PR DESCRIPTION
This PR changes data-r2/ in place, no directory rename applied, for discussion of the changes needed.
This is why it is marked "draft".

This PR does not include PR #82 which is needed as well for the SPARQL 1.0 test suite to run.

Changes and reason:

#### dawg-optional-filter-005-simplified (expr-5.rq)

Only one of `expr-5-result-simplified.ttl` and `expr-5-result-not-simplified.ttl` can be right.

There was an mmbiguity in the SPARQL 1.0 spec.

`expr-5-result-not-simplified.ttl` is the preferred answer (simplify after all algebra generated, not as generated).

Also reformatted `optional-filter/manifest.ttl`

#### datatype-2 : Literals with a datatype (q-datatype-2.rq)

`@lang` has a datatype in RDF 1.1
Update: `expr-builtin/result-datatype-2.srx`

#### Strings: Distinct (distinct-1.rq)
RDF 1.1 "" is now the same as ""^^xsd:string  
Updated `distinct-str.srx`

#### All: Distinct (distinct-1.rq)
Same.  
"" is now ""^^xsd:string  
Update `distinct-all.srx`

#### syntax-lit-08.rq (syntax-lit-08.rq)
Decimal form change.  
Updated: `syntax-sparql1/syntax-lit-08.rq`
