### PR TITLE
Remove symlinks for previous test locations for RDF 1.1 test suites.

### DIFF
--- a/nquads
+++ b/nquads
@@ -1,1 +1,0 @@
-rdf/rdf11/rdf-n-quads

--- a/ntriples
+++ b/ntriples
@@ -1,1 +1,0 @@
-rdf/rdf11/rdf-n-triples

--- a/rdf-mt
+++ b/rdf-mt
@@ -1,1 +1,0 @@
-rdf/rdf11/rdf-mt

--- a/rdf-xml
+++ b/rdf-xml
@@ -1,1 +1,0 @@
-rdf/rdf11/rdf-xml

--- a/trig
+++ b/trig
@@ -1,1 +1,0 @@
-rdf/rdf11/rdf-trig

--- a/turtle
+++ b/turtle
@@ -1,1 +1,0 @@
-rdf/rdf11/rdf-turtle


### PR DESCRIPTION
The RDF 1.1 test suites were relocated, and the symbolic link links were left as a temporary measure to allow dependent organizations to update to the new locations. This PR targets removing those links.