### PR TITLE
SPARQL CONCAT(): test the empty and single cases

### DIFF
--- a/sparql/sparql11/functions/concat-empty.rq
+++ b/sparql/sparql11/functions/concat-empty.rq
@@ -1,0 +1,1 @@
+SELECT (CONCAT() AS ?str) WHERE {}

--- a/sparql/sparql11/functions/concat-empty.srx
+++ b/sparql/sparql11/functions/concat-empty.srx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+<head>
+	<variable name="str"/>
+</head>
+<results>
+	<result><binding name="str"><literal></literal></binding></result>
+</results>
+</sparql>

--- a/sparql/sparql11/functions/concat-single.rq
+++ b/sparql/sparql11/functions/concat-single.rq
@@ -1,0 +1,4 @@
+PREFIX : <http://example.org/>
+SELECT (CONCAT(?str1) AS ?str) WHERE {
+	:s6 :str ?str1 .
+}

--- a/sparql/sparql11/functions/concat-single.srx
+++ b/sparql/sparql11/functions/concat-single.srx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+<head>
+	<variable name="str"/>
+</head>
+<results>
+	<result>
+		<binding name="str"><literal>abc</literal></binding>
+	</result>
+</results>
+</sparql>

--- a/sparql/sparql11/functions/manifest.ttl
+++ b/sparql/sparql11/functions/manifest.ttl
@@ -23,6 +23,8 @@
         :round01
         :concat01
         :concat02
+        :concat-empty
+        :concat-single
         :substring01
         :substring01-non-bmp
         :substring02
@@ -221,6 +223,22 @@
            qt:data   <data2.ttl> ] ;
     mf:result  <concat02.srx> ;
     .
+
+:concat-empty rdf:type mf:QueryEvaluationTest ;
+    mf:name    "CONCAT() without parameter" ;
+    mf:feature sparql:concat ;
+    mf:action
+         [ qt:query  <concat-empty.rq> ;
+           qt:data   <data.ttl> ] ;
+    mf:result  <concat-empty.srx> .
+
+:concat-single rdf:type mf:QueryEvaluationTest ;
+    mf:name    "CONCAT() with a single parameter" ;
+    mf:feature sparql:concat ;
+    mf:action
+         [ qt:query  <concat-single.rq> ;
+           qt:data   <data.ttl> ] ;
+    mf:result  <concat-single.srx> .
 
 :substring01 rdf:type mf:QueryEvaluationTest ;
     mf:name    "SUBSTR() (3-argument)" ;


### PR DESCRIPTION
Related to:
- [sparql-errata#errata-query-4](https://www.w3.org/2013/sparql-errata#errata-query-4).
- https://github.com/w3c/sparql-query/pull/70
