### PR TITLE
SPARQL 1.1: Adds a test for CONSTRUCT and list

### DIFF
--- a/sparql/sparql11/construct/constructlist.rq
+++ b/sparql/sparql11/construct/constructlist.rq
@@ -1,0 +1,3 @@
+PREFIX : <http://example.org/>
+
+CONSTRUCT { (?s ?o) :prop ?p } WHERE { ?s ?p ?o }

--- a/sparql/sparql11/construct/constructlistresult.ttl
+++ b/sparql/sparql11/construct/constructlistresult.ttl
@@ -1,0 +1,6 @@
+@prefix : <http://example.org/> .
+
+(:s1 :o1) :prop :p .
+(:s2 :o1) :prop :p .
+(:s2 :o2) :prop :p .
+(:s3 :o3) :prop :p .

--- a/sparql/sparql11/construct/manifest.ttl
+++ b/sparql/sparql11/construct/manifest.ttl
@@ -15,6 +15,7 @@
     :constructwhere04
     :constructwhere05
     :constructwhere06
+    :constructlist
     ) .
 
 :constructwhere01 rdf:type mf:QueryEvaluationTest ;
@@ -73,3 +74,10 @@
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-02-01#resolution_3> ;
     mf:action <constructwhere06.rq> .
+
+:constructlist rdf:type mf:QueryEvaluationTest ;
+    mf:name    "CONSTRUCT list" ;
+    mf:action
+         [ qt:query  <constructlist.rq> ;
+           qt:data <data.ttl> ] ;
+    mf:result  <constructlistresult.ttl> .


### PR DESCRIPTION
This feature is in the grammar but not covered by the testsuite