### PR TITLE
RDF star tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,14 +177,23 @@ em.rfc2119 {
 <ul>
   <li><a href="rdf/">RDF tests</a>
     <ul>
-      <li>RDF 1.2</li>
+      <li><a href="rdf/rdf12/">RDF 1.2</a>
+        <ul>
+          <li><a href="rdf/rdf12/rdf-n-triples/syntax">N-Triples syntax tests</a></li>
+          <li><a href="rdf/rdf12/rdf-semantics">Semantics tests</a></li>
+          <li><a href="rdf/rdf12/rdf-turtle/syntax">Turtle syntax tests</a></li>
+          <li><a href="rdf/rdf12/rdf-turtle/eval">Turtle evaluation tests</a></li>
+          <li><a href="rdf/rdf12/rdf-trig/syntax">TriG syntax tests</a></li>
+          <li><a href="rdf/rdf12/rdf-trig/eval">TriG evaluation tests</a></li>
+        </ul>
+      </li>
       <li><a href="rdf/rdf11/">RDF 1.1 tests</a>
         <ul>
           <li><a href="rdf/rdf11/rdf-n-quads/">N-Quads tests</a> (<a href="rdf/rdf11/rdf-n-quads/reports/">implementation report</a>)</li>
           <li><a href="rdf/rdf11/rdf-n-triples/">N-Triples tests</a> (<a href="rdf/rdf11/rdf-n-triples/reports/">implementation report</a>)</li>
           <li><a href="rdf/rdf11/rdf-mt/">RDF Schema and Semantics tests</a> (<a href="rdf/rdf11/rdf-mt/reports/">implementation report</a>)</li>
           <li><a href="rdf/rdf11/rdf-xml/">RDF/XML Syntax tests</a> (<a href="rdf/rdf11/rdf-xml/reports/">implementation report</a>)</li>
-          <li><a href="rdf/rdf11/rdf-trig/">RDF/XML Syntax tests</a> (<a href="rdf/rdf11/rdf-trig/reports/">implementation report</a>)</li>
+          <li><a href="rdf/rdf11/rdf-trig/">TriG Syntax tests</a> (<a href="rdf/rdf11/rdf-trig/reports/">implementation report</a>)</li>
           <li><a href="rdf/rdf11/rdf-turtle/">Turtle tests</a> (<a href="rdf/rdf11/rdf-turtle/reports/">implementation report</a>)</li>
         </ul>
       </li>

--- a/rdf/rdf11/rdf-mt/index.html
+++ b/rdf/rdf11/rdf-mt/index.html
@@ -111,7 +111,7 @@
           </a>
           <span about='#datatypes-intensional-xsd-integer-decimal-compatible' property='mf:name'>datatypes-intensional-xsd-integer-decimal-compatible</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#datatypes-intensional-xsd-integer-decimal-compatible' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='#datatypes-intensional-xsd-integer-decimal-compatible' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>The claim that xsd:integer is a subClassOF xsd:decimal is not incompatible with using the intensional semantics for datatypes.</p>
           </div>
@@ -124,8 +124,8 @@
             <dd property='mf:entailmentRegime'>RDFS</dd>
             <dt>recognizedDatatypes</dt>
             <dd>
-              <code inlist property='mf:recognizedDatatypes' resource='xsd:decimal'>xsd:decimal</code>
-              <code inlist property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
+              <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:decimal'>xsd:decimal</code>
+              <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
             </dd>
             <dt>unrecognizedDatatypes</dt>
             <dd>
@@ -143,7 +143,7 @@
           </a>
           <span about='#datatypes-non-well-formed-literal-1' property='mf:name'>datatypes-non-well-formed-literal-1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#datatypes-non-well-formed-literal-1' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='#datatypes-non-well-formed-literal-1' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Without datatype knowledge, a &#39;badly-formed&#39; datatyped literal cannot be detected. Used to be a postitive test to itself.</p>
           </div>
@@ -160,7 +160,7 @@
             </dd>
             <dt>unrecognizedDatatypes</dt>
             <dd>
-              <code inlist property='mf:unrecognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
+              <code inlist='true' property='mf:unrecognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
             </dd>
             <dt>action</dt>
             <dd>
@@ -174,7 +174,7 @@
           </a>
           <span about='#datatypes-non-well-formed-literal-2' property='mf:name'>datatypes-non-well-formed-literal-2</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#datatypes-non-well-formed-literal-2' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='#datatypes-non-well-formed-literal-2' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>With appropriate datatype knowledge, a &#39;badly-formed&#39; datatyped literal can be detected. Ill-formed datatyped literals now are inconsistent. Used to be negative entailment to <datatypes/test002b.nt></p>
             </div>
@@ -187,7 +187,7 @@
               <dd property='mf:entailmentRegime'>RDFS</dd>
               <dt>recognizedDatatypes</dt>
               <dd>
-                <code inlist property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
+                <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
               </dd>
               <dt>unrecognizedDatatypes</dt>
               <dd>
@@ -205,7 +205,7 @@
             </a>
             <span about='#datatypes-semantic-equivalence-within-type-1' property='mf:name'>datatypes-semantic-equivalence-within-type-1</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#datatypes-semantic-equivalence-within-type-1' typeof='mf:PositiveEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#datatypes-semantic-equivalence-within-type-1' typeof='mf:PositiveEntailmentTest'>
             <div property='rdfs:comment'>
               <p>Demonstrating the semantic equivalence of two lexical forms of the same datatyped value.</p>
             </div>
@@ -218,7 +218,7 @@
               <dd property='mf:entailmentRegime'>RDF</dd>
               <dt>recognizedDatatypes</dt>
               <dd>
-                <code inlist property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
+                <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
               </dd>
               <dt>unrecognizedDatatypes</dt>
               <dd>
@@ -240,7 +240,7 @@
             </a>
             <span about='#datatypes-semantic-equivalence-within-type-2' property='mf:name'>datatypes-semantic-equivalence-within-type-2</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#datatypes-semantic-equivalence-within-type-2' typeof='mf:PositiveEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#datatypes-semantic-equivalence-within-type-2' typeof='mf:PositiveEntailmentTest'>
             <div property='rdfs:comment'>
               <p>As semantic-equivalence-within-type-1; the entailment works both ways.</p>
             </div>
@@ -253,7 +253,7 @@
               <dd property='mf:entailmentRegime'>RDF</dd>
               <dt>recognizedDatatypes</dt>
               <dd>
-                <code inlist property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
+                <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
               </dd>
               <dt>unrecognizedDatatypes</dt>
               <dd>
@@ -275,7 +275,7 @@
             </a>
             <span about='#datatypes-semantic-equivalence-between-datatypes' property='mf:name'>datatypes-semantic-equivalence-between-datatypes</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#datatypes-semantic-equivalence-between-datatypes' typeof='mf:PositiveEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#datatypes-semantic-equivalence-between-datatypes' typeof='mf:PositiveEntailmentTest'>
             <div property='rdfs:comment'>
               <p>Members of different datatypes may be semantically equivalent.</p>
             </div>
@@ -288,8 +288,8 @@
               <dd property='mf:entailmentRegime'>RDF</dd>
               <dt>recognizedDatatypes</dt>
               <dd>
-                <code inlist property='mf:recognizedDatatypes' resource='xsd:decimal'>xsd:decimal</code>
-                <code inlist property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
+                <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:decimal'>xsd:decimal</code>
+                <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
               </dd>
               <dt>unrecognizedDatatypes</dt>
               <dd>
@@ -311,7 +311,7 @@
             </a>
             <span about='#datatypes-range-clash' property='mf:name'>datatypes-range-clash</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#datatypes-range-clash' typeof='mf:PositiveEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#datatypes-range-clash' typeof='mf:PositiveEntailmentTest'>
             <div property='rdfs:comment'>
               <p>Where sufficient DT knowledge is available, a range clash may be detected; the document then contains a contradiction.</p>
             </div>
@@ -324,8 +324,8 @@
               <dd property='mf:entailmentRegime'>RDFS</dd>
               <dt>recognizedDatatypes</dt>
               <dd>
-                <code inlist property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
-                <code inlist property='mf:recognizedDatatypes' resource='xsd:string'>xsd:string</code>
+                <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
+                <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:string'>xsd:string</code>
               </dd>
               <dt>unrecognizedDatatypes</dt>
               <dd>
@@ -343,7 +343,7 @@
             </a>
             <span about='#datatypes-test008' property='mf:name'>datatypes-test008</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#datatypes-test008' typeof='mf:PositiveEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#datatypes-test008' typeof='mf:PositiveEntailmentTest'>
             <div property='rdfs:comment'>
               <p>From decisions listed in http://lists.w3.org/Archives/Public/w3c-rdfcore-wg/2002Oct/0098.html</p>
             </div>
@@ -378,7 +378,7 @@
             </a>
             <span about='#datatypes-test009' property='mf:name'>datatypes-test009</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#datatypes-test009' typeof='mf:NegativeEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#datatypes-test009' typeof='mf:NegativeEntailmentTest'>
             <div property='rdfs:comment'>
               <p>From decisions listed in http://lists.w3.org/Archives/Public/w3c-rdfcore-wg/2002Oct/0098.html</p>
             </div>
@@ -395,7 +395,7 @@
               </dd>
               <dt>unrecognizedDatatypes</dt>
               <dd>
-                <code inlist property='mf:unrecognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
+                <code inlist='true' property='mf:unrecognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
               </dd>
               <dt>action</dt>
               <dd>
@@ -413,7 +413,7 @@
             </a>
             <span about='#datatypes-test010' property='mf:name'>datatypes-test010</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#datatypes-test010' typeof='mf:PositiveEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#datatypes-test010' typeof='mf:PositiveEntailmentTest'>
             <div property='rdfs:comment'>
               <p>From decisions listed in http://lists.w3.org/Archives/Public/w3c-rdfcore-wg/2002Oct/0098.html</p>
             </div>
@@ -426,7 +426,7 @@
               <dd property='mf:entailmentRegime'>RDFS</dd>
               <dt>recognizedDatatypes</dt>
               <dd>
-                <code inlist property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
+                <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:integer'>xsd:integer</code>
               </dd>
               <dt>unrecognizedDatatypes</dt>
               <dd>
@@ -444,7 +444,7 @@
             </a>
             <span about='#datatypes-plain-literal-and-xsd-string' property='mf:name'>datatypes-plain-literal-and-xsd-string</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#datatypes-plain-literal-and-xsd-string' typeof='mf:PositiveEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#datatypes-plain-literal-and-xsd-string' typeof='mf:PositiveEntailmentTest'>
             <div property='rdfs:comment'>
               <p>A plain literal denotes the same thing as its corresponding xsd:string, where one exists.</p>
             </div>
@@ -457,7 +457,7 @@
               <dd property='mf:entailmentRegime'>RDFS</dd>
               <dt>recognizedDatatypes</dt>
               <dd>
-                <code inlist property='mf:recognizedDatatypes' resource='xsd:string'>xsd:string</code>
+                <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:string'>xsd:string</code>
               </dd>
               <dt>unrecognizedDatatypes</dt>
               <dd>
@@ -479,7 +479,7 @@
             </a>
             <span about='#horst-01-subClassOf-intensional' property='mf:name'>horst-01-subClassOf-intensional</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#horst-01-subClassOf-intensional' typeof='mf:NegativeEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#horst-01-subClassOf-intensional' typeof='mf:NegativeEntailmentTest'>
             <div property='rdfs:comment'>
               <p>rdfs:subClassOf has intensional semantics, not extensional.</p>
             </div>
@@ -514,7 +514,7 @@
             </a>
             <span about='#horst-01-subPropertyOf-intensional' property='mf:name'>horst-01-subPropertyOf-intensional</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#horst-01-subPropertyOf-intensional' typeof='mf:NegativeEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#horst-01-subPropertyOf-intensional' typeof='mf:NegativeEntailmentTest'>
             <div property='rdfs:comment'>
               <p>rdfs:subPropertyOf has intensional semantics, not extensional.</p>
             </div>
@@ -549,7 +549,7 @@
             </a>
             <span about='#rdf-charmod-uris-test003' property='mf:name'>rdf-charmod-uris-test003</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#rdf-charmod-uris-test003' typeof='mf:NegativeEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#rdf-charmod-uris-test003' typeof='mf:NegativeEntailmentTest'>
             <div property='rdfs:comment'>
               <p>An international URI ref and its %-escaped form label different nodes in the graph. No model theoretic relationship holds between them.</p>
             </div>
@@ -584,7 +584,7 @@
             </a>
             <span about='#rdf-charmod-uris-test004' property='mf:name'>rdf-charmod-uris-test004</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#rdf-charmod-uris-test004' typeof='mf:NegativeEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#rdf-charmod-uris-test004' typeof='mf:NegativeEntailmentTest'>
             <div property='rdfs:comment'>
               <p>An international URI ref and its %-escaped form label different nodes in the graph. No model theoretic relationship holds between them.</p>
             </div>
@@ -619,7 +619,7 @@
             </a>
             <span about='#rdfms-seq-representation-test002' property='mf:name'>rdfms-seq-representation-test002</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#rdfms-seq-representation-test002' typeof='mf:PositiveEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#rdfms-seq-representation-test002' typeof='mf:PositiveEntailmentTest'>
             <div property='rdfs:comment'>
               <p>Statement of the MT closure rule.</p>
             </div>
@@ -654,7 +654,7 @@
             </a>
             <span about='#rdfms-seq-representation-test003' property='mf:name'>rdfms-seq-representation-test003</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#rdfms-seq-representation-test003' typeof='mf:PositiveEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#rdfms-seq-representation-test003' typeof='mf:PositiveEntailmentTest'>
             <div property='rdfs:comment'>
               <p>Statement of the MT closure rule.</p>
             </div>
@@ -689,7 +689,7 @@
             </a>
             <span about='#rdfms-seq-representation-test004' property='mf:name'>rdfms-seq-representation-test004</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#rdfms-seq-representation-test004' typeof='mf:PositiveEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#rdfms-seq-representation-test004' typeof='mf:PositiveEntailmentTest'>
             <div property='rdfs:comment'>
               <p>Statement of the MT closure rule.</p>
             </div>
@@ -724,7 +724,7 @@
             </a>
             <span about='#rdfms-xmllang-test007a' property='mf:name'>rdfms-xmllang-test007a</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#rdfms-xmllang-test007a' typeof='mf:NegativeEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#rdfms-xmllang-test007a' typeof='mf:NegativeEntailmentTest'>
             <div property='rdfs:comment'>
               <p>Plain literals are distinguishable on the basis of language tags.</p>
             </div>
@@ -759,7 +759,7 @@
             </a>
             <span about='#rdfms-xmllang-test007b' property='mf:name'>rdfms-xmllang-test007b</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#rdfms-xmllang-test007b' typeof='mf:NegativeEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#rdfms-xmllang-test007b' typeof='mf:NegativeEntailmentTest'>
             <div property='rdfs:comment'>
               <p>Plain literals are distinguishable on the basis of language tags.</p>
             </div>
@@ -794,7 +794,7 @@
             </a>
             <span about='#rdfms-xmllang-test007c' property='mf:name'>rdfms-xmllang-test007c</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#rdfms-xmllang-test007c' typeof='mf:NegativeEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#rdfms-xmllang-test007c' typeof='mf:NegativeEntailmentTest'>
             <div property='rdfs:comment'>
               <p>Plain literals are distinguishable on the basis of language tags.</p>
             </div>
@@ -829,7 +829,7 @@
             </a>
             <span about='#rdfs-container-membership-superProperty-test001' property='mf:name'>rdfs-container-membership-superProperty-test001</span>
           </dt>
-          <dd inlist property='mf:entry' resource='#rdfs-container-membership-superProperty-test001' typeof='mf:NegativeEntailmentTest'>
+          <dd inlist='true' property='mf:entry' resource='#rdfs-container-membership-superProperty-test001' typeof='mf:NegativeEntailmentTest'>
             <div property='rdfs:comment'>
               <p>While it is a superproperty, <em>:a <rdfs:contains (@@member?)> _:b . does NOT entail _:a &lt;rdf:</em>n&gt; _:b . for any _n.</p>
               </div>
@@ -864,7 +864,7 @@
               </a>
               <span about='#rdfs-domain-and-range-intensionality-range' property='mf:name'>rdfs-domain-and-range-intensionality-range</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#rdfs-domain-and-range-intensionality-range' typeof='mf:NegativeEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#rdfs-domain-and-range-intensionality-range' typeof='mf:NegativeEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>RDF Semantics defines rdfs:range to have an intensional reading. However, semantic extensions may give an extensional reading to range. The premise/conclusion pair is a non-entailment for RDFS reasoning, but may hold in semantic extensions.</p>
               </div>
@@ -899,7 +899,7 @@
               </a>
               <span about='#rdfs-domain-and-range-intensionality-domain' property='mf:name'>rdfs-domain-and-range-intensionality-domain</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#rdfs-domain-and-range-intensionality-domain' typeof='mf:NegativeEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#rdfs-domain-and-range-intensionality-domain' typeof='mf:NegativeEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>RDF Semantics defines rdfs:range to have an intensional reading of domain. However, semantic extensions may give an extensional reading to domain. The premise/conclusion pair is a non-entailment for RDFS reasoning, but may hold in semantic extensions.</p>
               </div>
@@ -934,7 +934,7 @@
               </a>
               <span about='#rdfs-entailment-test001' property='mf:name'>rdfs-entailment-test001</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#rdfs-entailment-test001' typeof='mf:PositiveEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#rdfs-entailment-test001' typeof='mf:PositiveEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>Indicating a simple inconsistency drawn from RDFS. RDFS can only produce inconsistencies through badly-formed XMLLiteral datatypes. rdf:XMLLiteral support is no longer mandatory.</p>
               </div>
@@ -947,7 +947,7 @@
                 <dd property='mf:entailmentRegime'>RDFS</dd>
                 <dt>recognizedDatatypes</dt>
                 <dd>
-                  <code inlist property='mf:recognizedDatatypes' resource='http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral'>http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral</code>
+                  <code inlist='true' property='mf:recognizedDatatypes' resource='http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral'>http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral</code>
                 </dd>
                 <dt>unrecognizedDatatypes</dt>
                 <dd>
@@ -965,7 +965,7 @@
               </a>
               <span about='#rdfs-entailment-test002' property='mf:name'>rdfs-entailment-test002</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#rdfs-entailment-test002' typeof='mf:PositiveEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#rdfs-entailment-test002' typeof='mf:PositiveEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>Datatype clashes can occur in RDFS entailment. Use to be from an inconsistent graph, any entailment can be drawn. This is an example.</p>
               </div>
@@ -978,8 +978,8 @@
                 <dd property='mf:entailmentRegime'>RDFS</dd>
                 <dt>recognizedDatatypes</dt>
                 <dd>
-                  <code inlist property='mf:recognizedDatatypes' resource='xsd:string'>xsd:string</code>
-                  <code inlist property='mf:recognizedDatatypes' resource='http://www.w3.org/1999/02/22-rdf-syntax-ns#langString'>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code>
+                  <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:string'>xsd:string</code>
+                  <code inlist='true' property='mf:recognizedDatatypes' resource='http://www.w3.org/1999/02/22-rdf-syntax-ns#langString'>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code>
                 </dd>
                 <dt>unrecognizedDatatypes</dt>
                 <dd>
@@ -997,7 +997,7 @@
               </a>
               <span about='#rdfs-no-cycles-in-subClassOf-test001' property='mf:name'>rdfs-no-cycles-in-subClassOf-test001</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#rdfs-no-cycles-in-subClassOf-test001' typeof='mf:PositiveEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#rdfs-no-cycles-in-subClassOf-test001' typeof='mf:PositiveEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>Cycles are permitted in subClassOf; therefore, no error occurs and the following entailment holds trivially.</p>
               </div>
@@ -1032,7 +1032,7 @@
               </a>
               <span about='#rdfs-no-cycles-in-subPropertyOf-test001' property='mf:name'>rdfs-no-cycles-in-subPropertyOf-test001</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#rdfs-no-cycles-in-subPropertyOf-test001' typeof='mf:PositiveEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#rdfs-no-cycles-in-subPropertyOf-test001' typeof='mf:PositiveEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>Cycles are permitted in subPropertyOf; therefore, no error occurs and the following entailment holds trivially.</p>
               </div>
@@ -1067,7 +1067,7 @@
               </a>
               <span about='#rdfs-subClassOf-a-Property-test001' property='mf:name'>rdfs-subClassOf-a-Property-test001</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#rdfs-subClassOf-a-Property-test001' typeof='mf:NegativeEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#rdfs-subClassOf-a-Property-test001' typeof='mf:NegativeEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>an instance of the Property class may have an rdfs:subClassOf property. the meaning of such a property is defined by the model theory. The wording of the formal resolution is a bit bare, so let me add a few words of explanation. What this means is that a resource can be both a class and a property. This test is encoded as follows: a Property may have a subclass (that is, such an RDF graph is satisfiable)</p>
               </div>
@@ -1098,7 +1098,7 @@
               </a>
               <span about='#rdfs-subPropertyOf-semantics-test001' property='mf:name'>rdfs-subPropertyOf-semantics-test001</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#rdfs-subPropertyOf-semantics-test001' typeof='mf:PositiveEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#rdfs-subPropertyOf-semantics-test001' typeof='mf:PositiveEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>The inheritance semantics of the subPropertyOf relationship needs to be clarified. =&gt; subProperties inherit conjunctively the domain and range of their superproperties</p>
               </div>
@@ -1133,7 +1133,7 @@
               </a>
               <span about='#statement-entailment-test001' property='mf:name'>statement-entailment-test001</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#statement-entailment-test001' typeof='mf:NegativeEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#statement-entailment-test001' typeof='mf:NegativeEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>RDFCore WG RESOLVED that a reified statement was a stating, not a statement. The following entailment does not, therefore, hold.</p>
               </div>
@@ -1168,7 +1168,7 @@
               </a>
               <span about='#statement-entailment-test002' property='mf:name'>statement-entailment-test002</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#statement-entailment-test002' typeof='mf:NegativeEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#statement-entailment-test002' typeof='mf:NegativeEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>RDFCore WG RESOLVED that a statement does NOT entail its reification. The following entailment does not, therefore, hold.</p>
               </div>
@@ -1203,7 +1203,7 @@
               </a>
               <span about='#statement-entailment-test003' property='mf:name'>statement-entailment-test003</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#statement-entailment-test003' typeof='mf:NegativeEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#statement-entailment-test003' typeof='mf:NegativeEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>RDFCore WG RESOLVED that a reified statement was a stating, not a statement. The following entailment does not, therefore, hold. This is the same as test001, but using RDFS-entailment.</p>
               </div>
@@ -1238,7 +1238,7 @@
               </a>
               <span about='#statement-entailment-test004' property='mf:name'>statement-entailment-test004</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#statement-entailment-test004' typeof='mf:NegativeEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#statement-entailment-test004' typeof='mf:NegativeEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>RDFCore WG RESOLVED that a statement does NOT entail its reification. The following entailment does not, therefore, hold. This is the same as test002, but using RDFS-entailment.</p>
               </div>
@@ -1273,7 +1273,7 @@
               </a>
               <span about='#tex-01-language-tag-case-1' property='mf:name'>tex-01-language-tag-case-1</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#tex-01-language-tag-case-1' typeof='mf:PositiveEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#tex-01-language-tag-case-1' typeof='mf:PositiveEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>The case of the language tag is not significant.</p>
               </div>
@@ -1308,7 +1308,7 @@
               </a>
               <span about='#tex-01-language-tag-case-2' property='mf:name'>tex-01-language-tag-case-2</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#tex-01-language-tag-case-2' typeof='mf:PositiveEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#tex-01-language-tag-case-2' typeof='mf:PositiveEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>The case of the language tag is not significant.</p>
               </div>
@@ -1343,7 +1343,7 @@
               </a>
               <span about='#xmlsch-02-whitespace-facet-1' property='mf:name'>xmlsch-02-whitespace-facet-1</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#xmlsch-02-whitespace-facet-1' typeof='mf:NegativeEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#xmlsch-02-whitespace-facet-1' typeof='mf:NegativeEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>A well-formed typed literal is not related to an ill-formed literal. Even if they only differ by whitespace.</p>
               </div>
@@ -1356,7 +1356,7 @@
                 <dd property='mf:entailmentRegime'>RDFS</dd>
                 <dt>recognizedDatatypes</dt>
                 <dd>
-                  <code inlist property='mf:recognizedDatatypes' resource='xsd:int'>xsd:int</code>
+                  <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:int'>xsd:int</code>
                 </dd>
                 <dt>unrecognizedDatatypes</dt>
                 <dd>
@@ -1378,7 +1378,7 @@
               </a>
               <span about='#xmlsch-02-whitespace-facet-2' property='mf:name'>xmlsch-02-whitespace-facet-2</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#xmlsch-02-whitespace-facet-2' typeof='mf:PositiveEntailmentTest'>
+            <dd inlist='true' property='mf:entry' resource='#xmlsch-02-whitespace-facet-2' typeof='mf:PositiveEntailmentTest'>
               <div property='rdfs:comment'>
                 <p>A well-formed typed literal is not related to an ill-formed literal. Even if they only differ by whitespace. Ill-formed datatyped literals now are inconsistent. Used to be negative entailment to <xmlsch-02/test001.ttl> .</p>
                 </div>
@@ -1391,7 +1391,7 @@
                   <dd property='mf:entailmentRegime'>RDFS</dd>
                   <dt>recognizedDatatypes</dt>
                   <dd>
-                    <code inlist property='mf:recognizedDatatypes' resource='xsd:int'>xsd:int</code>
+                    <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:int'>xsd:int</code>
                   </dd>
                   <dt>unrecognizedDatatypes</dt>
                   <dd>
@@ -1409,7 +1409,7 @@
                 </a>
                 <span about='#xmlsch-02-whitespace-facet-4' property='mf:name'>xmlsch-02-whitespace-facet-4</span>
               </dt>
-              <dd inlist property='mf:entry' resource='#xmlsch-02-whitespace-facet-4' typeof='mf:PositiveEntailmentTest'>
+              <dd inlist='true' property='mf:entry' resource='#xmlsch-02-whitespace-facet-4' typeof='mf:PositiveEntailmentTest'>
                 <div property='rdfs:comment'>
                   <p>An integer with whitespace is ill-formed. Ill-formed datatyped literals now are inconsistent. Used to be negative entailment.</p>
                 </div>
@@ -1422,7 +1422,7 @@
                   <dd property='mf:entailmentRegime'>RDFS</dd>
                   <dt>recognizedDatatypes</dt>
                   <dd>
-                    <code inlist property='mf:recognizedDatatypes' resource='xsd:int'>xsd:int</code>
+                    <code inlist='true' property='mf:recognizedDatatypes' resource='xsd:int'>xsd:int</code>
                   </dd>
                   <dt>unrecognizedDatatypes</dt>
                   <dd>

--- a/rdf/rdf11/rdf-n-quads/index.html
+++ b/rdf/rdf11/rdf-n-quads/index.html
@@ -82,7 +82,7 @@
           </a>
           <span about='#nq-syntax-uri-01' property='mf:name'>nq-syntax-uri-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-uri-01' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-uri-01' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>URI graph with URI triple</p>
           </div>
@@ -103,7 +103,7 @@
           </a>
           <span about='#nq-syntax-uri-02' property='mf:name'>nq-syntax-uri-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-uri-02' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-uri-02' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>URI graph with BNode subject</p>
           </div>
@@ -124,7 +124,7 @@
           </a>
           <span about='#nq-syntax-uri-03' property='mf:name'>nq-syntax-uri-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-uri-03' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-uri-03' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>URI graph with BNode object</p>
           </div>
@@ -145,7 +145,7 @@
           </a>
           <span about='#nq-syntax-uri-04' property='mf:name'>nq-syntax-uri-04</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-uri-04' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-uri-04' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>URI graph with simple literal</p>
           </div>
@@ -166,7 +166,7 @@
           </a>
           <span about='#nq-syntax-uri-05' property='mf:name'>nq-syntax-uri-05</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-uri-05' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-uri-05' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>URI graph with language tagged literal</p>
           </div>
@@ -187,7 +187,7 @@
           </a>
           <span about='#nq-syntax-uri-06' property='mf:name'>nq-syntax-uri-06</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-uri-06' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-uri-06' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>URI graph with datatyped literal</p>
           </div>
@@ -208,7 +208,7 @@
           </a>
           <span about='#nq-syntax-bnode-01' property='mf:name'>nq-syntax-bnode-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bnode-01' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bnode-01' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>BNode graph with URI triple</p>
           </div>
@@ -229,7 +229,7 @@
           </a>
           <span about='#nq-syntax-bnode-02' property='mf:name'>nq-syntax-bnode-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bnode-02' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bnode-02' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>BNode graph with BNode subject</p>
           </div>
@@ -250,7 +250,7 @@
           </a>
           <span about='#nq-syntax-bnode-03' property='mf:name'>nq-syntax-bnode-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bnode-03' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bnode-03' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>BNode graph with BNode object</p>
           </div>
@@ -271,7 +271,7 @@
           </a>
           <span about='#nq-syntax-bnode-04' property='mf:name'>nq-syntax-bnode-04</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bnode-04' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bnode-04' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>BNode graph with simple literal</p>
           </div>
@@ -292,7 +292,7 @@
           </a>
           <span about='#nq-syntax-bnode-05' property='mf:name'>nq-syntax-bnode-05</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bnode-05' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bnode-05' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>BNode graph with language tagged literal</p>
           </div>
@@ -313,7 +313,7 @@
           </a>
           <span about='#nq-syntax-bnode-06' property='mf:name'>nq-syntax-bnode-06</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bnode-06' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bnode-06' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>BNode graph with datatyped literal</p>
           </div>
@@ -334,7 +334,7 @@
           </a>
           <span about='#nq-syntax-bad-literal-01' property='mf:name'>nq-syntax-bad-literal-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bad-literal-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bad-literal-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Graph name may not be a simple literal (negative test)</p>
           </div>
@@ -355,7 +355,7 @@
           </a>
           <span about='#nq-syntax-bad-literal-02' property='mf:name'>nq-syntax-bad-literal-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bad-literal-02' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bad-literal-02' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Graph name may not be a language tagged literal (negative test)</p>
           </div>
@@ -376,7 +376,7 @@
           </a>
           <span about='#nq-syntax-bad-literal-03' property='mf:name'>nq-syntax-bad-literal-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bad-literal-03' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bad-literal-03' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Graph name may not be a datatyped literal (negative test)</p>
           </div>
@@ -397,7 +397,7 @@
           </a>
           <span about='#nq-syntax-bad-uri-01' property='mf:name'>nq-syntax-bad-uri-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bad-uri-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bad-uri-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Graph name URI must be absolute (negative test)</p>
           </div>
@@ -418,7 +418,7 @@
           </a>
           <span about='#nq-syntax-bad-quint-01' property='mf:name'>nq-syntax-bad-quint-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nq-syntax-bad-quint-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nq-syntax-bad-quint-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>N-Quads does not have a fifth element (negative test)</p>
           </div>
@@ -439,7 +439,7 @@
           </a>
           <span about='#nt-syntax-file-01' property='mf:name'>nt-syntax-file-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-file-01' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-file-01' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Empty file</p>
           </div>
@@ -460,7 +460,7 @@
           </a>
           <span about='#nt-syntax-file-02' property='mf:name'>nt-syntax-file-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-file-02' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-file-02' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Only comment</p>
           </div>
@@ -481,7 +481,7 @@
           </a>
           <span about='#nt-syntax-file-03' property='mf:name'>nt-syntax-file-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-file-03' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-file-03' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>One comment, one empty line</p>
           </div>
@@ -502,7 +502,7 @@
           </a>
           <span about='#nt-syntax-uri-01' property='mf:name'>nt-syntax-uri-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-uri-01' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-uri-01' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Only IRIs</p>
           </div>
@@ -523,7 +523,7 @@
           </a>
           <span about='#nt-syntax-uri-02' property='mf:name'>nt-syntax-uri-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-uri-02' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-uri-02' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>IRIs with Unicode escape</p>
           </div>
@@ -544,7 +544,7 @@
           </a>
           <span about='#nt-syntax-uri-03' property='mf:name'>nt-syntax-uri-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-uri-03' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-uri-03' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>IRIs with long Unicode escape</p>
           </div>
@@ -565,7 +565,7 @@
           </a>
           <span about='#nt-syntax-uri-04' property='mf:name'>nt-syntax-uri-04</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-uri-04' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-uri-04' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Legal IRIs</p>
           </div>
@@ -586,7 +586,7 @@
           </a>
           <span about='#nt-syntax-string-01' property='mf:name'>nt-syntax-string-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-string-01' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-string-01' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>string literal</p>
           </div>
@@ -607,7 +607,7 @@
           </a>
           <span about='#nt-syntax-string-02' property='mf:name'>nt-syntax-string-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-string-02' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-string-02' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>langString literal</p>
           </div>
@@ -628,7 +628,7 @@
           </a>
           <span about='#nt-syntax-string-03' property='mf:name'>nt-syntax-string-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-string-03' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-string-03' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>langString literal with region</p>
           </div>
@@ -649,7 +649,7 @@
           </a>
           <span about='#nt-syntax-str-esc-01' property='mf:name'>nt-syntax-str-esc-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-str-esc-01' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-str-esc-01' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>string literal with escaped newline</p>
           </div>
@@ -670,7 +670,7 @@
           </a>
           <span about='#nt-syntax-str-esc-02' property='mf:name'>nt-syntax-str-esc-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-str-esc-02' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-str-esc-02' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>string literal with Unicode escape</p>
           </div>
@@ -691,7 +691,7 @@
           </a>
           <span about='#nt-syntax-str-esc-03' property='mf:name'>nt-syntax-str-esc-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-str-esc-03' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-str-esc-03' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>string literal with long Unicode escape</p>
           </div>
@@ -712,7 +712,7 @@
           </a>
           <span about='#nt-syntax-bnode-01' property='mf:name'>nt-syntax-bnode-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bnode-01' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bnode-01' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>bnode subject</p>
           </div>
@@ -733,7 +733,7 @@
           </a>
           <span about='#nt-syntax-bnode-02' property='mf:name'>nt-syntax-bnode-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bnode-02' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bnode-02' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>bnode object</p>
           </div>
@@ -754,7 +754,7 @@
           </a>
           <span about='#nt-syntax-bnode-03' property='mf:name'>nt-syntax-bnode-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bnode-03' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bnode-03' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Blank node labels may start with a digit</p>
           </div>
@@ -775,7 +775,7 @@
           </a>
           <span about='#nt-syntax-datatypes-01' property='mf:name'>nt-syntax-datatypes-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-datatypes-01' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-datatypes-01' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>xsd:byte literal</p>
           </div>
@@ -796,7 +796,7 @@
           </a>
           <span about='#nt-syntax-datatypes-02' property='mf:name'>nt-syntax-datatypes-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-datatypes-02' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-datatypes-02' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>integer as xsd:string</p>
           </div>
@@ -817,7 +817,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-01' property='mf:name'>nt-syntax-bad-uri-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : space (negative test)</p>
           </div>
@@ -838,7 +838,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-02' property='mf:name'>nt-syntax-bad-uri-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-02' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-02' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : bad escape (negative test)</p>
           </div>
@@ -859,7 +859,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-03' property='mf:name'>nt-syntax-bad-uri-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-03' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-03' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : bad long escape (negative test)</p>
           </div>
@@ -880,7 +880,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-04' property='mf:name'>nt-syntax-bad-uri-04</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-04' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-04' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : character escapes not allowed (negative test)</p>
           </div>
@@ -901,7 +901,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-05' property='mf:name'>nt-syntax-bad-uri-05</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-05' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-05' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : character escapes not allowed (2) (negative test)</p>
           </div>
@@ -922,7 +922,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-06' property='mf:name'>nt-syntax-bad-uri-06</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-06' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-06' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : relative IRI not allowed in subject (negative test)</p>
           </div>
@@ -943,7 +943,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-07' property='mf:name'>nt-syntax-bad-uri-07</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-07' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-07' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : relative IRI not allowed in predicate (negative test)</p>
           </div>
@@ -964,7 +964,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-08' property='mf:name'>nt-syntax-bad-uri-08</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-08' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-08' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : relative IRI not allowed in object (negative test)</p>
           </div>
@@ -985,7 +985,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-09' property='mf:name'>nt-syntax-bad-uri-09</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-09' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-09' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : relative IRI not allowed in datatype (negative test)</p>
           </div>
@@ -1006,7 +1006,7 @@
           </a>
           <span about='#nt-syntax-bad-prefix-01' property='mf:name'>nt-syntax-bad-prefix-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-prefix-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-prefix-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>@prefix not allowed in N-Quads (negative test)</p>
           </div>
@@ -1027,7 +1027,7 @@
           </a>
           <span about='#nt-syntax-bad-base-01' property='mf:name'>nt-syntax-bad-base-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-base-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-base-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>@base not allowed in N-Quads (negative test)</p>
           </div>
@@ -1048,7 +1048,7 @@
           </a>
           <span about='#nt-syntax-bad-bnode-01' property='mf:name'>nt-syntax-bad-bnode-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-bnode-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-bnode-01' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Colon in bnode label not allowed (negative test)</p>
           </div>
@@ -1056,7 +1056,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-bnode-01.nq' property='mf:action'>nt-syntax-bad-bnode-01.nq</a>
@@ -1069,7 +1069,7 @@
           </a>
           <span about='#nt-syntax-bad-bnode-02' property='mf:name'>nt-syntax-bad-bnode-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-bnode-02' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-bnode-02' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Colon in bnode label not allowed (negative test)</p>
           </div>
@@ -1077,7 +1077,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-bnode-02.nq' property='mf:action'>nt-syntax-bad-bnode-02.nq</a>
@@ -1090,7 +1090,7 @@
           </a>
           <span about='#nt-syntax-bad-struct-01' property='mf:name'>nt-syntax-bad-struct-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-struct-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-struct-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>N-Quads does not have objectList (negative test)</p>
           </div>
@@ -1111,7 +1111,7 @@
           </a>
           <span about='#nt-syntax-bad-struct-02' property='mf:name'>nt-syntax-bad-struct-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-struct-02' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-struct-02' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>N-Quads does not have predicateObjectList (negative test)</p>
           </div>
@@ -1132,7 +1132,7 @@
           </a>
           <span about='#nt-syntax-bad-lang-01' property='mf:name'>nt-syntax-bad-lang-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-lang-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-lang-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>langString with bad lang (negative test)</p>
           </div>
@@ -1153,7 +1153,7 @@
           </a>
           <span about='#nt-syntax-bad-esc-01' property='mf:name'>nt-syntax-bad-esc-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-esc-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-esc-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad string escape (negative test)</p>
           </div>
@@ -1174,7 +1174,7 @@
           </a>
           <span about='#nt-syntax-bad-esc-02' property='mf:name'>nt-syntax-bad-esc-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-esc-02' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-esc-02' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad string escape (negative test)</p>
           </div>
@@ -1195,7 +1195,7 @@
           </a>
           <span about='#nt-syntax-bad-esc-03' property='mf:name'>nt-syntax-bad-esc-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-esc-03' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-esc-03' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad string escape (negative test)</p>
           </div>
@@ -1216,7 +1216,7 @@
           </a>
           <span about='#nt-syntax-bad-string-01' property='mf:name'>nt-syntax-bad-string-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>mismatching string literal open/close (negative test)</p>
           </div>
@@ -1237,7 +1237,7 @@
           </a>
           <span about='#nt-syntax-bad-string-02' property='mf:name'>nt-syntax-bad-string-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-02' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-02' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>mismatching string literal open/close (negative test)</p>
           </div>
@@ -1258,7 +1258,7 @@
           </a>
           <span about='#nt-syntax-bad-string-03' property='mf:name'>nt-syntax-bad-string-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-03' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-03' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>single quotes (negative test)</p>
           </div>
@@ -1279,7 +1279,7 @@
           </a>
           <span about='#nt-syntax-bad-string-04' property='mf:name'>nt-syntax-bad-string-04</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-04' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-04' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>long single string literal (negative test)</p>
           </div>
@@ -1300,7 +1300,7 @@
           </a>
           <span about='#nt-syntax-bad-string-05' property='mf:name'>nt-syntax-bad-string-05</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-05' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-05' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>long double string literal (negative test)</p>
           </div>
@@ -1321,7 +1321,7 @@
           </a>
           <span about='#nt-syntax-bad-string-06' property='mf:name'>nt-syntax-bad-string-06</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-06' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-06' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>string literal with no end (negative test)</p>
           </div>
@@ -1342,7 +1342,7 @@
           </a>
           <span about='#nt-syntax-bad-string-07' property='mf:name'>nt-syntax-bad-string-07</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-07' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-07' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>string literal with no start (negative test)</p>
           </div>
@@ -1363,7 +1363,7 @@
           </a>
           <span about='#nt-syntax-bad-num-01' property='mf:name'>nt-syntax-bad-num-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-num-01' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-num-01' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>no numbers in N-Quads (integer) (negative test)</p>
           </div>
@@ -1384,7 +1384,7 @@
           </a>
           <span about='#nt-syntax-bad-num-02' property='mf:name'>nt-syntax-bad-num-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-num-02' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-num-02' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>no numbers in N-Quads (decimal) (negative test)</p>
           </div>
@@ -1405,7 +1405,7 @@
           </a>
           <span about='#nt-syntax-bad-num-03' property='mf:name'>nt-syntax-bad-num-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-num-03' typeof='rdft:TestNQuadsNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-num-03' typeof='rdft:TestNQuadsNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>no numbers in N-Quads (float) (negative test)</p>
           </div>
@@ -1426,7 +1426,7 @@
           </a>
           <span about='#nt-syntax-subm-01' property='mf:name'>nt-syntax-subm-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-subm-01' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-subm-01' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Submission test from Original RDF Test Cases</p>
           </div>
@@ -1447,7 +1447,7 @@
           </a>
           <span about='#comment_following_triple' property='mf:name'>comment_following_triple</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#comment_following_triple' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#comment_following_triple' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Tests comments after a triple</p>
           </div>
@@ -1468,7 +1468,7 @@
           </a>
           <span about='#literal' property='mf:name'>literal</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal &quot;&quot;&quot;x&quot;&quot;&quot;</p>
           </div>
@@ -1489,7 +1489,7 @@
           </a>
           <span about='#literal_all_controls' property='mf:name'>literal_all_controls</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_all_controls' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_all_controls' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal<em>all</em>controls &#39;\x00\x01\x02\x03\x04...&#39;</p>
           </div>
@@ -1510,7 +1510,7 @@
           </a>
           <span about='#literal_all_punctuation' property='mf:name'>literal_all_punctuation</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_all_punctuation' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_all_punctuation' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal<em>all</em>punctuation &#39;!&quot;#$%&amp;()...&#39;</p>
           </div>
@@ -1531,7 +1531,7 @@
           </a>
           <span about='#literal_ascii_boundaries' property='mf:name'>literal_ascii_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_ascii_boundaries' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_ascii_boundaries' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal<em>ascii</em>boundaries &#39;\x00\x26\x28...&#39;</p>
           </div>
@@ -1552,7 +1552,7 @@
           </a>
           <span about='#literal_with_2_dquotes' property='mf:name'>literal_with_2_dquotes</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_2_dquotes' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_2_dquotes' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with 2 squotes &quot;&quot;&quot;a&quot;&quot;b&quot;&quot;&quot;</p>
           </div>
@@ -1573,7 +1573,7 @@
           </a>
           <span about='#literal_with_2_squotes' property='mf:name'>literal_with_2_squotes</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_2_squotes' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_2_squotes' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with 2 squotes &quot;x&#39;&#39;y&quot;</p>
           </div>
@@ -1594,7 +1594,7 @@
           </a>
           <span about='#literal_with_BACKSPACE' property='mf:name'>literal_with_BACKSPACE</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_BACKSPACE' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_BACKSPACE' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with BACKSPACE</p>
           </div>
@@ -1615,7 +1615,7 @@
           </a>
           <span about='#literal_with_CARRIAGE_RETURN' property='mf:name'>literal_with_CARRIAGE_RETURN</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_CARRIAGE_RETURN' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_CARRIAGE_RETURN' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with CARRIAGE RETURN</p>
           </div>
@@ -1636,7 +1636,7 @@
           </a>
           <span about='#literal_with_CHARACTER_TABULATION' property='mf:name'>literal_with_CHARACTER_TABULATION</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_CHARACTER_TABULATION' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_CHARACTER_TABULATION' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with CHARACTER TABULATION</p>
           </div>
@@ -1657,7 +1657,7 @@
           </a>
           <span about='#literal_with_dquote' property='mf:name'>literal_with_dquote</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_dquote' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_dquote' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with dquote &quot;x&quot;y&quot;</p>
           </div>
@@ -1678,7 +1678,7 @@
           </a>
           <span about='#literal_with_FORM_FEED' property='mf:name'>literal_with_FORM_FEED</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_FORM_FEED' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_FORM_FEED' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with FORM FEED</p>
           </div>
@@ -1699,7 +1699,7 @@
           </a>
           <span about='#literal_with_LINE_FEED' property='mf:name'>literal_with_LINE_FEED</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_LINE_FEED' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_LINE_FEED' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with LINE FEED</p>
           </div>
@@ -1720,7 +1720,7 @@
           </a>
           <span about='#literal_with_numeric_escape4' property='mf:name'>literal_with_numeric_escape4</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_numeric_escape4' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_numeric_escape4' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with numeric escape4 \u</p>
           </div>
@@ -1741,7 +1741,7 @@
           </a>
           <span about='#literal_with_numeric_escape8' property='mf:name'>literal_with_numeric_escape8</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_numeric_escape8' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_numeric_escape8' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with numeric escape8 \U</p>
           </div>
@@ -1762,7 +1762,7 @@
           </a>
           <span about='#literal_with_REVERSE_SOLIDUS' property='mf:name'>literal_with_REVERSE_SOLIDUS</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with REVERSE SOLIDUS</p>
           </div>
@@ -1783,7 +1783,7 @@
           </a>
           <span about='#literal_with_REVERSE_SOLIDUS2' property='mf:name'>literal_with_REVERSE_SOLIDUS2</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS2' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS2' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>REVERSE SOLIDUS at end of literal</p>
           </div>
@@ -1804,7 +1804,7 @@
           </a>
           <span about='#literal_with_squote' property='mf:name'>literal_with_squote</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_squote' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_squote' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with squote &quot;x&#39;y&quot;</p>
           </div>
@@ -1825,7 +1825,7 @@
           </a>
           <span about='#literal_with_UTF8_boundaries' property='mf:name'>literal_with_UTF8_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_UTF8_boundaries' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_UTF8_boundaries' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal<em>with</em>UTF8_boundaries &#39;\x80\x7ff\x800\xfff...&#39;</p>
           </div>
@@ -1846,7 +1846,7 @@
           </a>
           <span about='#langtagged_string' property='mf:name'>langtagged_string</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#langtagged_string' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#langtagged_string' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>langtagged string &quot;x&quot;@en</p>
           </div>
@@ -1867,7 +1867,7 @@
           </a>
           <span about='#lantag_with_subtag' property='mf:name'>lantag_with_subtag</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#lantag_with_subtag' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#lantag_with_subtag' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>lantag with subtag &quot;x&quot;@en-us</p>
           </div>
@@ -1888,7 +1888,7 @@
           </a>
           <span about='#minimal_whitespace' property='mf:name'>minimal_whitespace</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#minimal_whitespace' typeof='rdft:TestNQuadsPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#minimal_whitespace' typeof='rdft:TestNQuadsPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>tests absense of whitespace between subject, predicate, object and end-of-statement</p>
           </div>

--- a/rdf/rdf11/rdf-n-triples/index.html
+++ b/rdf/rdf11/rdf-n-triples/index.html
@@ -82,7 +82,7 @@
           </a>
           <span about='#nt-syntax-file-01' property='mf:name'>nt-syntax-file-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-file-01' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-file-01' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Empty file</p>
           </div>
@@ -90,7 +90,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-file-01.nt' property='mf:action'>nt-syntax-file-01.nt</a>
@@ -103,7 +103,7 @@
           </a>
           <span about='#nt-syntax-file-02' property='mf:name'>nt-syntax-file-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-file-02' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-file-02' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Only comment</p>
           </div>
@@ -111,7 +111,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-file-02.nt' property='mf:action'>nt-syntax-file-02.nt</a>
@@ -124,7 +124,7 @@
           </a>
           <span about='#nt-syntax-file-03' property='mf:name'>nt-syntax-file-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-file-03' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-file-03' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>One comment, one empty line</p>
           </div>
@@ -132,7 +132,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-file-03.nt' property='mf:action'>nt-syntax-file-03.nt</a>
@@ -145,7 +145,7 @@
           </a>
           <span about='#nt-syntax-uri-01' property='mf:name'>nt-syntax-uri-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-uri-01' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-uri-01' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Only IRIs</p>
           </div>
@@ -153,7 +153,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-uri-01.nt' property='mf:action'>nt-syntax-uri-01.nt</a>
@@ -166,7 +166,7 @@
           </a>
           <span about='#nt-syntax-uri-02' property='mf:name'>nt-syntax-uri-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-uri-02' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-uri-02' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>IRIs with Unicode escape</p>
           </div>
@@ -174,7 +174,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-uri-02.nt' property='mf:action'>nt-syntax-uri-02.nt</a>
@@ -187,7 +187,7 @@
           </a>
           <span about='#nt-syntax-uri-03' property='mf:name'>nt-syntax-uri-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-uri-03' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-uri-03' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>IRIs with long Unicode escape</p>
           </div>
@@ -195,7 +195,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-uri-03.nt' property='mf:action'>nt-syntax-uri-03.nt</a>
@@ -208,7 +208,7 @@
           </a>
           <span about='#nt-syntax-uri-04' property='mf:name'>nt-syntax-uri-04</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-uri-04' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-uri-04' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Legal IRIs</p>
           </div>
@@ -216,7 +216,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-uri-04.nt' property='mf:action'>nt-syntax-uri-04.nt</a>
@@ -229,7 +229,7 @@
           </a>
           <span about='#nt-syntax-string-01' property='mf:name'>nt-syntax-string-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-string-01' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-string-01' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>string literal</p>
           </div>
@@ -237,7 +237,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-string-01.nt' property='mf:action'>nt-syntax-string-01.nt</a>
@@ -250,7 +250,7 @@
           </a>
           <span about='#nt-syntax-string-02' property='mf:name'>nt-syntax-string-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-string-02' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-string-02' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>langString literal</p>
           </div>
@@ -258,7 +258,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-string-02.nt' property='mf:action'>nt-syntax-string-02.nt</a>
@@ -271,7 +271,7 @@
           </a>
           <span about='#nt-syntax-string-03' property='mf:name'>nt-syntax-string-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-string-03' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-string-03' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>langString literal with region</p>
           </div>
@@ -279,7 +279,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-string-03.nt' property='mf:action'>nt-syntax-string-03.nt</a>
@@ -292,7 +292,7 @@
           </a>
           <span about='#nt-syntax-str-esc-01' property='mf:name'>nt-syntax-str-esc-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-str-esc-01' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-str-esc-01' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>string literal with escaped newline</p>
           </div>
@@ -300,7 +300,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-str-esc-01.nt' property='mf:action'>nt-syntax-str-esc-01.nt</a>
@@ -313,7 +313,7 @@
           </a>
           <span about='#nt-syntax-str-esc-02' property='mf:name'>nt-syntax-str-esc-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-str-esc-02' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-str-esc-02' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>string literal with Unicode escape</p>
           </div>
@@ -321,7 +321,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-str-esc-02.nt' property='mf:action'>nt-syntax-str-esc-02.nt</a>
@@ -334,7 +334,7 @@
           </a>
           <span about='#nt-syntax-str-esc-03' property='mf:name'>nt-syntax-str-esc-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-str-esc-03' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-str-esc-03' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>string literal with long Unicode escape</p>
           </div>
@@ -342,7 +342,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-str-esc-03.nt' property='mf:action'>nt-syntax-str-esc-03.nt</a>
@@ -355,7 +355,7 @@
           </a>
           <span about='#nt-syntax-bnode-01' property='mf:name'>nt-syntax-bnode-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bnode-01' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bnode-01' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>bnode subject</p>
           </div>
@@ -363,7 +363,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bnode-01.nt' property='mf:action'>nt-syntax-bnode-01.nt</a>
@@ -376,7 +376,7 @@
           </a>
           <span about='#nt-syntax-bnode-02' property='mf:name'>nt-syntax-bnode-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bnode-02' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bnode-02' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>bnode object</p>
           </div>
@@ -384,7 +384,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bnode-02.nt' property='mf:action'>nt-syntax-bnode-02.nt</a>
@@ -397,7 +397,7 @@
           </a>
           <span about='#nt-syntax-bnode-03' property='mf:name'>nt-syntax-bnode-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bnode-03' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bnode-03' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Blank node labels may start with a digit</p>
           </div>
@@ -405,7 +405,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bnode-03.nt' property='mf:action'>nt-syntax-bnode-03.nt</a>
@@ -418,7 +418,7 @@
           </a>
           <span about='#nt-syntax-datatypes-01' property='mf:name'>nt-syntax-datatypes-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-datatypes-01' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-datatypes-01' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>xsd:byte literal</p>
           </div>
@@ -426,7 +426,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-datatypes-01.nt' property='mf:action'>nt-syntax-datatypes-01.nt</a>
@@ -439,7 +439,7 @@
           </a>
           <span about='#nt-syntax-datatypes-02' property='mf:name'>nt-syntax-datatypes-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-datatypes-02' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-datatypes-02' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>integer as xsd:string</p>
           </div>
@@ -447,7 +447,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-datatypes-02.nt' property='mf:action'>nt-syntax-datatypes-02.nt</a>
@@ -460,7 +460,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-01' property='mf:name'>nt-syntax-bad-uri-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-01' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : space (negative test)</p>
           </div>
@@ -468,7 +468,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-uri-01.nt' property='mf:action'>nt-syntax-bad-uri-01.nt</a>
@@ -481,7 +481,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-02' property='mf:name'>nt-syntax-bad-uri-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-02' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-02' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : bad escape (negative test)</p>
           </div>
@@ -489,7 +489,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-uri-02.nt' property='mf:action'>nt-syntax-bad-uri-02.nt</a>
@@ -502,7 +502,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-03' property='mf:name'>nt-syntax-bad-uri-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-03' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-03' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : bad long escape (negative test)</p>
           </div>
@@ -510,7 +510,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-uri-03.nt' property='mf:action'>nt-syntax-bad-uri-03.nt</a>
@@ -523,7 +523,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-04' property='mf:name'>nt-syntax-bad-uri-04</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-04' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-04' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : character escapes not allowed (negative test)</p>
           </div>
@@ -531,7 +531,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-uri-04.nt' property='mf:action'>nt-syntax-bad-uri-04.nt</a>
@@ -544,7 +544,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-05' property='mf:name'>nt-syntax-bad-uri-05</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-05' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-05' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : character escapes not allowed (2) (negative test)</p>
           </div>
@@ -552,7 +552,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-uri-05.nt' property='mf:action'>nt-syntax-bad-uri-05.nt</a>
@@ -565,7 +565,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-06' property='mf:name'>nt-syntax-bad-uri-06</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-06' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-06' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : relative IRI not allowed in subject (negative test)</p>
           </div>
@@ -573,7 +573,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-uri-06.nt' property='mf:action'>nt-syntax-bad-uri-06.nt</a>
@@ -586,7 +586,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-07' property='mf:name'>nt-syntax-bad-uri-07</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-07' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-07' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : relative IRI not allowed in predicate (negative test)</p>
           </div>
@@ -594,7 +594,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-uri-07.nt' property='mf:action'>nt-syntax-bad-uri-07.nt</a>
@@ -607,7 +607,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-08' property='mf:name'>nt-syntax-bad-uri-08</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-08' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-08' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : relative IRI not allowed in object (negative test)</p>
           </div>
@@ -615,7 +615,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-uri-08.nt' property='mf:action'>nt-syntax-bad-uri-08.nt</a>
@@ -628,7 +628,7 @@
           </a>
           <span about='#nt-syntax-bad-uri-09' property='mf:name'>nt-syntax-bad-uri-09</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-uri-09' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-uri-09' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad IRI : relative IRI not allowed in datatype (negative test)</p>
           </div>
@@ -636,7 +636,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-uri-09.nt' property='mf:action'>nt-syntax-bad-uri-09.nt</a>
@@ -649,7 +649,7 @@
           </a>
           <span about='#nt-syntax-bad-prefix-01' property='mf:name'>nt-syntax-bad-prefix-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-prefix-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-prefix-01' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>@prefix not allowed in n-triples (negative test)</p>
           </div>
@@ -657,7 +657,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-prefix-01.nt' property='mf:action'>nt-syntax-bad-prefix-01.nt</a>
@@ -670,7 +670,7 @@
           </a>
           <span about='#nt-syntax-bad-base-01' property='mf:name'>nt-syntax-bad-base-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-base-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-base-01' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>@base not allowed in N-Triples (negative test)</p>
           </div>
@@ -678,7 +678,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-base-01.nt' property='mf:action'>nt-syntax-bad-base-01.nt</a>
@@ -691,7 +691,7 @@
           </a>
           <span about='#nt-syntax-bad-bnode-01' property='mf:name'>nt-syntax-bad-bnode-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-bnode-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-bnode-01' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Colon in bnode label not allowed (negative test)</p>
           </div>
@@ -699,7 +699,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-bnode-01.nt' property='mf:action'>nt-syntax-bad-bnode-01.nt</a>
@@ -712,7 +712,7 @@
           </a>
           <span about='#nt-syntax-bad-bnode-02' property='mf:name'>nt-syntax-bad-bnode-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-bnode-02' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-bnode-02' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Colon in bnode label not allowed (negative test)</p>
           </div>
@@ -720,7 +720,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-bnode-02.nt' property='mf:action'>nt-syntax-bad-bnode-02.nt</a>
@@ -733,7 +733,7 @@
           </a>
           <span about='#nt-syntax-bad-struct-01' property='mf:name'>nt-syntax-bad-struct-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-struct-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-struct-01' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>N-Triples does not have objectList (negative test)</p>
           </div>
@@ -741,7 +741,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-struct-01.nt' property='mf:action'>nt-syntax-bad-struct-01.nt</a>
@@ -754,7 +754,7 @@
           </a>
           <span about='#nt-syntax-bad-struct-02' property='mf:name'>nt-syntax-bad-struct-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-struct-02' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-struct-02' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>N-Triples does not have predicateObjectList (negative test)</p>
           </div>
@@ -762,7 +762,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-struct-02.nt' property='mf:action'>nt-syntax-bad-struct-02.nt</a>
@@ -775,7 +775,7 @@
           </a>
           <span about='#nt-syntax-bad-lang-01' property='mf:name'>nt-syntax-bad-lang-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-lang-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-lang-01' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>langString with bad lang (negative test)</p>
           </div>
@@ -783,7 +783,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-lang-01.nt' property='mf:action'>nt-syntax-bad-lang-01.nt</a>
@@ -796,7 +796,7 @@
           </a>
           <span about='#nt-syntax-bad-esc-01' property='mf:name'>nt-syntax-bad-esc-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-esc-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-esc-01' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad string escape (negative test)</p>
           </div>
@@ -804,7 +804,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-esc-01.nt' property='mf:action'>nt-syntax-bad-esc-01.nt</a>
@@ -817,7 +817,7 @@
           </a>
           <span about='#nt-syntax-bad-esc-02' property='mf:name'>nt-syntax-bad-esc-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-esc-02' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-esc-02' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad string escape (negative test)</p>
           </div>
@@ -825,7 +825,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-esc-02.nt' property='mf:action'>nt-syntax-bad-esc-02.nt</a>
@@ -838,7 +838,7 @@
           </a>
           <span about='#nt-syntax-bad-esc-03' property='mf:name'>nt-syntax-bad-esc-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-esc-03' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-esc-03' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Bad string escape (negative test)</p>
           </div>
@@ -846,7 +846,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-esc-03.nt' property='mf:action'>nt-syntax-bad-esc-03.nt</a>
@@ -859,7 +859,7 @@
           </a>
           <span about='#nt-syntax-bad-string-01' property='mf:name'>nt-syntax-bad-string-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-01' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>mismatching string literal open/close (negative test)</p>
           </div>
@@ -867,7 +867,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-string-01.nt' property='mf:action'>nt-syntax-bad-string-01.nt</a>
@@ -880,7 +880,7 @@
           </a>
           <span about='#nt-syntax-bad-string-02' property='mf:name'>nt-syntax-bad-string-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-02' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-02' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>mismatching string literal open/close (negative test)</p>
           </div>
@@ -888,7 +888,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-string-02.nt' property='mf:action'>nt-syntax-bad-string-02.nt</a>
@@ -901,7 +901,7 @@
           </a>
           <span about='#nt-syntax-bad-string-03' property='mf:name'>nt-syntax-bad-string-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-03' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-03' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>single quotes (negative test)</p>
           </div>
@@ -909,7 +909,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-string-03.nt' property='mf:action'>nt-syntax-bad-string-03.nt</a>
@@ -922,7 +922,7 @@
           </a>
           <span about='#nt-syntax-bad-string-04' property='mf:name'>nt-syntax-bad-string-04</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-04' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-04' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>long single string literal (negative test)</p>
           </div>
@@ -930,7 +930,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-string-04.nt' property='mf:action'>nt-syntax-bad-string-04.nt</a>
@@ -943,7 +943,7 @@
           </a>
           <span about='#nt-syntax-bad-string-05' property='mf:name'>nt-syntax-bad-string-05</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-05' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-05' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>long double string literal (negative test)</p>
           </div>
@@ -951,7 +951,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-string-05.nt' property='mf:action'>nt-syntax-bad-string-05.nt</a>
@@ -964,7 +964,7 @@
           </a>
           <span about='#nt-syntax-bad-string-06' property='mf:name'>nt-syntax-bad-string-06</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-06' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-06' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>string literal with no end (negative test)</p>
           </div>
@@ -972,7 +972,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-string-06.nt' property='mf:action'>nt-syntax-bad-string-06.nt</a>
@@ -985,7 +985,7 @@
           </a>
           <span about='#nt-syntax-bad-string-07' property='mf:name'>nt-syntax-bad-string-07</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-string-07' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-string-07' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>string literal with no start (negative test)</p>
           </div>
@@ -993,7 +993,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-string-07.nt' property='mf:action'>nt-syntax-bad-string-07.nt</a>
@@ -1006,7 +1006,7 @@
           </a>
           <span about='#nt-syntax-bad-num-01' property='mf:name'>nt-syntax-bad-num-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-num-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-num-01' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>no numbers in N-Triples (integer) (negative test)</p>
           </div>
@@ -1014,7 +1014,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-num-01.nt' property='mf:action'>nt-syntax-bad-num-01.nt</a>
@@ -1027,7 +1027,7 @@
           </a>
           <span about='#nt-syntax-bad-num-02' property='mf:name'>nt-syntax-bad-num-02</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-num-02' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-num-02' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>no numbers in N-Triples (decimal) (negative test)</p>
           </div>
@@ -1035,7 +1035,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-num-02.nt' property='mf:action'>nt-syntax-bad-num-02.nt</a>
@@ -1048,7 +1048,7 @@
           </a>
           <span about='#nt-syntax-bad-num-03' property='mf:name'>nt-syntax-bad-num-03</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-bad-num-03' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-bad-num-03' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>no numbers in N-Triples (float) (negative test)</p>
           </div>
@@ -1056,7 +1056,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesNegativeSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-bad-num-03.nt' property='mf:action'>nt-syntax-bad-num-03.nt</a>
@@ -1069,7 +1069,7 @@
           </a>
           <span about='#nt-syntax-subm-01' property='mf:name'>nt-syntax-subm-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#nt-syntax-subm-01' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#nt-syntax-subm-01' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Submission test from Original RDF Test Cases</p>
           </div>
@@ -1077,7 +1077,7 @@
             <dt>type</dt>
             <dd>rdft:TestNTriplesPositiveSyntax</dd>
             <dt>approval</dt>
-            <dd property='mf:approval'></dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='nt-syntax-subm-01.nt' property='mf:action'>nt-syntax-subm-01.nt</a>
@@ -1090,7 +1090,7 @@
           </a>
           <span about='#comment_following_triple' property='mf:name'>comment_following_triple</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#comment_following_triple' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#comment_following_triple' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>Tests comments after a triple</p>
           </div>
@@ -1111,7 +1111,7 @@
           </a>
           <span about='#literal' property='mf:name'>literal</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal &quot;&quot;&quot;x&quot;&quot;&quot;</p>
           </div>
@@ -1132,7 +1132,7 @@
           </a>
           <span about='#literal_all_controls' property='mf:name'>literal_all_controls</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_all_controls' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_all_controls' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal<em>all</em>controls &#39;\x00\x01\x02\x03\x04...&#39;</p>
           </div>
@@ -1153,7 +1153,7 @@
           </a>
           <span about='#literal_all_punctuation' property='mf:name'>literal_all_punctuation</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_all_punctuation' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_all_punctuation' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal<em>all</em>punctuation &#39;!&quot;#$%&amp;()...&#39;</p>
           </div>
@@ -1174,7 +1174,7 @@
           </a>
           <span about='#literal_ascii_boundaries' property='mf:name'>literal_ascii_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_ascii_boundaries' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_ascii_boundaries' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal<em>ascii</em>boundaries &#39;\x00\x26\x28...&#39;</p>
           </div>
@@ -1195,7 +1195,7 @@
           </a>
           <span about='#literal_with_2_dquotes' property='mf:name'>literal_with_2_dquotes</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_2_dquotes' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_2_dquotes' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with 2 squotes &quot;&quot;&quot;a&quot;&quot;b&quot;&quot;&quot;</p>
           </div>
@@ -1216,7 +1216,7 @@
           </a>
           <span about='#literal_with_2_squotes' property='mf:name'>literal_with_2_squotes</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_2_squotes' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_2_squotes' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with 2 squotes &quot;x&#39;&#39;y&quot;</p>
           </div>
@@ -1237,7 +1237,7 @@
           </a>
           <span about='#literal_with_BACKSPACE' property='mf:name'>literal_with_BACKSPACE</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_BACKSPACE' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_BACKSPACE' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with BACKSPACE</p>
           </div>
@@ -1258,7 +1258,7 @@
           </a>
           <span about='#literal_with_CARRIAGE_RETURN' property='mf:name'>literal_with_CARRIAGE_RETURN</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_CARRIAGE_RETURN' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_CARRIAGE_RETURN' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with CARRIAGE RETURN</p>
           </div>
@@ -1279,7 +1279,7 @@
           </a>
           <span about='#literal_with_CHARACTER_TABULATION' property='mf:name'>literal_with_CHARACTER_TABULATION</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_CHARACTER_TABULATION' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_CHARACTER_TABULATION' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with CHARACTER TABULATION</p>
           </div>
@@ -1300,7 +1300,7 @@
           </a>
           <span about='#literal_with_dquote' property='mf:name'>literal_with_dquote</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_dquote' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_dquote' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with dquote &quot;x&quot;y&quot;</p>
           </div>
@@ -1321,7 +1321,7 @@
           </a>
           <span about='#literal_with_FORM_FEED' property='mf:name'>literal_with_FORM_FEED</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_FORM_FEED' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_FORM_FEED' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with FORM FEED</p>
           </div>
@@ -1342,7 +1342,7 @@
           </a>
           <span about='#literal_with_LINE_FEED' property='mf:name'>literal_with_LINE_FEED</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_LINE_FEED' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_LINE_FEED' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with LINE FEED</p>
           </div>
@@ -1363,7 +1363,7 @@
           </a>
           <span about='#literal_with_numeric_escape4' property='mf:name'>literal_with_numeric_escape4</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_numeric_escape4' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_numeric_escape4' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with numeric escape4 \u</p>
           </div>
@@ -1384,7 +1384,7 @@
           </a>
           <span about='#literal_with_numeric_escape8' property='mf:name'>literal_with_numeric_escape8</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_numeric_escape8' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_numeric_escape8' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with numeric escape8 \U</p>
           </div>
@@ -1405,7 +1405,7 @@
           </a>
           <span about='#literal_with_REVERSE_SOLIDUS' property='mf:name'>literal_with_REVERSE_SOLIDUS</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with REVERSE SOLIDUS</p>
           </div>
@@ -1426,7 +1426,7 @@
           </a>
           <span about='#literal_with_REVERSE_SOLIDUS2' property='mf:name'>literal_with_REVERSE_SOLIDUS2</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS2' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS2' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>REVERSE SOLIDUS at end of literal</p>
           </div>
@@ -1447,7 +1447,7 @@
           </a>
           <span about='#literal_with_squote' property='mf:name'>literal_with_squote</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_squote' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_squote' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal with squote &quot;x&#39;y&quot;</p>
           </div>
@@ -1468,7 +1468,7 @@
           </a>
           <span about='#literal_with_UTF8_boundaries' property='mf:name'>literal_with_UTF8_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#literal_with_UTF8_boundaries' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#literal_with_UTF8_boundaries' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>literal<em>with</em>UTF8_boundaries &#39;\x80\x7ff\x800\xfff...&#39;</p>
           </div>
@@ -1489,7 +1489,7 @@
           </a>
           <span about='#langtagged_string' property='mf:name'>langtagged_string</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#langtagged_string' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#langtagged_string' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>langtagged string &quot;x&quot;@en</p>
           </div>
@@ -1510,7 +1510,7 @@
           </a>
           <span about='#lantag_with_subtag' property='mf:name'>lantag_with_subtag</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#lantag_with_subtag' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#lantag_with_subtag' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>lantag with subtag &quot;x&quot;@en-us</p>
           </div>
@@ -1531,7 +1531,7 @@
           </a>
           <span about='#minimal_whitespace' property='mf:name'>minimal_whitespace</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#minimal_whitespace' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#minimal_whitespace' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>tests absense of whitespace between subject, predicate, object and end-of-statement</p>
           </div>

--- a/rdf/rdf11/rdf-trig/index.html
+++ b/rdf/rdf11/rdf-trig/index.html
@@ -82,7 +82,7 @@
           </a>
           <span about='#anonymous_blank_node_graph' property='mf:name'>anonymous_blank_node_graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#anonymous_blank_node_graph' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#anonymous_blank_node_graph' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>anonymous blank node graph</p>
           </div>
@@ -107,7 +107,7 @@
           </a>
           <span about='#labeled_blank_node_graph' property='mf:name'>labeled_blank_node_graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_graph' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_graph' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node graph</p>
           </div>
@@ -132,7 +132,7 @@
           </a>
           <span about='#alternating_iri_graphs' property='mf:name'>alternating_iri_graphs</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#alternating_iri_graphs' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#alternating_iri_graphs' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>alternating graphs with IRI names</p>
           </div>
@@ -157,7 +157,7 @@
           </a>
           <span about='#alternating_bnode_graphs' property='mf:name'>alternating_bnode_graphs</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#alternating_bnode_graphs' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#alternating_bnode_graphs' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>alternating graphs with BNode names</p>
           </div>
@@ -182,7 +182,7 @@
           </a>
           <span about='#trig-syntax-bad-base-04' property='mf:name'>trig-syntax-bad-base-04</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#trig-syntax-bad-base-04' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-base-04' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>@base inside graph (negative test)</p>
           </div>
@@ -203,7 +203,7 @@
           </a>
           <span about='#trig-syntax-bad-base-05' property='mf:name'>trig-syntax-bad-base-05</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#trig-syntax-bad-base-05' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-base-05' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>BASE inside graph (negative test)</p>
           </div>
@@ -224,7 +224,7 @@
           </a>
           <span about='#trig-syntax-bad-prefix-06' property='mf:name'>trig-syntax-bad-prefix-06</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#trig-syntax-bad-prefix-06' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-prefix-06' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>@prefix inside graph (negative test)</p>
           </div>
@@ -245,7 +245,7 @@
           </a>
           <span about='#trig-syntax-bad-prefix-07' property='mf:name'>trig-syntax-bad-prefix-07</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#trig-syntax-bad-prefix-07' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-prefix-07' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>PREFIX inside graph (negative test)</p>
           </div>
@@ -266,7 +266,7 @@
           </a>
           <span about='#trig-syntax-struct-06' property='mf:name'>trig-syntax-struct-06</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#trig-syntax-struct-06' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#trig-syntax-struct-06' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>missing &#39;.&#39;</p>
           </div>
@@ -287,7 +287,7 @@
           </a>
           <span about='#trig-syntax-struct-07' property='mf:name'>trig-syntax-struct-07</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#trig-syntax-struct-07' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#trig-syntax-struct-07' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>trailing &#39;;&#39; no &#39;.&#39;</p>
           </div>
@@ -308,7 +308,7 @@
           </a>
           <span about='#trig-syntax-minimal-whitespace-01' property='mf:name'>trig-syntax-minimal-whitespace-01</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#trig-syntax-minimal-whitespace-01' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#trig-syntax-minimal-whitespace-01' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
             <p>tests absense of whitespace in various positions</p>
           </div>
@@ -329,7 +329,7 @@
           </a>
           <span about='#IRI_subject' property='mf:name'>IRI_subject</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#IRI_subject' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#IRI_subject' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>IRI subject</p>
           </div>
@@ -354,7 +354,7 @@
           </a>
           <span about='#IRI_with_four_digit_numeric_escape' property='mf:name'>IRI_with_four_digit_numeric_escape</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#IRI_with_four_digit_numeric_escape' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#IRI_with_four_digit_numeric_escape' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>IRI with four digit numeric escape (\u)</p>
           </div>
@@ -379,7 +379,7 @@
           </a>
           <span about='#IRI_with_eight_digit_numeric_escape' property='mf:name'>IRI_with_eight_digit_numeric_escape</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#IRI_with_eight_digit_numeric_escape' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#IRI_with_eight_digit_numeric_escape' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>IRI with eight digit numeric escape (\U)</p>
           </div>
@@ -404,7 +404,7 @@
           </a>
           <span about='#IRI_with_all_punctuation' property='mf:name'>IRI_with_all_punctuation</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#IRI_with_all_punctuation' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#IRI_with_all_punctuation' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>IRI with all punctuation</p>
           </div>
@@ -429,7 +429,7 @@
           </a>
           <span about='#bareword_a_predicate' property='mf:name'>bareword_a_predicate</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#bareword_a_predicate' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#bareword_a_predicate' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>bareword a predicate</p>
           </div>
@@ -454,7 +454,7 @@
           </a>
           <span about='#old_style_prefix' property='mf:name'>old_style_prefix</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#old_style_prefix' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#old_style_prefix' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>old-style prefix</p>
           </div>
@@ -479,7 +479,7 @@
           </a>
           <span about='#SPARQL_style_prefix' property='mf:name'>SPARQL_style_prefix</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#SPARQL_style_prefix' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#SPARQL_style_prefix' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>SPARQL-style prefix</p>
           </div>
@@ -504,7 +504,7 @@
           </a>
           <span about='#prefixed_IRI_predicate' property='mf:name'>prefixed_IRI_predicate</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefixed_IRI_predicate' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefixed_IRI_predicate' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>prefixed IRI predicate</p>
           </div>
@@ -529,7 +529,7 @@
           </a>
           <span about='#prefixed_IRI_object' property='mf:name'>prefixed_IRI_object</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefixed_IRI_object' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefixed_IRI_object' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>prefixed IRI object</p>
           </div>
@@ -554,7 +554,7 @@
           </a>
           <span about='#prefix_only_IRI' property='mf:name'>prefix_only_IRI</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefix_only_IRI' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefix_only_IRI' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>prefix-only IRI (p:)</p>
           </div>
@@ -579,7 +579,7 @@
           </a>
           <span about='#prefix_with_PN_CHARS_BASE_character_boundaries' property='mf:name'>prefix_with_PN_CHARS_BASE_character_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefix_with_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefix_with_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>prefix with PN CHARS BASE character boundaries (prefix: AZazÀÖØöø...:)</p>
           </div>
@@ -604,7 +604,7 @@
           </a>
           <span about='#prefix_with_non_leading_extras' property='mf:name'>prefix_with_non_leading_extras</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefix_with_non_leading_extras' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefix_with_non_leading_extras' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>prefix with<em>non</em>leading<em>extras (</em>:a·̀ͯ‿.⁀)</p>
           </div>
@@ -629,7 +629,7 @@
           </a>
           <span about='#default_namespace_IRI' property='mf:name'>default_namespace_IRI</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#default_namespace_IRI' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#default_namespace_IRI' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>default namespace IRI (:ln)</p>
           </div>
@@ -654,7 +654,7 @@
           </a>
           <span about='#prefix_reassigned_and_used' property='mf:name'>prefix_reassigned_and_used</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefix_reassigned_and_used' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefix_reassigned_and_used' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>prefix reassigned and used</p>
           </div>
@@ -679,7 +679,7 @@
           </a>
           <span about='#reserved_escaped_localName' property='mf:name'>reserved_escaped_localName</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#reserved_escaped_localName' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#reserved_escaped_localName' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>reserved-escaped local name</p>
           </div>
@@ -704,7 +704,7 @@
           </a>
           <span about='#percent_escaped_localName' property='mf:name'>percent_escaped_localName</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#percent_escaped_localName' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#percent_escaped_localName' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>percent-escaped local name</p>
           </div>
@@ -729,7 +729,7 @@
           </a>
           <span about='#HYPHEN_MINUS_in_localName' property='mf:name'>HYPHEN_MINUS_in_localName</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#HYPHEN_MINUS_in_localName' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#HYPHEN_MINUS_in_localName' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>HYPHEN-MINUS in local name</p>
           </div>
@@ -754,7 +754,7 @@
           </a>
           <span about='#underscore_in_localName' property='mf:name'>underscore_in_localName</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#underscore_in_localName' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#underscore_in_localName' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>underscore in local name</p>
           </div>
@@ -779,7 +779,7 @@
           </a>
           <span about='#localname_with_COLON' property='mf:name'>localname_with_COLON</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localname_with_COLON' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#localname_with_COLON' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>localname with COLON</p>
           </div>
@@ -804,7 +804,7 @@
           </a>
           <span about='#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries' property='mf:name'>localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>localName with assigned, NFC-normalized, basic-multilingual-plane PN CHARS BASE character boundaries (p:AZazÀÖØöø...)</p>
           </div>
@@ -829,7 +829,7 @@
           </a>
           <span about='#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries' property='mf:name'>localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>localName with assigned, NFC-normalized PN CHARS BASE character boundaries (p:AZazÀÖØöø...)</p>
           </div>
@@ -854,7 +854,7 @@
           </a>
           <span about='#localName_with_nfc_PN_CHARS_BASE_character_boundaries' property='mf:name'>localName_with_nfc_PN_CHARS_BASE_character_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_nfc_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_nfc_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>localName with nfc-normalize PN CHARS BASE character boundaries (p:AZazÀÖØöø...)</p>
           </div>
@@ -879,7 +879,7 @@
           </a>
           <span about='#localName_with_leading_underscore' property='mf:name'>localName_with_leading_underscore</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_leading_underscore' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_leading_underscore' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>localName with leading underscore (p:_)</p>
           </div>
@@ -904,7 +904,7 @@
           </a>
           <span about='#localName_with_leading_digit' property='mf:name'>localName_with_leading_digit</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_leading_digit' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_leading_digit' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>localName with leading digit (p:_)</p>
           </div>
@@ -929,7 +929,7 @@
           </a>
           <span about='#localName_with_non_leading_extras' property='mf:name'>localName_with_non_leading_extras</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_non_leading_extras' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_non_leading_extras' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>localName with<em>non</em>leading<em>extras (</em>:a·̀ͯ‿.⁀)</p>
           </div>
@@ -954,7 +954,7 @@
           </a>
           <span about='#old_style_base' property='mf:name'>old_style_base</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#old_style_base' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#old_style_base' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>old-style base</p>
           </div>
@@ -979,7 +979,7 @@
           </a>
           <span about='#SPARQL_style_base' property='mf:name'>SPARQL_style_base</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#SPARQL_style_base' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#SPARQL_style_base' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>SPARQL-style base</p>
           </div>
@@ -1004,7 +1004,7 @@
           </a>
           <span about='#labeled_blank_node_subject' property='mf:name'>labeled_blank_node_subject</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_subject' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_subject' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node subject</p>
           </div>
@@ -1029,7 +1029,7 @@
           </a>
           <span about='#labeled_blank_node_object' property='mf:name'>labeled_blank_node_object</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_object' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_object' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node object</p>
           </div>
@@ -1054,7 +1054,7 @@
           </a>
           <span about='#labeled_blank_node_with_PN_CHARS_BASE_character_boundaries' property='mf:name'>labeled_blank_node_with_PN_CHARS_BASE_character_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_with_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_with_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node with PN<em>CHARS</em>BASE character boundaries (_:AZazÀÖØöø...)</p>
           </div>
@@ -1079,7 +1079,7 @@
           </a>
           <span about='#labeled_blank_node_with_leading_underscore' property='mf:name'>labeled_blank_node_with_leading_underscore</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_with_leading_underscore' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_with_leading_underscore' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node with<em>leading</em>underscore (<em>:</em>)</p>
           </div>
@@ -1104,7 +1104,7 @@
           </a>
           <span about='#labeled_blank_node_with_leading_digit' property='mf:name'>labeled_blank_node_with_leading_digit</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_with_leading_digit' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_with_leading_digit' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node with<em>leading</em>digit (_:0)</p>
           </div>
@@ -1129,7 +1129,7 @@
           </a>
           <span about='#labeled_blank_node_with_non_leading_extras' property='mf:name'>labeled_blank_node_with_non_leading_extras</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_with_non_leading_extras' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_with_non_leading_extras' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node with<em>non</em>leading<em>extras (</em>:a·̀ͯ‿.⁀)</p>
           </div>
@@ -1154,7 +1154,7 @@
           </a>
           <span about='#anonymous_blank_node_subject' property='mf:name'>anonymous_blank_node_subject</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#anonymous_blank_node_subject' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#anonymous_blank_node_subject' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>anonymous blank node subject</p>
           </div>
@@ -1179,7 +1179,7 @@
           </a>
           <span about='#anonymous_blank_node_object' property='mf:name'>anonymous_blank_node_object</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#anonymous_blank_node_object' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#anonymous_blank_node_object' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>anonymous blank node object</p>
           </div>
@@ -1204,7 +1204,7 @@
           </a>
           <span about='#sole_blankNodePropertyList' property='mf:name'>sole_blankNodePropertyList</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#sole_blankNodePropertyList' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='#sole_blankNodePropertyList' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
             <p>sole blankNodePropertyList [ 
               <p> <o> ] .</p>
@@ -1230,7 +1230,7 @@
               </a>
               <span about='#blankNodePropertyList_as_subject' property='mf:name'>blankNodePropertyList_as_subject</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#blankNodePropertyList_as_subject' typeof='rdft:TestTrigEval'>
+            <dd inlist='true' property='mf:entry' resource='#blankNodePropertyList_as_subject' typeof='rdft:TestTrigEval'>
               <div property='rdfs:comment'>
                 <p>blankNodePropertyList as subject [ … ] 
                   <p> <o> .</p>
@@ -1256,7 +1256,7 @@
                   </a>
                   <span about='#blankNodePropertyList_as_object' property='mf:name'>blankNodePropertyList_as_object</span>
                 </dt>
-                <dd inlist property='mf:entry' resource='#blankNodePropertyList_as_object' typeof='rdft:TestTrigEval'>
+                <dd inlist='true' property='mf:entry' resource='#blankNodePropertyList_as_object' typeof='rdft:TestTrigEval'>
                   <div property='rdfs:comment'>
                     <p>blankNodePropertyList as object <s> 
                         <p> [ … ] .</p>
@@ -1282,7 +1282,7 @@
                       </a>
                       <span about='#blankNodePropertyList_with_multiple_triples' property='mf:name'>blankNodePropertyList_with_multiple_triples</span>
                     </dt>
-                    <dd inlist property='mf:entry' resource='#blankNodePropertyList_with_multiple_triples' typeof='rdft:TestTrigEval'>
+                    <dd inlist='true' property='mf:entry' resource='#blankNodePropertyList_with_multiple_triples' typeof='rdft:TestTrigEval'>
                       <div property='rdfs:comment'>
                         <p>blankNodePropertyList with multiple triples [ <s> 
                             <p> ; <s2> <p2> ]</p>
@@ -1308,7 +1308,7 @@
                               </a>
                               <span about='#nested_blankNodePropertyLists' property='mf:name'>nested_blankNodePropertyLists</span>
                             </dt>
-                            <dd inlist property='mf:entry' resource='#nested_blankNodePropertyLists' typeof='rdft:TestTrigEval'>
+                            <dd inlist='true' property='mf:entry' resource='#nested_blankNodePropertyLists' typeof='rdft:TestTrigEval'>
                               <div property='rdfs:comment'>
                                 <p>nested blankNodePropertyLists [ <p1> [ <p2> <o2> ] ; <p3> <o3> ]</p>
                                         </div>
@@ -1333,7 +1333,7 @@
                                         </a>
                                         <span about='#blankNodePropertyList_containing_collection' property='mf:name'>blankNodePropertyList_containing_collection</span>
                                       </dt>
-                                      <dd inlist property='mf:entry' resource='#blankNodePropertyList_containing_collection' typeof='rdft:TestTrigEval'>
+                                      <dd inlist='true' property='mf:entry' resource='#blankNodePropertyList_containing_collection' typeof='rdft:TestTrigEval'>
                                         <div property='rdfs:comment'>
                                           <p>blankNodePropertyList containing collection [ <p1> ( … ) ]</p>
                                           </div>
@@ -1358,7 +1358,7 @@
                                           </a>
                                           <span about='#collection_subject' property='mf:name'>collection_subject</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#collection_subject' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#collection_subject' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>collection subject</p>
                                           </div>
@@ -1383,7 +1383,7 @@
                                           </a>
                                           <span about='#collection_object' property='mf:name'>collection_object</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#collection_object' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#collection_object' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>collection object</p>
                                           </div>
@@ -1408,7 +1408,7 @@
                                           </a>
                                           <span about='#empty_collection' property='mf:name'>empty_collection</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#empty_collection' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#empty_collection' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>empty collection ()</p>
                                           </div>
@@ -1433,7 +1433,7 @@
                                           </a>
                                           <span about='#nested_collection' property='mf:name'>nested_collection</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#nested_collection' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#nested_collection' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>nested collection (())</p>
                                           </div>
@@ -1458,7 +1458,7 @@
                                           </a>
                                           <span about='#first' property='mf:name'>first</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#first' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#first' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>first, not last, non-empty nested collection</p>
                                           </div>
@@ -1483,7 +1483,7 @@
                                           </a>
                                           <span about='#last' property='mf:name'>last</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#last' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#last' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>last, not first, non-empty nested collection</p>
                                           </div>
@@ -1508,7 +1508,7 @@
                                           </a>
                                           <span about='#LITERAL1' property='mf:name'>LITERAL1</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL1' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL1' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL1 &#39;x&#39;</p>
                                           </div>
@@ -1533,7 +1533,7 @@
                                           </a>
                                           <span about='#LITERAL1_ascii_boundaries' property='mf:name'>LITERAL1_ascii_boundaries</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL1_ascii_boundaries' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL1_ascii_boundaries' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL1<em>ascii</em>boundaries &#39;\x00\x09\x0b\x0c\x0e\x26\x28...&#39;</p>
                                           </div>
@@ -1558,7 +1558,7 @@
                                           </a>
                                           <span about='#LITERAL1_with_UTF8_boundaries' property='mf:name'>LITERAL1_with_UTF8_boundaries</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL1_with_UTF8_boundaries' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL1_with_UTF8_boundaries' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL1<em>with</em>UTF8_boundaries &#39;\x80\x7ff\x800\xfff...&#39;</p>
                                           </div>
@@ -1583,7 +1583,7 @@
                                           </a>
                                           <span about='#LITERAL1_all_controls' property='mf:name'>LITERAL1_all_controls</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL1_all_controls' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL1_all_controls' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL1<em>all</em>controls &#39;\x00\x01\x02\x03\x04...&#39;</p>
                                           </div>
@@ -1608,7 +1608,7 @@
                                           </a>
                                           <span about='#LITERAL1_all_punctuation' property='mf:name'>LITERAL1_all_punctuation</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL1_all_punctuation' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL1_all_punctuation' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL1<em>all</em>punctuation &#39;!&quot;#$%&amp;()...&#39;</p>
                                           </div>
@@ -1633,7 +1633,7 @@
                                           </a>
                                           <span about='#LITERAL_LONG1' property='mf:name'>LITERAL_LONG1</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL_LONG1' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG1' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL_LONG1 &#39;&#39;&#39;x&#39;&#39;&#39;</p>
                                           </div>
@@ -1658,7 +1658,7 @@
                                           </a>
                                           <span about='#LITERAL_LONG1_ascii_boundaries' property='mf:name'>LITERAL_LONG1_ascii_boundaries</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL_LONG1_ascii_boundaries' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG1_ascii_boundaries' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL<em>LONG1</em>ascii_boundaries &#39;\x00\x26\x28...&#39;</p>
                                           </div>
@@ -1683,7 +1683,7 @@
                                           </a>
                                           <span about='#LITERAL_LONG1_with_UTF8_boundaries' property='mf:name'>LITERAL_LONG1_with_UTF8_boundaries</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL_LONG1_with_UTF8_boundaries' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG1_with_UTF8_boundaries' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL<em>LONG1</em>with<em>UTF8</em>boundaries &#39;\x80\x7ff\x800\xfff...&#39;</p>
                                           </div>
@@ -1708,7 +1708,7 @@
                                           </a>
                                           <span about='#LITERAL_LONG1_with_1_squote' property='mf:name'>LITERAL_LONG1_with_1_squote</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL_LONG1_with_1_squote' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG1_with_1_squote' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL_LONG1 with 1 squote &#39;&#39;&#39;a&#39;b&#39;&#39;&#39;</p>
                                           </div>
@@ -1733,7 +1733,7 @@
                                           </a>
                                           <span about='#LITERAL_LONG1_with_2_squotes' property='mf:name'>LITERAL_LONG1_with_2_squotes</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL_LONG1_with_2_squotes' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG1_with_2_squotes' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL_LONG1 with 2 squotes &#39;&#39;&#39;a&#39;&#39;b&#39;&#39;&#39;</p>
                                           </div>
@@ -1758,7 +1758,7 @@
                                           </a>
                                           <span about='#LITERAL2' property='mf:name'>LITERAL2</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL2' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL2' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL2 &quot;x&quot;</p>
                                           </div>
@@ -1783,7 +1783,7 @@
                                           </a>
                                           <span about='#LITERAL2_ascii_boundaries' property='mf:name'>LITERAL2_ascii_boundaries</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL2_ascii_boundaries' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL2_ascii_boundaries' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL2<em>ascii</em>boundaries &#39;\x00\x09\x0b\x0c\x0e\x21\x23...&#39;</p>
                                           </div>
@@ -1808,7 +1808,7 @@
                                           </a>
                                           <span about='#LITERAL2_with_UTF8_boundaries' property='mf:name'>LITERAL2_with_UTF8_boundaries</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL2_with_UTF8_boundaries' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL2_with_UTF8_boundaries' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL2<em>with</em>UTF8_boundaries &#39;\x80\x7ff\x800\xfff...&#39;</p>
                                           </div>
@@ -1833,7 +1833,7 @@
                                           </a>
                                           <span about='#LITERAL_LONG2' property='mf:name'>LITERAL_LONG2</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL_LONG2' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL_LONG2 &quot;&quot;&quot;x&quot;&quot;&quot;</p>
                                           </div>
@@ -1858,7 +1858,7 @@
                                           </a>
                                           <span about='#LITERAL_LONG2_ascii_boundaries' property='mf:name'>LITERAL_LONG2_ascii_boundaries</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL_LONG2_ascii_boundaries' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2_ascii_boundaries' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL<em>LONG2</em>ascii_boundaries &#39;\x00\x21\x23...&#39;</p>
                                           </div>
@@ -1883,7 +1883,7 @@
                                           </a>
                                           <span about='#LITERAL_LONG2_with_UTF8_boundaries' property='mf:name'>LITERAL_LONG2_with_UTF8_boundaries</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL_LONG2_with_UTF8_boundaries' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2_with_UTF8_boundaries' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL<em>LONG2</em>with<em>UTF8</em>boundaries &#39;\x80\x7ff\x800\xfff...&#39;</p>
                                           </div>
@@ -1908,7 +1908,7 @@
                                           </a>
                                           <span about='#LITERAL_LONG2_with_1_squote' property='mf:name'>LITERAL_LONG2_with_1_squote</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL_LONG2_with_1_squote' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2_with_1_squote' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL_LONG2 with 1 squote &quot;&quot;&quot;a&quot;b&quot;&quot;&quot;</p>
                                           </div>
@@ -1933,7 +1933,7 @@
                                           </a>
                                           <span about='#LITERAL_LONG2_with_2_squotes' property='mf:name'>LITERAL_LONG2_with_2_squotes</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#LITERAL_LONG2_with_2_squotes' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2_with_2_squotes' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>LITERAL_LONG2 with 2 squotes &quot;&quot;&quot;a&quot;&quot;b&quot;&quot;&quot;</p>
                                           </div>
@@ -1958,7 +1958,7 @@
                                           </a>
                                           <span about='#literal_with_CHARACTER_TABULATION' property='mf:name'>literal_with_CHARACTER_TABULATION</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_CHARACTER_TABULATION' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_CHARACTER_TABULATION' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with CHARACTER TABULATION</p>
                                           </div>
@@ -1983,7 +1983,7 @@
                                           </a>
                                           <span about='#literal_with_BACKSPACE' property='mf:name'>literal_with_BACKSPACE</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_BACKSPACE' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_BACKSPACE' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with BACKSPACE</p>
                                           </div>
@@ -2008,7 +2008,7 @@
                                           </a>
                                           <span about='#literal_with_LINE_FEED' property='mf:name'>literal_with_LINE_FEED</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_LINE_FEED' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_LINE_FEED' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with LINE FEED</p>
                                           </div>
@@ -2033,7 +2033,7 @@
                                           </a>
                                           <span about='#literal_with_CARRIAGE_RETURN' property='mf:name'>literal_with_CARRIAGE_RETURN</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_CARRIAGE_RETURN' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_CARRIAGE_RETURN' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with CARRIAGE RETURN</p>
                                           </div>
@@ -2058,7 +2058,7 @@
                                           </a>
                                           <span about='#literal_with_FORM_FEED' property='mf:name'>literal_with_FORM_FEED</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_FORM_FEED' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_FORM_FEED' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with FORM FEED</p>
                                           </div>
@@ -2083,7 +2083,7 @@
                                           </a>
                                           <span about='#literal_with_REVERSE_SOLIDUS' property='mf:name'>literal_with_REVERSE_SOLIDUS</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with REVERSE SOLIDUS</p>
                                           </div>
@@ -2108,7 +2108,7 @@
                                           </a>
                                           <span about='#literal_with_escaped_CHARACTER_TABULATION' property='mf:name'>literal_with_escaped_CHARACTER_TABULATION</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_escaped_CHARACTER_TABULATION' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_escaped_CHARACTER_TABULATION' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with escaped CHARACTER TABULATION</p>
                                           </div>
@@ -2133,7 +2133,7 @@
                                           </a>
                                           <span about='#literal_with_escaped_BACKSPACE' property='mf:name'>literal_with_escaped_BACKSPACE</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_escaped_BACKSPACE' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_escaped_BACKSPACE' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with escaped BACKSPACE</p>
                                           </div>
@@ -2158,7 +2158,7 @@
                                           </a>
                                           <span about='#literal_with_escaped_LINE_FEED' property='mf:name'>literal_with_escaped_LINE_FEED</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_escaped_LINE_FEED' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_escaped_LINE_FEED' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with escaped LINE FEED</p>
                                           </div>
@@ -2183,7 +2183,7 @@
                                           </a>
                                           <span about='#literal_with_escaped_CARRIAGE_RETURN' property='mf:name'>literal_with_escaped_CARRIAGE_RETURN</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_escaped_CARRIAGE_RETURN' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_escaped_CARRIAGE_RETURN' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with escaped CARRIAGE RETURN</p>
                                           </div>
@@ -2208,7 +2208,7 @@
                                           </a>
                                           <span about='#literal_with_escaped_FORM_FEED' property='mf:name'>literal_with_escaped_FORM_FEED</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_escaped_FORM_FEED' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_escaped_FORM_FEED' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with escaped FORM FEED</p>
                                           </div>
@@ -2233,7 +2233,7 @@
                                           </a>
                                           <span about='#literal_with_numeric_escape4' property='mf:name'>literal_with_numeric_escape4</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_numeric_escape4' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_numeric_escape4' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with numeric escape4 \u</p>
                                           </div>
@@ -2258,7 +2258,7 @@
                                           </a>
                                           <span about='#literal_with_numeric_escape8' property='mf:name'>literal_with_numeric_escape8</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#literal_with_numeric_escape8' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#literal_with_numeric_escape8' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>literal with numeric escape8 \U</p>
                                           </div>
@@ -2283,7 +2283,7 @@
                                           </a>
                                           <span about='#IRIREF_datatype' property='mf:name'>IRIREF_datatype</span>
                                         </dt>
-                                        <dd inlist property='mf:entry' resource='#IRIREF_datatype' typeof='rdft:TestTrigEval'>
+                                        <dd inlist='true' property='mf:entry' resource='#IRIREF_datatype' typeof='rdft:TestTrigEval'>
                                           <div property='rdfs:comment'>
                                             <p>IRIREF datatype &quot;&quot;^^<t></p>
                                             </div>
@@ -2308,7 +2308,7 @@
                                             </a>
                                             <span about='#prefixed_name_datatype' property='mf:name'>prefixed_name_datatype</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#prefixed_name_datatype' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#prefixed_name_datatype' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>prefixed name datatype &quot;&quot;^^p:t</p>
                                             </div>
@@ -2333,7 +2333,7 @@
                                             </a>
                                             <span about='#bareword_integer' property='mf:name'>bareword_integer</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#bareword_integer' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#bareword_integer' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>bareword integer</p>
                                             </div>
@@ -2358,7 +2358,7 @@
                                             </a>
                                             <span about='#bareword_decimal' property='mf:name'>bareword_decimal</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#bareword_decimal' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#bareword_decimal' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>bareword decimal</p>
                                             </div>
@@ -2383,7 +2383,7 @@
                                             </a>
                                             <span about='#bareword_double' property='mf:name'>bareword_double</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#bareword_double' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#bareword_double' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>bareword double</p>
                                             </div>
@@ -2408,7 +2408,7 @@
                                             </a>
                                             <span about='#double_lower_case_e' property='mf:name'>double_lower_case_e</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#double_lower_case_e' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#double_lower_case_e' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>double lower case e</p>
                                             </div>
@@ -2433,7 +2433,7 @@
                                             </a>
                                             <span about='#negative_numeric' property='mf:name'>negative_numeric</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#negative_numeric' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#negative_numeric' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>negative numeric</p>
                                             </div>
@@ -2458,7 +2458,7 @@
                                             </a>
                                             <span about='#positive_numeric' property='mf:name'>positive_numeric</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#positive_numeric' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#positive_numeric' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>positive numeric</p>
                                             </div>
@@ -2483,7 +2483,7 @@
                                             </a>
                                             <span about='#numeric_with_leading_0' property='mf:name'>numeric_with_leading_0</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#numeric_with_leading_0' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#numeric_with_leading_0' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>numeric with leading 0</p>
                                             </div>
@@ -2508,7 +2508,7 @@
                                             </a>
                                             <span about='#literal_true' property='mf:name'>literal_true</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#literal_true' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#literal_true' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>literal true</p>
                                             </div>
@@ -2533,7 +2533,7 @@
                                             </a>
                                             <span about='#literal_false' property='mf:name'>literal_false</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#literal_false' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#literal_false' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>literal false</p>
                                             </div>
@@ -2558,7 +2558,7 @@
                                             </a>
                                             <span about='#langtagged_non_LONG' property='mf:name'>langtagged_non_LONG</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#langtagged_non_LONG' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#langtagged_non_LONG' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>langtagged non-LONG &quot;x&quot;@en</p>
                                             </div>
@@ -2583,7 +2583,7 @@
                                             </a>
                                             <span about='#langtagged_LONG' property='mf:name'>langtagged_LONG</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#langtagged_LONG' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#langtagged_LONG' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>langtagged LONG &quot;&quot;&quot;x&quot;&quot;&quot;@en</p>
                                             </div>
@@ -2608,7 +2608,7 @@
                                             </a>
                                             <span about='#lantag_with_subtag' property='mf:name'>lantag_with_subtag</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#lantag_with_subtag' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#lantag_with_subtag' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>lantag with subtag &quot;x&quot;@en-us</p>
                                             </div>
@@ -2633,7 +2633,7 @@
                                             </a>
                                             <span about='#objectList_with_two_objects' property='mf:name'>objectList_with_two_objects</span>
                                           </dt>
-                                          <dd inlist property='mf:entry' resource='#objectList_with_two_objects' typeof='rdft:TestTrigEval'>
+                                          <dd inlist='true' property='mf:entry' resource='#objectList_with_two_objects' typeof='rdft:TestTrigEval'>
                                             <div property='rdfs:comment'>
                                               <p>objectList with two objects … <o1>,<o2></p>
                                                 </div>
@@ -2658,7 +2658,7 @@
                                                 </a>
                                                 <span about='#predicateObjectList_with_two_objectLists' property='mf:name'>predicateObjectList_with_two_objectLists</span>
                                               </dt>
-                                              <dd inlist property='mf:entry' resource='#predicateObjectList_with_two_objectLists' typeof='rdft:TestTrigEval'>
+                                              <dd inlist='true' property='mf:entry' resource='#predicateObjectList_with_two_objectLists' typeof='rdft:TestTrigEval'>
                                                 <div property='rdfs:comment'>
                                                   <p>predicateObjectList with two objectLists … <o1>,<o2></p>
                                                     </div>
@@ -2683,7 +2683,7 @@
                                                     </a>
                                                     <span about='#repeated_semis_at_end' property='mf:name'>repeated_semis_at_end</span>
                                                   </dt>
-                                                  <dd inlist property='mf:entry' resource='#repeated_semis_at_end' typeof='rdft:TestTrigEval'>
+                                                  <dd inlist='true' property='mf:entry' resource='#repeated_semis_at_end' typeof='rdft:TestTrigEval'>
                                                     <div property='rdfs:comment'>
                                                       <p>repeated semis at end <s> 
                                                           <p> <o> ;; <p2> <o2> .</p>
@@ -2709,7 +2709,7 @@
                                                               </a>
                                                               <span about='#repeated_semis_not_at_end' property='mf:name'>repeated_semis_not_at_end</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#repeated_semis_not_at_end' typeof='rdft:TestTrigEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#repeated_semis_not_at_end' typeof='rdft:TestTrigEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>repeated semis not at end <s> 
                                                                     <p> <o> ;;.</p>
@@ -2735,7 +2735,7 @@
                                                                     </a>
                                                                     <span about='#comment_following_localName' property='mf:name'>comment_following_localName</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#comment_following_localName' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#comment_following_localName' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>comment following localName</p>
                                                                     </div>
@@ -2760,7 +2760,7 @@
                                                                     </a>
                                                                     <span about='#number_sign_following_localName' property='mf:name'>number_sign_following_localName</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#number_sign_following_localName' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#number_sign_following_localName' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>number sign following localName</p>
                                                                     </div>
@@ -2785,7 +2785,7 @@
                                                                     </a>
                                                                     <span about='#comment_following_PNAME_NS' property='mf:name'>comment_following_PNAME_NS</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#comment_following_PNAME_NS' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#comment_following_PNAME_NS' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>comment following PNAME_NS</p>
                                                                     </div>
@@ -2810,7 +2810,7 @@
                                                                     </a>
                                                                     <span about='#number_sign_following_PNAME_NS' property='mf:name'>number_sign_following_PNAME_NS</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#number_sign_following_PNAME_NS' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#number_sign_following_PNAME_NS' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>number sign following PNAME_NS</p>
                                                                     </div>
@@ -2835,7 +2835,7 @@
                                                                     </a>
                                                                     <span about='#LITERAL_LONG2_with_REVERSE_SOLIDUS' property='mf:name'>LITERAL_LONG2_with_REVERSE_SOLIDUS</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#LITERAL_LONG2_with_REVERSE_SOLIDUS' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2_with_REVERSE_SOLIDUS' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>REVERSE SOLIDUS at end of LITERAL_LONG2</p>
                                                                     </div>
@@ -2860,7 +2860,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-LITERAL2_with_langtag_and_datatype' property='mf:name'>trig-syntax-bad-num-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-LITERAL2_with_langtag_and_datatype' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-LITERAL2_with_langtag_and_datatype' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad number format (negative test)</p>
                                                                     </div>
@@ -2881,7 +2881,7 @@
                                                                     </a>
                                                                     <span about='#two_LITERAL_LONG2s' property='mf:name'>two_LITERAL_LONG2s</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#two_LITERAL_LONG2s' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#two_LITERAL_LONG2s' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>two LITERAL_LONG2s testing quote delimiter overrun</p>
                                                                     </div>
@@ -2906,7 +2906,7 @@
                                                                     </a>
                                                                     <span about='#langtagged_LONG_with_subtag' property='mf:name'>langtagged_LONG_with_subtag</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#langtagged_LONG_with_subtag' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#langtagged_LONG_with_subtag' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>langtagged LONG with subtag &quot;&quot;&quot;Cheers&quot;&quot;&quot;@en-UK</p>
                                                                     </div>
@@ -2931,7 +2931,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-file-01' property='mf:name'>trig-syntax-file-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-file-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-file-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Empty file</p>
                                                                     </div>
@@ -2952,7 +2952,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-file-02' property='mf:name'>trig-syntax-file-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-file-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-file-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Only comment</p>
                                                                     </div>
@@ -2973,7 +2973,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-file-03' property='mf:name'>trig-syntax-file-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-file-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-file-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>One comment, one empty line</p>
                                                                     </div>
@@ -2994,7 +2994,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-uri-01' property='mf:name'>trig-syntax-uri-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-uri-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-uri-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Only IRIs</p>
                                                                     </div>
@@ -3015,7 +3015,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-uri-02' property='mf:name'>trig-syntax-uri-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-uri-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-uri-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>IRIs with Unicode escape</p>
                                                                     </div>
@@ -3036,7 +3036,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-uri-03' property='mf:name'>trig-syntax-uri-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-uri-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-uri-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>IRIs with long Unicode escape</p>
                                                                     </div>
@@ -3057,7 +3057,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-uri-04' property='mf:name'>trig-syntax-uri-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-uri-04' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-uri-04' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Legal IRIs</p>
                                                                     </div>
@@ -3078,7 +3078,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-base-01' property='mf:name'>trig-syntax-base-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-base-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-base-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@base</p>
                                                                     </div>
@@ -3099,7 +3099,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-base-02' property='mf:name'>trig-syntax-base-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-base-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-base-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>BASE</p>
                                                                     </div>
@@ -3120,7 +3120,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-base-03' property='mf:name'>trig-syntax-base-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-base-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-base-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@base with relative IRIs</p>
                                                                     </div>
@@ -3141,7 +3141,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-base-04' property='mf:name'>trig-syntax-base-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-base-04' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-base-04' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>base with relative IRIs</p>
                                                                     </div>
@@ -3162,7 +3162,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-prefix-01' property='mf:name'>trig-syntax-prefix-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-prefix-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-prefix-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@prefix</p>
                                                                     </div>
@@ -3183,7 +3183,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-prefix-02' property='mf:name'>trig-syntax-prefix-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-prefix-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-prefix-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>PreFIX</p>
                                                                     </div>
@@ -3204,7 +3204,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-prefix-03' property='mf:name'>trig-syntax-prefix-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-prefix-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-prefix-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Empty PREFIX</p>
                                                                     </div>
@@ -3225,7 +3225,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-prefix-04' property='mf:name'>trig-syntax-prefix-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-prefix-04' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-prefix-04' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Empty @prefix with % escape</p>
                                                                     </div>
@@ -3246,7 +3246,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-prefix-05' property='mf:name'>trig-syntax-prefix-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-prefix-05' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-prefix-05' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@prefix with no suffix</p>
                                                                     </div>
@@ -3267,7 +3267,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-prefix-06' property='mf:name'>trig-syntax-prefix-06</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-prefix-06' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-prefix-06' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>colon is a legal pname character</p>
                                                                     </div>
@@ -3288,7 +3288,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-prefix-07' property='mf:name'>trig-syntax-prefix-07</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-prefix-07' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-prefix-07' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>dash is a legal pname character</p>
                                                                     </div>
@@ -3309,7 +3309,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-prefix-08' property='mf:name'>trig-syntax-prefix-08</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-prefix-08' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-prefix-08' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>underscore is a legal pname character</p>
                                                                     </div>
@@ -3330,7 +3330,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-prefix-09' property='mf:name'>trig-syntax-prefix-09</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-prefix-09' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-prefix-09' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>percents in pnames</p>
                                                                     </div>
@@ -3351,7 +3351,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-01' property='mf:name'>trig-syntax-string-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>string literal</p>
                                                                     </div>
@@ -3372,7 +3372,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-02' property='mf:name'>trig-syntax-string-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>langString literal</p>
                                                                     </div>
@@ -3393,7 +3393,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-03' property='mf:name'>trig-syntax-string-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>langString literal with region</p>
                                                                     </div>
@@ -3414,7 +3414,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-04' property='mf:name'>trig-syntax-string-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-04' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-04' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>squote string literal</p>
                                                                     </div>
@@ -3435,7 +3435,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-05' property='mf:name'>trig-syntax-string-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-05' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-05' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>squote langString literal</p>
                                                                     </div>
@@ -3456,7 +3456,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-06' property='mf:name'>trig-syntax-string-06</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-06' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-06' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>squote langString literal with region</p>
                                                                     </div>
@@ -3477,7 +3477,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-07' property='mf:name'>trig-syntax-string-07</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-07' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-07' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>long string literal with embedded single- and double-quotes</p>
                                                                     </div>
@@ -3498,7 +3498,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-08' property='mf:name'>trig-syntax-string-08</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-08' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-08' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>long string literal with embedded newline</p>
                                                                     </div>
@@ -3519,7 +3519,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-09' property='mf:name'>trig-syntax-string-09</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-09' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-09' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>squote long string literal with embedded single- and double-quotes</p>
                                                                     </div>
@@ -3540,7 +3540,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-10' property='mf:name'>trig-syntax-string-10</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-10' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-10' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>long langString literal with embedded newline</p>
                                                                     </div>
@@ -3561,7 +3561,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-string-11' property='mf:name'>trig-syntax-string-11</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-string-11' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-string-11' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>squote long langString literal with embedded newline</p>
                                                                     </div>
@@ -3582,7 +3582,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-str-esc-01' property='mf:name'>trig-syntax-str-esc-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-str-esc-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-str-esc-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>string literal with escaped newline</p>
                                                                     </div>
@@ -3603,7 +3603,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-str-esc-02' property='mf:name'>trig-syntax-str-esc-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-str-esc-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-str-esc-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>string literal with Unicode escape</p>
                                                                     </div>
@@ -3624,7 +3624,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-str-esc-03' property='mf:name'>trig-syntax-str-esc-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-str-esc-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-str-esc-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>string literal with long Unicode escape</p>
                                                                     </div>
@@ -3645,7 +3645,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-pname-esc-01' property='mf:name'>trig-syntax-pname-esc-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-pname-esc-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-pname-esc-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>pname with back-slash escapes</p>
                                                                     </div>
@@ -3666,7 +3666,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-pname-esc-02' property='mf:name'>trig-syntax-pname-esc-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-pname-esc-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-pname-esc-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>pname with back-slash escapes (2)</p>
                                                                     </div>
@@ -3687,7 +3687,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-pname-esc-03' property='mf:name'>trig-syntax-pname-esc-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-pname-esc-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-pname-esc-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>pname with back-slash escapes (3)</p>
                                                                     </div>
@@ -3708,7 +3708,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bnode-01' property='mf:name'>trig-syntax-bnode-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bnode-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bnode-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>bnode subject</p>
                                                                     </div>
@@ -3729,7 +3729,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bnode-02' property='mf:name'>trig-syntax-bnode-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bnode-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bnode-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>bnode object</p>
                                                                     </div>
@@ -3750,7 +3750,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bnode-03' property='mf:name'>trig-syntax-bnode-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bnode-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bnode-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>bnode property list object</p>
                                                                     </div>
@@ -3771,7 +3771,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bnode-04' property='mf:name'>trig-syntax-bnode-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bnode-04' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bnode-04' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>bnode property list object (2)</p>
                                                                     </div>
@@ -3792,7 +3792,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bnode-05' property='mf:name'>trig-syntax-bnode-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bnode-05' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bnode-05' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>bnode property list subject</p>
                                                                     </div>
@@ -3813,7 +3813,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bnode-06' property='mf:name'>trig-syntax-bnode-06</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bnode-06' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bnode-06' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>labeled bnode subject</p>
                                                                     </div>
@@ -3834,7 +3834,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bnode-07' property='mf:name'>trig-syntax-bnode-07</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bnode-07' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bnode-07' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>labeled bnode subject and object</p>
                                                                     </div>
@@ -3855,7 +3855,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bnode-08' property='mf:name'>trig-syntax-bnode-08</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bnode-08' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bnode-08' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>bare bnode property list</p>
                                                                     </div>
@@ -3876,7 +3876,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bnode-09' property='mf:name'>trig-syntax-bnode-09</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bnode-09' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bnode-09' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>bnode property list</p>
                                                                     </div>
@@ -3897,7 +3897,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bnode-10' property='mf:name'>trig-syntax-bnode-10</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bnode-10' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bnode-10' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>mixed bnode property list and triple</p>
                                                                     </div>
@@ -3918,7 +3918,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-01' property='mf:name'>trig-syntax-number-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>integer literal</p>
                                                                     </div>
@@ -3939,7 +3939,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-02' property='mf:name'>trig-syntax-number-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>negative integer literal</p>
                                                                     </div>
@@ -3960,7 +3960,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-03' property='mf:name'>trig-syntax-number-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>positive integer literal</p>
                                                                     </div>
@@ -3981,7 +3981,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-04' property='mf:name'>trig-syntax-number-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-04' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-04' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>decimal literal</p>
                                                                     </div>
@@ -4002,7 +4002,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-05' property='mf:name'>trig-syntax-number-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-05' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-05' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>decimal literal (no leading digits)</p>
                                                                     </div>
@@ -4023,7 +4023,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-06' property='mf:name'>trig-syntax-number-06</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-06' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-06' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>negative decimal literal</p>
                                                                     </div>
@@ -4044,7 +4044,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-07' property='mf:name'>trig-syntax-number-07</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-07' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-07' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>positive decimal literal</p>
                                                                     </div>
@@ -4065,7 +4065,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-08' property='mf:name'>trig-syntax-number-08</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-08' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-08' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>integer literal with decimal lexical confusion</p>
                                                                     </div>
@@ -4086,7 +4086,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-09' property='mf:name'>trig-syntax-number-09</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-09' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-09' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>double literal</p>
                                                                     </div>
@@ -4107,7 +4107,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-10' property='mf:name'>trig-syntax-number-10</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-10' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-10' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>negative double literal</p>
                                                                     </div>
@@ -4128,7 +4128,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-number-11' property='mf:name'>trig-syntax-number-11</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-number-11' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-number-11' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>double literal no fraction</p>
                                                                     </div>
@@ -4149,7 +4149,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-datatypes-01' property='mf:name'>trig-syntax-datatypes-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-datatypes-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-datatypes-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>xsd:byte literal</p>
                                                                     </div>
@@ -4170,7 +4170,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-datatypes-02' property='mf:name'>trig-syntax-datatypes-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-datatypes-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-datatypes-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>integer as xsd:string</p>
                                                                     </div>
@@ -4191,7 +4191,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-kw-01' property='mf:name'>trig-syntax-kw-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-kw-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-kw-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>boolean literal (true)</p>
                                                                     </div>
@@ -4212,7 +4212,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-kw-02' property='mf:name'>trig-syntax-kw-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-kw-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-kw-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>boolean literal (false)</p>
                                                                     </div>
@@ -4233,7 +4233,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-kw-03' property='mf:name'>trig-syntax-kw-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-kw-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-kw-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>&#39;a&#39; as keyword</p>
                                                                     </div>
@@ -4254,7 +4254,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-struct-01' property='mf:name'>trig-syntax-struct-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-struct-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-struct-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>object list</p>
                                                                     </div>
@@ -4275,7 +4275,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-struct-02' property='mf:name'>trig-syntax-struct-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-struct-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-struct-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>predicate list with object list</p>
                                                                     </div>
@@ -4296,7 +4296,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-struct-03' property='mf:name'>trig-syntax-struct-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-struct-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-struct-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>predicate list with object list and dangling &#39;;&#39;</p>
                                                                     </div>
@@ -4317,7 +4317,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-struct-04' property='mf:name'>trig-syntax-struct-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-struct-04' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-struct-04' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>predicate list with multiple ;;</p>
                                                                     </div>
@@ -4338,7 +4338,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-struct-05' property='mf:name'>trig-syntax-struct-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-struct-05' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-struct-05' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>predicate list with multiple ;;</p>
                                                                     </div>
@@ -4359,7 +4359,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-lists-01' property='mf:name'>trig-syntax-lists-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-lists-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-lists-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>empty list</p>
                                                                     </div>
@@ -4380,7 +4380,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-lists-02' property='mf:name'>trig-syntax-lists-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-lists-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-lists-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>mixed list</p>
                                                                     </div>
@@ -4401,7 +4401,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-lists-03' property='mf:name'>trig-syntax-lists-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-lists-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-lists-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>isomorphic list as subject and object</p>
                                                                     </div>
@@ -4422,7 +4422,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-lists-04' property='mf:name'>trig-syntax-lists-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-lists-04' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-lists-04' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>lists of lists</p>
                                                                     </div>
@@ -4443,7 +4443,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-lists-05' property='mf:name'>trig-syntax-lists-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-lists-05' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-lists-05' typeof='rdft:TestTrigPositiveSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>mixed lists with embedded lists</p>
                                                                     </div>
@@ -4464,7 +4464,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-uri-01' property='mf:name'>trig-syntax-bad-uri-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-uri-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-uri-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad IRI : space (negative test)</p>
                                                                     </div>
@@ -4485,7 +4485,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-uri-02' property='mf:name'>trig-syntax-bad-uri-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-uri-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-uri-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad IRI : bad escape (negative test)</p>
                                                                     </div>
@@ -4506,7 +4506,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-uri-03' property='mf:name'>trig-syntax-bad-uri-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-uri-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-uri-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad IRI : bad long escape (negative test)</p>
                                                                     </div>
@@ -4527,7 +4527,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-uri-04' property='mf:name'>trig-syntax-bad-uri-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-uri-04' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-uri-04' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad IRI : character escapes not allowed (negative test)</p>
                                                                     </div>
@@ -4548,7 +4548,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-uri-05' property='mf:name'>trig-syntax-bad-uri-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-uri-05' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-uri-05' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad IRI : character escapes not allowed (2) (negative test)</p>
                                                                     </div>
@@ -4569,7 +4569,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-prefix-01' property='mf:name'>trig-syntax-bad-prefix-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-prefix-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-prefix-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>No prefix (negative test)</p>
                                                                     </div>
@@ -4590,7 +4590,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-prefix-02' property='mf:name'>trig-syntax-bad-prefix-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-prefix-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-prefix-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>No prefix (2) (negative test)</p>
                                                                     </div>
@@ -4611,7 +4611,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-prefix-03' property='mf:name'>trig-syntax-bad-prefix-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-prefix-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-prefix-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@prefix without URI (negative test)</p>
                                                                     </div>
@@ -4632,7 +4632,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-prefix-04' property='mf:name'>trig-syntax-bad-prefix-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-prefix-04' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-prefix-04' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@prefix without prefix name (negative test)</p>
                                                                     </div>
@@ -4653,7 +4653,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-prefix-05' property='mf:name'>trig-syntax-bad-prefix-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-prefix-05' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-prefix-05' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@prefix without &#39;:&#39; (negative test)</p>
                                                                     </div>
@@ -4674,7 +4674,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-base-01' property='mf:name'>trig-syntax-bad-base-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-base-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-base-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@base without URI (negative test)</p>
                                                                     </div>
@@ -4695,7 +4695,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-base-02' property='mf:name'>trig-syntax-bad-base-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-base-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-base-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@base in wrong case (negative test)</p>
                                                                     </div>
@@ -4716,7 +4716,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-base-03' property='mf:name'>trig-syntax-bad-base-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-base-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-base-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>BASE without URI (negative test)</p>
                                                                     </div>
@@ -4737,7 +4737,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-bnode-01' property='mf:name'>trig-syntax-bad-bnode-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-bnode-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-bnode-01' typeof='rdft:TestNTriplesNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Colon in bnode label not allowed (negative test)</p>
                                                                     </div>
@@ -4745,7 +4745,7 @@
                                                                       <dt>type</dt>
                                                                       <dd>rdft:TestNTriplesNegativeSyntax</dd>
                                                                       <dt>approval</dt>
-                                                                      <dd property='mf:approval'></dd>
+                                                                      <dd property='mf:approval' resource=''></dd>
                                                                       <dt>action</dt>
                                                                       <dd>
                                                                         <a href='trig-syntax-bad-bnode-01.trig' property='mf:action'>trig-syntax-bad-bnode-01.trig</a>
@@ -4758,7 +4758,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-bnode-02' property='mf:name'>trig-syntax-bad-bnode-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-bnode-02' typeof='rdft:TestNTriplesNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-bnode-02' typeof='rdft:TestNTriplesNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Colon in bnode label not allowed (negative test)</p>
                                                                     </div>
@@ -4766,7 +4766,7 @@
                                                                       <dt>type</dt>
                                                                       <dd>rdft:TestNTriplesNegativeSyntax</dd>
                                                                       <dt>approval</dt>
-                                                                      <dd property='mf:approval'></dd>
+                                                                      <dd property='mf:approval' resource=''></dd>
                                                                       <dt>action</dt>
                                                                       <dd>
                                                                         <a href='trig-syntax-bad-bnode-02.trig' property='mf:action'>trig-syntax-bad-bnode-02.trig</a>
@@ -4779,7 +4779,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-02' property='mf:name'>trig-syntax-bad-struct-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Turtle is not N3 (negative test)</p>
                                                                     </div>
@@ -4800,7 +4800,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-03' property='mf:name'>trig-syntax-bad-struct-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Turtle is not NQuads (negative test)</p>
                                                                     </div>
@@ -4821,7 +4821,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-04' property='mf:name'>trig-syntax-bad-struct-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-04' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-04' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Turtle does not allow literals-as-subjects (negative test)</p>
                                                                     </div>
@@ -4842,7 +4842,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-05' property='mf:name'>trig-syntax-bad-struct-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-05' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-05' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Turtle does not allow literals-as-predicates (negative test)</p>
                                                                     </div>
@@ -4863,7 +4863,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-06' property='mf:name'>trig-syntax-bad-struct-06</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-06' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-06' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Turtle does not allow bnodes-as-predicates (negative test)</p>
                                                                     </div>
@@ -4884,7 +4884,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-07' property='mf:name'>trig-syntax-bad-struct-07</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-07' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-07' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Turtle does not allow labeled bnodes-as-predicates (negative test)</p>
                                                                     </div>
@@ -4905,7 +4905,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-kw-01' property='mf:name'>trig-syntax-bad-kw-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-kw-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-kw-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>&#39;A&#39; is not a keyword (negative test)</p>
                                                                     </div>
@@ -4926,7 +4926,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-kw-02' property='mf:name'>trig-syntax-bad-kw-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-kw-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-kw-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>&#39;a&#39; cannot be used as subject (negative test)</p>
                                                                     </div>
@@ -4947,7 +4947,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-kw-03' property='mf:name'>trig-syntax-bad-kw-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-kw-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-kw-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>&#39;a&#39; cannot be used as object (negative test)</p>
                                                                     </div>
@@ -4968,7 +4968,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-kw-04' property='mf:name'>trig-syntax-bad-kw-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-kw-04' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-kw-04' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>&#39;true&#39; cannot be used as subject (negative test)</p>
                                                                     </div>
@@ -4989,7 +4989,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-kw-05' property='mf:name'>trig-syntax-bad-kw-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-kw-05' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-kw-05' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>&#39;true&#39; cannot be used as object (negative test)</p>
                                                                     </div>
@@ -5010,7 +5010,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-01' property='mf:name'>trig-syntax-bad-n3-extras-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>{} fomulae not in TriG (negative test)</p>
                                                                     </div>
@@ -5031,7 +5031,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-02' property='mf:name'>trig-syntax-bad-n3-extras-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>= is not TriG (negative test)</p>
                                                                     </div>
@@ -5052,7 +5052,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-03' property='mf:name'>trig-syntax-bad-n3-extras-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>N3 paths not in TriG (negative test)</p>
                                                                     </div>
@@ -5073,7 +5073,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-04' property='mf:name'>trig-syntax-bad-n3-extras-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-04' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-04' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>N3 paths not in TriG (negative test)</p>
                                                                     </div>
@@ -5094,7 +5094,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-05' property='mf:name'>trig-syntax-bad-n3-extras-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-05' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-05' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>N3 is...of not in TriG (negative test)</p>
                                                                     </div>
@@ -5115,7 +5115,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-06' property='mf:name'>trig-syntax-bad-n3-extras-06</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-06' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-06' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>N3 paths not in TriG (negative test)</p>
                                                                     </div>
@@ -5136,7 +5136,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-07' property='mf:name'>trig-syntax-bad-n3-extras-07</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-07' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-07' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@keywords is not TriG (negative test)</p>
                                                                     </div>
@@ -5157,7 +5157,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-08' property='mf:name'>trig-syntax-bad-n3-extras-08</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-08' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-08' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@keywords is not TriG (negative test)</p>
                                                                     </div>
@@ -5178,7 +5178,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-09' property='mf:name'>trig-syntax-bad-n3-extras-09</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-09' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-09' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>=&gt; is not TriG (negative test)</p>
                                                                     </div>
@@ -5199,7 +5199,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-10' property='mf:name'>trig-syntax-bad-n3-extras-10</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-10' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-10' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>&lt;= is not TriG (negative test)</p>
                                                                     </div>
@@ -5220,7 +5220,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-11' property='mf:name'>trig-syntax-bad-n3-extras-11</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-11' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-11' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@forSome is not TriG (negative test)</p>
                                                                     </div>
@@ -5241,7 +5241,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-12' property='mf:name'>trig-syntax-bad-n3-extras-12</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-12' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-12' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@forAll is not TriG (negative test)</p>
                                                                     </div>
@@ -5262,7 +5262,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-n3-extras-13' property='mf:name'>trig-syntax-bad-n3-extras-13</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-n3-extras-13' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-n3-extras-13' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@keywords is not TriG (negative test)</p>
                                                                     </div>
@@ -5283,7 +5283,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-09' property='mf:name'>trig-syntax-bad-struct-09</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-09' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-09' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>extra &#39;.&#39; (negative test)</p>
                                                                     </div>
@@ -5304,7 +5304,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-10' property='mf:name'>trig-syntax-bad-struct-10</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-10' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-10' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>extra &#39;.&#39; (negative test)</p>
                                                                     </div>
@@ -5325,7 +5325,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-12' property='mf:name'>trig-syntax-bad-struct-12</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-12' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-12' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>subject, predicate, no object (negative test)</p>
                                                                     </div>
@@ -5346,7 +5346,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-13' property='mf:name'>trig-syntax-bad-struct-13</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-13' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-13' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>subject, predicate, no object (negative test)</p>
                                                                     </div>
@@ -5367,7 +5367,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-14' property='mf:name'>trig-syntax-bad-struct-14</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-14' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-14' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>literal as subject (negative test)</p>
                                                                     </div>
@@ -5388,7 +5388,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-15' property='mf:name'>trig-syntax-bad-struct-15</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-15' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-15' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>literal as predicate (negative test)</p>
                                                                     </div>
@@ -5409,7 +5409,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-16' property='mf:name'>trig-syntax-bad-struct-16</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-16' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-16' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>bnode as predicate (negative test)</p>
                                                                     </div>
@@ -5430,7 +5430,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-struct-17' property='mf:name'>trig-syntax-bad-struct-17</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-struct-17' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-struct-17' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>labeled bnode as predicate (negative test)</p>
                                                                     </div>
@@ -5451,7 +5451,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-lang-01' property='mf:name'>trig-syntax-bad-lang-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-lang-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-lang-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>langString with bad lang (negative test)</p>
                                                                     </div>
@@ -5472,7 +5472,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-esc-01' property='mf:name'>trig-syntax-bad-esc-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-esc-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-esc-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad string escape (negative test)</p>
                                                                     </div>
@@ -5493,7 +5493,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-esc-02' property='mf:name'>trig-syntax-bad-esc-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-esc-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-esc-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad string escape (negative test)</p>
                                                                     </div>
@@ -5514,7 +5514,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-esc-03' property='mf:name'>trig-syntax-bad-esc-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-esc-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-esc-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad string escape (negative test)</p>
                                                                     </div>
@@ -5535,7 +5535,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-esc-04' property='mf:name'>trig-syntax-bad-esc-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-esc-04' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-esc-04' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad string escape (negative test)</p>
                                                                     </div>
@@ -5556,7 +5556,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-pname-01' property='mf:name'>trig-syntax-bad-pname-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-pname-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-pname-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>&#39;~&#39; must be escaped in pname (negative test)</p>
                                                                     </div>
@@ -5577,7 +5577,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-pname-02' property='mf:name'>trig-syntax-bad-pname-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-pname-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-pname-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad %-sequence in pname (negative test)</p>
                                                                     </div>
@@ -5598,7 +5598,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-pname-03' property='mf:name'>trig-syntax-bad-pname-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-pname-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-pname-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad unicode escape in pname (negative test)</p>
                                                                     </div>
@@ -5619,7 +5619,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-string-01' property='mf:name'>trig-syntax-bad-string-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-string-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-string-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>mismatching string literal open/close (negative test)</p>
                                                                     </div>
@@ -5640,7 +5640,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-string-02' property='mf:name'>trig-syntax-bad-string-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-string-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-string-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>mismatching string literal open/close (negative test)</p>
                                                                     </div>
@@ -5661,7 +5661,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-string-03' property='mf:name'>trig-syntax-bad-string-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-string-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-string-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>mismatching string literal long/short (negative test)</p>
                                                                     </div>
@@ -5682,7 +5682,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-string-04' property='mf:name'>trig-syntax-bad-string-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-string-04' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-string-04' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>mismatching long string literal open/close (negative test)</p>
                                                                     </div>
@@ -5703,7 +5703,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-string-05' property='mf:name'>trig-syntax-bad-string-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-string-05' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-string-05' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Long literal with missing end (negative test)</p>
                                                                     </div>
@@ -5724,7 +5724,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-string-06' property='mf:name'>trig-syntax-bad-string-06</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-string-06' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-string-06' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Long literal with extra quote (negative test)</p>
                                                                     </div>
@@ -5745,7 +5745,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-string-07' property='mf:name'>trig-syntax-bad-string-07</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-string-07' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-string-07' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Long literal with extra squote (negative test)</p>
                                                                     </div>
@@ -5766,7 +5766,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-num-01' property='mf:name'>trig-syntax-bad-num-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-num-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-num-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad number format (negative test)</p>
                                                                     </div>
@@ -5787,7 +5787,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-num-02' property='mf:name'>trig-syntax-bad-num-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-num-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-num-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad number format (negative test)</p>
                                                                     </div>
@@ -5808,7 +5808,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-num-03' property='mf:name'>trig-syntax-bad-num-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-num-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-num-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad number format (negative test)</p>
                                                                     </div>
@@ -5829,7 +5829,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-num-04' property='mf:name'>trig-syntax-bad-num-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-num-04' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-num-04' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad number format (negative test)</p>
                                                                     </div>
@@ -5850,7 +5850,7 @@
                                                                     </a>
                                                                     <span about='#trig-syntax-bad-num-05' property='mf:name'>trig-syntax-bad-num-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-syntax-bad-num-05' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-num-05' typeof='rdft:TestTrigNegativeSyntax'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Bad number format (negative test)</p>
                                                                     </div>
@@ -5871,7 +5871,7 @@
                                                                     </a>
                                                                     <span about='#trig-eval-struct-01' property='mf:name'>trig-eval-struct-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-eval-struct-01' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-eval-struct-01' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>triple with IRIs</p>
                                                                     </div>
@@ -5896,7 +5896,7 @@
                                                                     </a>
                                                                     <span about='#trig-eval-struct-02' property='mf:name'>trig-eval-struct-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-eval-struct-02' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-eval-struct-02' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>triple with IRIs and embedded whitespace</p>
                                                                     </div>
@@ -5921,7 +5921,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-01' property='mf:name'>trig-subm-01</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-01' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-01' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>Blank subject</p>
                                                                     </div>
@@ -5946,7 +5946,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-02' property='mf:name'>trig-subm-02</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-02' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-02' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>@prefix and qnames</p>
                                                                     </div>
@@ -5971,7 +5971,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-03' property='mf:name'>trig-subm-03</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-03' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-03' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>, operator</p>
                                                                     </div>
@@ -5996,7 +5996,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-04' property='mf:name'>trig-subm-04</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-04' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-04' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>; operator</p>
                                                                     </div>
@@ -6021,7 +6021,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-05' property='mf:name'>trig-subm-05</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-05' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-05' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>empty [] as subject and object</p>
                                                                     </div>
@@ -6046,7 +6046,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-06' property='mf:name'>trig-subm-06</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-06' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-06' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>non-empty [] as subject and object</p>
                                                                     </div>
@@ -6071,7 +6071,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-07' property='mf:name'>trig-subm-07</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-07' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-07' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>&#39;a&#39; as predicate</p>
                                                                     </div>
@@ -6096,7 +6096,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-08' property='mf:name'>trig-subm-08</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-08' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-08' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>simple collection</p>
                                                                     </div>
@@ -6121,7 +6121,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-09' property='mf:name'>trig-subm-09</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-09' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-09' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>empty collection</p>
                                                                     </div>
@@ -6146,7 +6146,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-10' property='mf:name'>trig-subm-10</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-10' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-10' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>integer datatyped literal</p>
                                                                     </div>
@@ -6171,7 +6171,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-11' property='mf:name'>trig-subm-11</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-11' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-11' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>decimal integer canonicalization</p>
                                                                     </div>
@@ -6196,7 +6196,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-12' property='mf:name'>trig-subm-12</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-12' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-12' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <ul>
                                                                         <li>and _ in names and qnames</li>
@@ -6223,7 +6223,7 @@
                                                                     </a>
                                                                     <span about='#trig-subm-13' property='mf:name'>trig-subm-13</span>
                                                                   </dt>
-                                                                  <dd inlist property='mf:entry' resource='#trig-subm-13' typeof='rdft:TestTrigEval'>
+                                                                  <dd inlist='true' property='mf:entry' resource='#trig-subm-13' typeof='rdft:TestTrigEval'>
                                                                     <div property='rdfs:comment'>
                                                                       <p>tests for rdf:_<numbers> and other qnames starting with _</p>
                                                                       </div>
@@ -6248,7 +6248,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-14' property='mf:name'>trig-subm-14</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-14' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-14' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>bare : allowed</p>
                                                                       </div>
@@ -6273,7 +6273,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-15' property='mf:name'>trig-subm-15</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-15' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-15' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>simple long literal</p>
                                                                       </div>
@@ -6298,7 +6298,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-16' property='mf:name'>trig-subm-16</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-16' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-16' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>long literals with escapes</p>
                                                                       </div>
@@ -6323,7 +6323,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-17' property='mf:name'>trig-subm-17</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-17' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-17' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>floating point number</p>
                                                                       </div>
@@ -6348,7 +6348,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-18' property='mf:name'>trig-subm-18</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-18' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-18' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>empty literals, normal and long variant</p>
                                                                       </div>
@@ -6373,7 +6373,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-19' property='mf:name'>trig-subm-19</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-19' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-19' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>positive integer, decimal and doubles</p>
                                                                       </div>
@@ -6398,7 +6398,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-20' property='mf:name'>trig-subm-20</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-20' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-20' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>negative integer, decimal and doubles</p>
                                                                       </div>
@@ -6423,7 +6423,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-21' property='mf:name'>trig-subm-21</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-21' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-21' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>long literal ending in double quote</p>
                                                                       </div>
@@ -6448,7 +6448,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-22' property='mf:name'>trig-subm-22</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-22' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-22' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>boolean literals</p>
                                                                       </div>
@@ -6473,7 +6473,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-23' property='mf:name'>trig-subm-23</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-23' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-23' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>comments</p>
                                                                       </div>
@@ -6498,7 +6498,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-24' property='mf:name'>trig-subm-24</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-24' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-24' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>no final mewline</p>
                                                                       </div>
@@ -6523,7 +6523,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-25' property='mf:name'>trig-subm-25</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-25' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-25' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>repeating a @prefix changes pname definition</p>
                                                                       </div>
@@ -6548,7 +6548,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-26' property='mf:name'>trig-subm-26</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-26' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-26' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Variations on decimal canonicalization</p>
                                                                       </div>
@@ -6573,7 +6573,7 @@
                                                                       </a>
                                                                       <span about='#trig-subm-27' property='mf:name'>trig-subm-27</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-subm-27' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-subm-27' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Repeating @base changes base for relative IRI lookup</p>
                                                                       </div>
@@ -6598,7 +6598,7 @@
                                                                       </a>
                                                                       <span about='#trig-eval-bad-01' property='mf:name'>trig-eval-bad-01</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-eval-bad-01' typeof='rdft:TestTrigNegativeEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-eval-bad-01' typeof='rdft:TestTrigNegativeEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Bad IRI : good escape, bad charcater (negative evaluation test)</p>
                                                                       </div>
@@ -6619,7 +6619,7 @@
                                                                       </a>
                                                                       <span about='#trig-eval-bad-02' property='mf:name'>trig-eval-bad-02</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-eval-bad-02' typeof='rdft:TestTrigNegativeEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-eval-bad-02' typeof='rdft:TestTrigNegativeEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Bad IRI : hex 3C is &lt; (negative evaluation test)</p>
                                                                       </div>
@@ -6640,7 +6640,7 @@
                                                                       </a>
                                                                       <span about='#trig-eval-bad-03' property='mf:name'>trig-eval-bad-03</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-eval-bad-03' typeof='rdft:TestTrigNegativeEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-eval-bad-03' typeof='rdft:TestTrigNegativeEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Bad IRI : hex 3E is (negative evaluation test)</p>
                                                                       </div>
@@ -6661,7 +6661,7 @@
                                                                       </a>
                                                                       <span about='#trig-eval-bad-04' property='mf:name'>trig-eval-bad-04</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-eval-bad-04' typeof='rdft:TestTrigNegativeEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-eval-bad-04' typeof='rdft:TestTrigNegativeEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Bad IRI : {abc} (negative evaluation test)</p>
                                                                       </div>
@@ -6682,7 +6682,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-blank-label-dot-end' property='mf:name'>trig-syntax-bad-blank-label-dot-end</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-blank-label-dot-end' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-blank-label-dot-end' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Blank node label must not end in dot</p>
                                                                       </div>
@@ -6703,7 +6703,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-ln-dash-start' property='mf:name'>trig-syntax-bad-ln-dash-start</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-ln-dash-start' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-ln-dash-start' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Local name must not begin with dash</p>
                                                                       </div>
@@ -6724,7 +6724,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-ln-escape-start' property='mf:name'>trig-syntax-bad-ln-escape-start</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-ln-escape-start' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-ln-escape-start' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Bad hex escape at start of local name</p>
                                                                       </div>
@@ -6745,7 +6745,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-ln-escape' property='mf:name'>trig-syntax-bad-ln-escape</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-ln-escape' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-ln-escape' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Bad hex escape in local name</p>
                                                                       </div>
@@ -6766,7 +6766,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-missing-ns-dot-end' property='mf:name'>trig-syntax-bad-missing-ns-dot-end</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-missing-ns-dot-end' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-missing-ns-dot-end' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Prefix must not end in dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)</p>
                                                                       </div>
@@ -6787,7 +6787,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-missing-ns-dot-start' property='mf:name'>trig-syntax-bad-missing-ns-dot-start</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-missing-ns-dot-start' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-missing-ns-dot-start' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Prefix must not start with dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)</p>
                                                                       </div>
@@ -6808,7 +6808,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-ns-dot-end' property='mf:name'>trig-syntax-bad-ns-dot-end</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-ns-dot-end' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-ns-dot-end' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Prefix must not end in dot</p>
                                                                       </div>
@@ -6829,7 +6829,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-ns-dot-start' property='mf:name'>trig-syntax-bad-ns-dot-start</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-ns-dot-start' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-ns-dot-start' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Prefix must not start with dot</p>
                                                                       </div>
@@ -6850,7 +6850,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-number-dot-in-anon' property='mf:name'>trig-syntax-bad-number-dot-in-anon</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-number-dot-in-anon' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-number-dot-in-anon' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Dot delimeter may not appear in anonymous nodes</p>
                                                                       </div>
@@ -6871,7 +6871,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-list-01' property='mf:name'>trig-syntax-bad-list-01</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-list-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-list-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Free-standing list outside {} : bad syntax</p>
                                                                       </div>
@@ -6892,7 +6892,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-list-02' property='mf:name'>trig-syntax-bad-list-02</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-list-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-list-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Free-standing list of zero-elements outside {} : bad syntax</p>
                                                                       </div>
@@ -6913,7 +6913,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-list-03' property='mf:name'>trig-syntax-bad-list-03</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-list-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-list-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Free-standing list inside {} : bad syntax</p>
                                                                       </div>
@@ -6934,7 +6934,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-bad-list-04' property='mf:name'>trig-syntax-bad-list-04</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-bad-list-04' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-bad-list-04' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Free-standing list of zero elements : bad syntax</p>
                                                                       </div>
@@ -6955,7 +6955,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-blank-label' property='mf:name'>trig-syntax-blank-label</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-blank-label' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-blank-label' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Characters allowed in blank node labels</p>
                                                                       </div>
@@ -6976,7 +6976,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-ln-colons' property='mf:name'>trig-syntax-ln-colons</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-ln-colons' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-ln-colons' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Colons in pname local names</p>
                                                                       </div>
@@ -6997,7 +6997,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-ln-dots' property='mf:name'>trig-syntax-ln-dots</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-ln-dots' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-ln-dots' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Dots in pname local names</p>
                                                                       </div>
@@ -7018,7 +7018,7 @@
                                                                       </a>
                                                                       <span about='#trig-syntax-ns-dots' property='mf:name'>trig-syntax-ns-dots</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-syntax-ns-dots' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-syntax-ns-dots' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Dots in namespace names</p>
                                                                       </div>
@@ -7039,7 +7039,7 @@
                                                                       </a>
                                                                       <span about='#trig-kw-graph-01' property='mf:name'>trig-kw-graph-01</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-kw-graph-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-kw-graph-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Named graphs can be proceeded by GRAPH</p>
                                                                       </div>
@@ -7060,7 +7060,7 @@
                                                                       </a>
                                                                       <span about='#trig-kw-graph-02' property='mf:name'>trig-kw-graph-02</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-kw-graph-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-kw-graph-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Trailing . not necessary inside {}</p>
                                                                       </div>
@@ -7081,7 +7081,7 @@
                                                                       </a>
                                                                       <span about='#trig-kw-graph-03' property='mf:name'>trig-kw-graph-03</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-kw-graph-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-kw-graph-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Named graph may be empty</p>
                                                                       </div>
@@ -7102,7 +7102,7 @@
                                                                       </a>
                                                                       <span about='#trig-kw-graph-04' property='mf:name'>trig-kw-graph-04</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-kw-graph-04' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-kw-graph-04' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                       </div>
                                                                       <dl class='test-detail'>
@@ -7122,7 +7122,7 @@
                                                                       </a>
                                                                       <span about='#trig-kw-graph-05' property='mf:name'>trig-kw-graph-05</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-kw-graph-05' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-kw-graph-05' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Use of empty prefix inside named graph</p>
                                                                       </div>
@@ -7143,7 +7143,7 @@
                                                                       </a>
                                                                       <span about='#trig-kw-graph-06' property='mf:name'>trig-kw-graph-06</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-kw-graph-06' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-kw-graph-06' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                       </div>
                                                                       <dl class='test-detail'>
@@ -7163,7 +7163,7 @@
                                                                       </a>
                                                                       <span about='#trig-kw-graph-07' property='mf:name'>trig-kw-graph-07</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-kw-graph-07' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-kw-graph-07' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Named graph may be named with BNode _:a</p>
                                                                       </div>
@@ -7184,7 +7184,7 @@
                                                                       </a>
                                                                       <span about='#trig-kw-graph-08' property='mf:name'>trig-kw-graph-08</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-kw-graph-08' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-kw-graph-08' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Named graph may be named with BNode []</p>
                                                                       </div>
@@ -7205,7 +7205,7 @@
                                                                       </a>
                                                                       <span about='#trig-kw-graph-09' property='mf:name'>trig-kw-graph-09</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-kw-graph-09' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-kw-graph-09' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Named graph may be named with PNAME</p>
                                                                       </div>
@@ -7226,7 +7226,7 @@
                                                                       </a>
                                                                       <span about='#trig-kw-graph-10' property='mf:name'>trig-kw-graph-10</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-kw-graph-10' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-kw-graph-10' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Named graph with PNAME and empty graph</p>
                                                                       </div>
@@ -7247,7 +7247,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-01' property='mf:name'>trig-graph-bad-01</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>GRAPH but no name - GRAPH is not used with the default graph</p>
                                                                       </div>
@@ -7268,7 +7268,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-02' property='mf:name'>trig-graph-bad-02</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>GRAPH not followed by DOT</p>
                                                                       </div>
@@ -7289,7 +7289,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-03' property='mf:name'>trig-graph-bad-03</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-03' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-03' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>GRAPH needs {}</p>
                                                                       </div>
@@ -7310,7 +7310,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-04' property='mf:name'>trig-graph-bad-04</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-04' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-04' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>GRAPH needs {}</p>
                                                                       </div>
@@ -7331,7 +7331,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-05' property='mf:name'>trig-graph-bad-05</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-05' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-05' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>GRAPH and a name, not several</p>
                                                                       </div>
@@ -7352,7 +7352,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-06' property='mf:name'>trig-graph-bad-06</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-06' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-06' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>GRAPH - Must close {}</p>
                                                                       </div>
@@ -7373,7 +7373,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-07' property='mf:name'>trig-graph-bad-07</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-07' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-07' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>GRAPH may not include a GRAPH</p>
                                                                       </div>
@@ -7394,7 +7394,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-08' property='mf:name'>trig-graph-bad-08</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-08' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-08' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>@graph is not a keyword</p>
                                                                       </div>
@@ -7415,7 +7415,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-09' property='mf:name'>trig-graph-bad-09</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-09' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-09' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Directives not allowed inside GRAPH</p>
                                                                       </div>
@@ -7436,7 +7436,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-10' property='mf:name'>trig-graph-bad-10</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-10' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-10' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>A graph may not be named with an empty collection</p>
                                                                       </div>
@@ -7457,7 +7457,7 @@
                                                                       </a>
                                                                       <span about='#trig-graph-bad-11' property='mf:name'>trig-graph-bad-11</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-graph-bad-11' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-graph-bad-11' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>A graph may not be named with a collection</p>
                                                                       </div>
@@ -7478,7 +7478,7 @@
                                                                       </a>
                                                                       <span about='#trig-bnodeplist-graph-01' property='mf:name'>trig-bnodeplist-graph-bad-01</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-bnodeplist-graph-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-bnodeplist-graph-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>A graph may not be named with a blankNodePropertyList</p>
                                                                       </div>
@@ -7499,7 +7499,7 @@
                                                                       </a>
                                                                       <span about='#trig-collection-graph-01' property='mf:name'>trig-collection-graph-bad-01</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-collection-graph-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-collection-graph-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>A graph may not be named with an empty collection</p>
                                                                       </div>
@@ -7520,7 +7520,7 @@
                                                                       </a>
                                                                       <span about='#trig-collection-graph-02' property='mf:name'>trig-collection-graph-bad-02</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-collection-graph-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-collection-graph-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>A graph may not be named with a collection</p>
                                                                       </div>
@@ -7541,7 +7541,7 @@
                                                                       </a>
                                                                       <span about='#trig-turtle-01' property='mf:name'>trig-turtle-01</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-turtle-01' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-turtle-01' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>TriG can parse Turtle</p>
                                                                       </div>
@@ -7562,7 +7562,7 @@
                                                                       </a>
                                                                       <span about='#trig-turtle-02' property='mf:name'>trig-turtle-02</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-turtle-02' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-turtle-02' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>TriG can parse Turtle (repeated PREFIX)</p>
                                                                       </div>
@@ -7583,7 +7583,7 @@
                                                                       </a>
                                                                       <span about='#trig-turtle-03' property='mf:name'>trig-turtle-03</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-turtle-03' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-turtle-03' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>TriG can parse Turtle (blankNodePropertyList subject)</p>
                                                                       </div>
@@ -7604,7 +7604,7 @@
                                                                       </a>
                                                                       <span about='#trig-turtle-04' property='mf:name'>trig-turtle-04</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-turtle-04' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-turtle-04' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>TriG can parse Turtle (blankNodePropertyList subject)</p>
                                                                       </div>
@@ -7625,7 +7625,7 @@
                                                                       </a>
                                                                       <span about='#trig-turtle-05' property='mf:name'>trig-turtle-05</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-turtle-05' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-turtle-05' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>TriG can parse Turtle (bare blankNodePropertyList)</p>
                                                                       </div>
@@ -7646,7 +7646,7 @@
                                                                       </a>
                                                                       <span about='#trig-turtle-06' property='mf:name'>trig-turtle-06</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-turtle-06' typeof='rdft:TestTrigPositiveSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-turtle-06' typeof='rdft:TestTrigPositiveSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>TriG can parse Turtle (collection subject and object)</p>
                                                                       </div>
@@ -7667,7 +7667,7 @@
                                                                       </a>
                                                                       <span about='#trig-turtle-bad-01' property='mf:name'>trig-turtle-bad-01</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-turtle-bad-01' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-turtle-bad-01' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>Trailing dot required in Turtle block</p>
                                                                       </div>
@@ -7688,7 +7688,7 @@
                                                                       </a>
                                                                       <span about='#trig-turtle-bad-02' property='mf:name'>trig-turtle-bad-02</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#trig-turtle-bad-02' typeof='rdft:TestTrigNegativeSyntax'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#trig-turtle-bad-02' typeof='rdft:TestTrigNegativeSyntax'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>TriG is not N-Quads</p>
                                                                       </div>
@@ -7709,7 +7709,7 @@
                                                                       </a>
                                                                       <span about='#IRI-resolution-01' property='mf:name'>IRI-resolution-01</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#IRI-resolution-01' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#IRI-resolution-01' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>IRI resolution (RFC3986 original cases)</p>
                                                                       </div>
@@ -7734,7 +7734,7 @@
                                                                       </a>
                                                                       <span about='#IRI-resolution-02' property='mf:name'>IRI-resolution-02</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#IRI-resolution-02' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#IRI-resolution-02' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>IRI resolution (RFC3986 using base IRI with trailing slash)</p>
                                                                       </div>
@@ -7759,7 +7759,7 @@
                                                                       </a>
                                                                       <span about='#IRI-resolution-07' property='mf:name'>IRI-resolution-07</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#IRI-resolution-07' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#IRI-resolution-07' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>IRI resolution (RFC3986 using base IRI with file path)</p>
                                                                       </div>
@@ -7784,7 +7784,7 @@
                                                                       </a>
                                                                       <span about='#IRI-resolution-08' property='mf:name'>IRI-resolution-08</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#IRI-resolution-08' typeof='rdft:TestTrigEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#IRI-resolution-08' typeof='rdft:TestTrigEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>IRI resolution (miscellaneous cases)</p>
                                                                       </div>

--- a/rdf/rdf11/rdf-turtle/index.html
+++ b/rdf/rdf11/rdf-turtle/index.html
@@ -82,7 +82,7 @@
           </a>
           <span about='#IRI_subject' property='mf:name'>IRI_subject</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#IRI_subject' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#IRI_subject' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>IRI subject</p>
           </div>
@@ -107,7 +107,7 @@
           </a>
           <span about='#IRI_with_four_digit_numeric_escape' property='mf:name'>IRI_with_four_digit_numeric_escape</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#IRI_with_four_digit_numeric_escape' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#IRI_with_four_digit_numeric_escape' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>IRI with four digit numeric escape (\u)</p>
           </div>
@@ -132,7 +132,7 @@
           </a>
           <span about='#IRI_with_eight_digit_numeric_escape' property='mf:name'>IRI_with_eight_digit_numeric_escape</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#IRI_with_eight_digit_numeric_escape' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#IRI_with_eight_digit_numeric_escape' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>IRI with eight digit numeric escape (\U)</p>
           </div>
@@ -157,7 +157,7 @@
           </a>
           <span about='#IRI_with_all_punctuation' property='mf:name'>IRI_with_all_punctuation</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#IRI_with_all_punctuation' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#IRI_with_all_punctuation' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>IRI with all punctuation</p>
           </div>
@@ -182,7 +182,7 @@
           </a>
           <span about='#bareword_a_predicate' property='mf:name'>bareword_a_predicate</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#bareword_a_predicate' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#bareword_a_predicate' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>bareword a predicate</p>
           </div>
@@ -207,7 +207,7 @@
           </a>
           <span about='#old_style_prefix' property='mf:name'>old_style_prefix</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#old_style_prefix' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#old_style_prefix' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>old-style prefix</p>
           </div>
@@ -232,7 +232,7 @@
           </a>
           <span about='#SPARQL_style_prefix' property='mf:name'>SPARQL_style_prefix</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#SPARQL_style_prefix' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#SPARQL_style_prefix' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>SPARQL-style prefix</p>
           </div>
@@ -257,7 +257,7 @@
           </a>
           <span about='#prefixed_IRI_predicate' property='mf:name'>prefixed_IRI_predicate</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefixed_IRI_predicate' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefixed_IRI_predicate' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>prefixed IRI predicate</p>
           </div>
@@ -282,7 +282,7 @@
           </a>
           <span about='#prefixed_IRI_object' property='mf:name'>prefixed_IRI_object</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefixed_IRI_object' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefixed_IRI_object' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>prefixed IRI object</p>
           </div>
@@ -307,7 +307,7 @@
           </a>
           <span about='#prefix_only_IRI' property='mf:name'>prefix_only_IRI</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefix_only_IRI' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefix_only_IRI' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>prefix-only IRI (p:)</p>
           </div>
@@ -332,7 +332,7 @@
           </a>
           <span about='#prefix_with_PN_CHARS_BASE_character_boundaries' property='mf:name'>prefix_with_PN_CHARS_BASE_character_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefix_with_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefix_with_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>prefix with PN CHARS BASE character boundaries (prefix: AZazÀÖØöø...:)</p>
           </div>
@@ -357,7 +357,7 @@
           </a>
           <span about='#prefix_with_non_leading_extras' property='mf:name'>prefix_with_non_leading_extras</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefix_with_non_leading_extras' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefix_with_non_leading_extras' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>prefix with<em>non</em>leading<em>extras (</em>:a·̀ͯ‿.⁀)</p>
           </div>
@@ -382,7 +382,7 @@
           </a>
           <span about='#default_namespace_IRI' property='mf:name'>default_namespace_IRI</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#default_namespace_IRI' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#default_namespace_IRI' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>default namespace IRI (:ln)</p>
           </div>
@@ -407,7 +407,7 @@
           </a>
           <span about='#prefix_reassigned_and_used' property='mf:name'>prefix_reassigned_and_used</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#prefix_reassigned_and_used' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#prefix_reassigned_and_used' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>prefix reassigned and used</p>
           </div>
@@ -432,7 +432,7 @@
           </a>
           <span about='#reserved_escaped_localName' property='mf:name'>reserved_escaped_localName</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#reserved_escaped_localName' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#reserved_escaped_localName' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>reserved-escaped local name</p>
           </div>
@@ -457,7 +457,7 @@
           </a>
           <span about='#percent_escaped_localName' property='mf:name'>percent_escaped_localName</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#percent_escaped_localName' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#percent_escaped_localName' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>percent-escaped local name</p>
           </div>
@@ -482,7 +482,7 @@
           </a>
           <span about='#HYPHEN_MINUS_in_localName' property='mf:name'>HYPHEN_MINUS_in_localName</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#HYPHEN_MINUS_in_localName' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#HYPHEN_MINUS_in_localName' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>HYPHEN-MINUS in local name</p>
           </div>
@@ -507,7 +507,7 @@
           </a>
           <span about='#underscore_in_localName' property='mf:name'>underscore_in_localName</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#underscore_in_localName' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#underscore_in_localName' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>underscore in local name</p>
           </div>
@@ -532,7 +532,7 @@
           </a>
           <span about='#localname_with_COLON' property='mf:name'>localname_with_COLON</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localname_with_COLON' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#localname_with_COLON' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>localname with COLON</p>
           </div>
@@ -557,7 +557,7 @@
           </a>
           <span about='#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries' property='mf:name'>localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>localName with assigned, NFC-normalized, basic-multilingual-plane PN CHARS BASE character boundaries (p:AZazÀÖØöø...)</p>
           </div>
@@ -582,7 +582,7 @@
           </a>
           <span about='#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries' property='mf:name'>localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>localName with assigned, NFC-normalized PN CHARS BASE character boundaries (p:AZazÀÖØöø...)</p>
           </div>
@@ -607,7 +607,7 @@
           </a>
           <span about='#localName_with_nfc_PN_CHARS_BASE_character_boundaries' property='mf:name'>localName_with_nfc_PN_CHARS_BASE_character_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_nfc_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_nfc_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>localName with nfc-normalize PN CHARS BASE character boundaries (p:AZazÀÖØöø...)</p>
           </div>
@@ -632,7 +632,7 @@
           </a>
           <span about='#localName_with_leading_underscore' property='mf:name'>localName_with_leading_underscore</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_leading_underscore' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_leading_underscore' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>localName with leading underscore (p:_)</p>
           </div>
@@ -657,7 +657,7 @@
           </a>
           <span about='#localName_with_leading_digit' property='mf:name'>localName_with_leading_digit</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_leading_digit' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_leading_digit' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>localName with leading digit (p:_)</p>
           </div>
@@ -682,7 +682,7 @@
           </a>
           <span about='#localName_with_non_leading_extras' property='mf:name'>localName_with_non_leading_extras</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#localName_with_non_leading_extras' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#localName_with_non_leading_extras' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>localName with<em>non</em>leading<em>extras (</em>:a·̀ͯ‿.⁀)</p>
           </div>
@@ -707,7 +707,7 @@
           </a>
           <span about='#old_style_base' property='mf:name'>old_style_base</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#old_style_base' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#old_style_base' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>old-style base</p>
           </div>
@@ -732,7 +732,7 @@
           </a>
           <span about='#SPARQL_style_base' property='mf:name'>SPARQL_style_base</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#SPARQL_style_base' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#SPARQL_style_base' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>SPARQL-style base</p>
           </div>
@@ -757,7 +757,7 @@
           </a>
           <span about='#labeled_blank_node_subject' property='mf:name'>labeled_blank_node_subject</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_subject' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_subject' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node subject</p>
           </div>
@@ -782,7 +782,7 @@
           </a>
           <span about='#labeled_blank_node_object' property='mf:name'>labeled_blank_node_object</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_object' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_object' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node object</p>
           </div>
@@ -807,7 +807,7 @@
           </a>
           <span about='#labeled_blank_node_with_PN_CHARS_BASE_character_boundaries' property='mf:name'>labeled_blank_node_with_PN_CHARS_BASE_character_boundaries</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_with_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_with_PN_CHARS_BASE_character_boundaries' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node with PN<em>CHARS</em>BASE character boundaries (_:AZazÀÖØöø...)</p>
           </div>
@@ -832,7 +832,7 @@
           </a>
           <span about='#labeled_blank_node_with_leading_underscore' property='mf:name'>labeled_blank_node_with_leading_underscore</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_with_leading_underscore' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_with_leading_underscore' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node with<em>leading</em>underscore (<em>:</em>)</p>
           </div>
@@ -857,7 +857,7 @@
           </a>
           <span about='#labeled_blank_node_with_leading_digit' property='mf:name'>labeled_blank_node_with_leading_digit</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_with_leading_digit' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_with_leading_digit' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node with<em>leading</em>digit (_:0)</p>
           </div>
@@ -882,7 +882,7 @@
           </a>
           <span about='#labeled_blank_node_with_non_leading_extras' property='mf:name'>labeled_blank_node_with_non_leading_extras</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#labeled_blank_node_with_non_leading_extras' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#labeled_blank_node_with_non_leading_extras' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>labeled blank node with<em>non</em>leading<em>extras (</em>:a·̀ͯ‿.⁀)</p>
           </div>
@@ -907,7 +907,7 @@
           </a>
           <span about='#anonymous_blank_node_subject' property='mf:name'>anonymous_blank_node_subject</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#anonymous_blank_node_subject' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#anonymous_blank_node_subject' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>anonymous blank node subject</p>
           </div>
@@ -932,7 +932,7 @@
           </a>
           <span about='#anonymous_blank_node_object' property='mf:name'>anonymous_blank_node_object</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#anonymous_blank_node_object' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#anonymous_blank_node_object' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>anonymous blank node object</p>
           </div>
@@ -957,7 +957,7 @@
           </a>
           <span about='#sole_blankNodePropertyList' property='mf:name'>sole_blankNodePropertyList</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#sole_blankNodePropertyList' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='#sole_blankNodePropertyList' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
             <p>sole blankNodePropertyList [ 
               <p> <o> ] .</p>
@@ -983,7 +983,7 @@
               </a>
               <span about='#blankNodePropertyList_as_subject' property='mf:name'>blankNodePropertyList_as_subject</span>
             </dt>
-            <dd inlist property='mf:entry' resource='#blankNodePropertyList_as_subject' typeof='rdft:TestTurtleEval'>
+            <dd inlist='true' property='mf:entry' resource='#blankNodePropertyList_as_subject' typeof='rdft:TestTurtleEval'>
               <div property='rdfs:comment'>
                 <p>blankNodePropertyList as subject [ … ] 
                   <p> <o> .</p>
@@ -1009,7 +1009,7 @@
                   </a>
                   <span about='#blankNodePropertyList_as_object' property='mf:name'>blankNodePropertyList_as_object</span>
                 </dt>
-                <dd inlist property='mf:entry' resource='#blankNodePropertyList_as_object' typeof='rdft:TestTurtleEval'>
+                <dd inlist='true' property='mf:entry' resource='#blankNodePropertyList_as_object' typeof='rdft:TestTurtleEval'>
                   <div property='rdfs:comment'>
                     <p>blankNodePropertyList as object <s> 
                         <p> [ … ] .</p>
@@ -1035,7 +1035,7 @@
                       </a>
                       <span about='#blankNodePropertyList_as_object_containing_objectList' property='mf:name'>blankNodePropertyList_as_object_containing_objectList</span>
                     </dt>
-                    <dd inlist property='mf:entry' resource='#blankNodePropertyList_as_object_containing_objectList' typeof='rdft:TestTurtleEval'>
+                    <dd inlist='true' property='mf:entry' resource='#blankNodePropertyList_as_object_containing_objectList' typeof='rdft:TestTurtleEval'>
                       <div property='rdfs:comment'>
                         <p>blankNodePropertyList as object containing objectList <s> 
                             <p> [ <p2> <o>,<o2> ] .</p>
@@ -1061,7 +1061,7 @@
                                 </a>
                                 <span about='#blankNodePropertyList_as_object_containing_objectList_of_two_objects' property='mf:name'>blankNodePropertyList_as_object_containing_objectList_of_two_objects</span>
                               </dt>
-                              <dd inlist property='mf:entry' resource='#blankNodePropertyList_as_object_containing_objectList_of_two_objects' typeof='rdft:TestTurtleEval'>
+                              <dd inlist='true' property='mf:entry' resource='#blankNodePropertyList_as_object_containing_objectList_of_two_objects' typeof='rdft:TestTurtleEval'>
                                 <div property='rdfs:comment'>
                                   <p>blankNodePropertyList as object containing objectList of two objects <s> 
                                       <p> [ <p2 <o> ] , <o2> .</p>
@@ -1087,7 +1087,7 @@
                                         </a>
                                         <span about='#blankNodePropertyList_with_multiple_triples' property='mf:name'>blankNodePropertyList_with_multiple_triples</span>
                                       </dt>
-                                      <dd inlist property='mf:entry' resource='#blankNodePropertyList_with_multiple_triples' typeof='rdft:TestTurtleEval'>
+                                      <dd inlist='true' property='mf:entry' resource='#blankNodePropertyList_with_multiple_triples' typeof='rdft:TestTurtleEval'>
                                         <div property='rdfs:comment'>
                                           <p>blankNodePropertyList with multiple triples [ <s> 
                                               <p> ; <s2> <p2> ]</p>
@@ -1113,7 +1113,7 @@
                                                 </a>
                                                 <span about='#nested_blankNodePropertyLists' property='mf:name'>nested_blankNodePropertyLists</span>
                                               </dt>
-                                              <dd inlist property='mf:entry' resource='#nested_blankNodePropertyLists' typeof='rdft:TestTurtleEval'>
+                                              <dd inlist='true' property='mf:entry' resource='#nested_blankNodePropertyLists' typeof='rdft:TestTurtleEval'>
                                                 <div property='rdfs:comment'>
                                                   <p>nested blankNodePropertyLists [ <p1> [ <p2> <o2> ] ; <p3> <o3> ]</p>
                                                           </div>
@@ -1138,7 +1138,7 @@
                                                           </a>
                                                           <span about='#blankNodePropertyList_containing_collection' property='mf:name'>blankNodePropertyList_containing_collection</span>
                                                         </dt>
-                                                        <dd inlist property='mf:entry' resource='#blankNodePropertyList_containing_collection' typeof='rdft:TestTurtleEval'>
+                                                        <dd inlist='true' property='mf:entry' resource='#blankNodePropertyList_containing_collection' typeof='rdft:TestTurtleEval'>
                                                           <div property='rdfs:comment'>
                                                             <p>blankNodePropertyList containing collection [ <p1> ( … ) ]</p>
                                                             </div>
@@ -1163,7 +1163,7 @@
                                                             </a>
                                                             <span about='#collection_subject' property='mf:name'>collection_subject</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#collection_subject' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#collection_subject' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>collection subject</p>
                                                             </div>
@@ -1188,7 +1188,7 @@
                                                             </a>
                                                             <span about='#collection_object' property='mf:name'>collection_object</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#collection_object' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#collection_object' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>collection object</p>
                                                             </div>
@@ -1213,7 +1213,7 @@
                                                             </a>
                                                             <span about='#empty_collection' property='mf:name'>empty_collection</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#empty_collection' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#empty_collection' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>empty collection ()</p>
                                                             </div>
@@ -1238,7 +1238,7 @@
                                                             </a>
                                                             <span about='#nested_collection' property='mf:name'>nested_collection</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#nested_collection' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#nested_collection' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>nested collection (())</p>
                                                             </div>
@@ -1263,7 +1263,7 @@
                                                             </a>
                                                             <span about='#first' property='mf:name'>first</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#first' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#first' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>first, not last, non-empty nested collection</p>
                                                             </div>
@@ -1288,7 +1288,7 @@
                                                             </a>
                                                             <span about='#last' property='mf:name'>last</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#last' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#last' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>last, not first, non-empty nested collection</p>
                                                             </div>
@@ -1313,7 +1313,7 @@
                                                             </a>
                                                             <span about='#LITERAL1' property='mf:name'>LITERAL1</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL1' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL1' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL1 &#39;x&#39;</p>
                                                             </div>
@@ -1338,7 +1338,7 @@
                                                             </a>
                                                             <span about='#LITERAL1_ascii_boundaries' property='mf:name'>LITERAL1_ascii_boundaries</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL1_ascii_boundaries' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL1_ascii_boundaries' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL1<em>ascii</em>boundaries &#39;\x00\x09\x0b\x0c\x0e\x26\x28...&#39;</p>
                                                             </div>
@@ -1363,7 +1363,7 @@
                                                             </a>
                                                             <span about='#LITERAL1_with_UTF8_boundaries' property='mf:name'>LITERAL1_with_UTF8_boundaries</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL1_with_UTF8_boundaries' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL1_with_UTF8_boundaries' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL1<em>with</em>UTF8_boundaries &#39;\x80\x7ff\x800\xfff...&#39;</p>
                                                             </div>
@@ -1388,7 +1388,7 @@
                                                             </a>
                                                             <span about='#LITERAL1_all_controls' property='mf:name'>LITERAL1_all_controls</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL1_all_controls' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL1_all_controls' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL1<em>all</em>controls &#39;\x00\x01\x02\x03\x04...&#39;</p>
                                                             </div>
@@ -1413,7 +1413,7 @@
                                                             </a>
                                                             <span about='#LITERAL1_all_punctuation' property='mf:name'>LITERAL1_all_punctuation</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL1_all_punctuation' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL1_all_punctuation' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL1<em>all</em>punctuation &#39;!&quot;#$%&amp;()...&#39;</p>
                                                             </div>
@@ -1438,7 +1438,7 @@
                                                             </a>
                                                             <span about='#LITERAL_LONG1' property='mf:name'>LITERAL_LONG1</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL_LONG1' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG1' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL_LONG1 &#39;&#39;&#39;x&#39;&#39;&#39;</p>
                                                             </div>
@@ -1463,7 +1463,7 @@
                                                             </a>
                                                             <span about='#LITERAL_LONG1_ascii_boundaries' property='mf:name'>LITERAL_LONG1_ascii_boundaries</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL_LONG1_ascii_boundaries' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG1_ascii_boundaries' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL<em>LONG1</em>ascii_boundaries &#39;\x00\x26\x28...&#39;</p>
                                                             </div>
@@ -1488,7 +1488,7 @@
                                                             </a>
                                                             <span about='#LITERAL_LONG1_with_UTF8_boundaries' property='mf:name'>LITERAL_LONG1_with_UTF8_boundaries</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL_LONG1_with_UTF8_boundaries' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG1_with_UTF8_boundaries' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL<em>LONG1</em>with<em>UTF8</em>boundaries &#39;\x80\x7ff\x800\xfff...&#39;</p>
                                                             </div>
@@ -1513,7 +1513,7 @@
                                                             </a>
                                                             <span about='#LITERAL_LONG1_with_1_squote' property='mf:name'>LITERAL_LONG1_with_1_squote</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL_LONG1_with_1_squote' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG1_with_1_squote' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL_LONG1 with 1 squote &#39;&#39;&#39;a&#39;b&#39;&#39;&#39;</p>
                                                             </div>
@@ -1538,7 +1538,7 @@
                                                             </a>
                                                             <span about='#LITERAL_LONG1_with_2_squotes' property='mf:name'>LITERAL_LONG1_with_2_squotes</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL_LONG1_with_2_squotes' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG1_with_2_squotes' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL_LONG1 with 2 squotes &#39;&#39;&#39;a&#39;&#39;b&#39;&#39;&#39;</p>
                                                             </div>
@@ -1563,7 +1563,7 @@
                                                             </a>
                                                             <span about='#LITERAL2' property='mf:name'>LITERAL2</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL2' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL2' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL2 &quot;x&quot;</p>
                                                             </div>
@@ -1588,7 +1588,7 @@
                                                             </a>
                                                             <span about='#LITERAL2_ascii_boundaries' property='mf:name'>LITERAL2_ascii_boundaries</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL2_ascii_boundaries' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL2_ascii_boundaries' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL2<em>ascii</em>boundaries &#39;\x00\x09\x0b\x0c\x0e\x21\x23...&#39;</p>
                                                             </div>
@@ -1613,7 +1613,7 @@
                                                             </a>
                                                             <span about='#LITERAL2_with_UTF8_boundaries' property='mf:name'>LITERAL2_with_UTF8_boundaries</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL2_with_UTF8_boundaries' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL2_with_UTF8_boundaries' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL2<em>with</em>UTF8_boundaries &#39;\x80\x7ff\x800\xfff...&#39;</p>
                                                             </div>
@@ -1638,7 +1638,7 @@
                                                             </a>
                                                             <span about='#LITERAL_LONG2' property='mf:name'>LITERAL_LONG2</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL_LONG2' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL_LONG2 &quot;&quot;&quot;x&quot;&quot;&quot;</p>
                                                             </div>
@@ -1663,7 +1663,7 @@
                                                             </a>
                                                             <span about='#LITERAL_LONG2_ascii_boundaries' property='mf:name'>LITERAL_LONG2_ascii_boundaries</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL_LONG2_ascii_boundaries' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2_ascii_boundaries' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL<em>LONG2</em>ascii_boundaries &#39;\x00\x21\x23...&#39;</p>
                                                             </div>
@@ -1688,7 +1688,7 @@
                                                             </a>
                                                             <span about='#LITERAL_LONG2_with_UTF8_boundaries' property='mf:name'>LITERAL_LONG2_with_UTF8_boundaries</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL_LONG2_with_UTF8_boundaries' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2_with_UTF8_boundaries' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL<em>LONG2</em>with<em>UTF8</em>boundaries &#39;\x80\x7ff\x800\xfff...&#39;</p>
                                                             </div>
@@ -1713,7 +1713,7 @@
                                                             </a>
                                                             <span about='#LITERAL_LONG2_with_1_squote' property='mf:name'>LITERAL_LONG2_with_1_squote</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL_LONG2_with_1_squote' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2_with_1_squote' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL_LONG2 with 1 squote &quot;&quot;&quot;a&quot;b&quot;&quot;&quot;</p>
                                                             </div>
@@ -1738,7 +1738,7 @@
                                                             </a>
                                                             <span about='#LITERAL_LONG2_with_2_squotes' property='mf:name'>LITERAL_LONG2_with_2_squotes</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#LITERAL_LONG2_with_2_squotes' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2_with_2_squotes' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>LITERAL_LONG2 with 2 squotes &quot;&quot;&quot;a&quot;&quot;b&quot;&quot;&quot;</p>
                                                             </div>
@@ -1763,7 +1763,7 @@
                                                             </a>
                                                             <span about='#literal_with_CHARACTER_TABULATION' property='mf:name'>literal_with_CHARACTER_TABULATION</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_CHARACTER_TABULATION' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_CHARACTER_TABULATION' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with CHARACTER TABULATION</p>
                                                             </div>
@@ -1788,7 +1788,7 @@
                                                             </a>
                                                             <span about='#literal_with_BACKSPACE' property='mf:name'>literal_with_BACKSPACE</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_BACKSPACE' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_BACKSPACE' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with BACKSPACE</p>
                                                             </div>
@@ -1813,7 +1813,7 @@
                                                             </a>
                                                             <span about='#literal_with_LINE_FEED' property='mf:name'>literal_with_LINE_FEED</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_LINE_FEED' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_LINE_FEED' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with LINE FEED</p>
                                                             </div>
@@ -1838,7 +1838,7 @@
                                                             </a>
                                                             <span about='#literal_with_CARRIAGE_RETURN' property='mf:name'>literal_with_CARRIAGE_RETURN</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_CARRIAGE_RETURN' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_CARRIAGE_RETURN' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with CARRIAGE RETURN</p>
                                                             </div>
@@ -1863,7 +1863,7 @@
                                                             </a>
                                                             <span about='#literal_with_FORM_FEED' property='mf:name'>literal_with_FORM_FEED</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_FORM_FEED' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_FORM_FEED' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with FORM FEED</p>
                                                             </div>
@@ -1888,7 +1888,7 @@
                                                             </a>
                                                             <span about='#literal_with_REVERSE_SOLIDUS' property='mf:name'>literal_with_REVERSE_SOLIDUS</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_REVERSE_SOLIDUS' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with REVERSE SOLIDUS</p>
                                                             </div>
@@ -1913,7 +1913,7 @@
                                                             </a>
                                                             <span about='#literal_with_escaped_CHARACTER_TABULATION' property='mf:name'>literal_with_escaped_CHARACTER_TABULATION</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_escaped_CHARACTER_TABULATION' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_escaped_CHARACTER_TABULATION' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with escaped CHARACTER TABULATION</p>
                                                             </div>
@@ -1938,7 +1938,7 @@
                                                             </a>
                                                             <span about='#literal_with_escaped_BACKSPACE' property='mf:name'>literal_with_escaped_BACKSPACE</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_escaped_BACKSPACE' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_escaped_BACKSPACE' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with escaped BACKSPACE</p>
                                                             </div>
@@ -1963,7 +1963,7 @@
                                                             </a>
                                                             <span about='#literal_with_escaped_LINE_FEED' property='mf:name'>literal_with_escaped_LINE_FEED</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_escaped_LINE_FEED' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_escaped_LINE_FEED' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with escaped LINE FEED</p>
                                                             </div>
@@ -1988,7 +1988,7 @@
                                                             </a>
                                                             <span about='#literal_with_escaped_CARRIAGE_RETURN' property='mf:name'>literal_with_escaped_CARRIAGE_RETURN</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_escaped_CARRIAGE_RETURN' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_escaped_CARRIAGE_RETURN' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with escaped CARRIAGE RETURN</p>
                                                             </div>
@@ -2013,7 +2013,7 @@
                                                             </a>
                                                             <span about='#literal_with_escaped_FORM_FEED' property='mf:name'>literal_with_escaped_FORM_FEED</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_escaped_FORM_FEED' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_escaped_FORM_FEED' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with escaped FORM FEED</p>
                                                             </div>
@@ -2038,7 +2038,7 @@
                                                             </a>
                                                             <span about='#literal_with_numeric_escape4' property='mf:name'>literal_with_numeric_escape4</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_numeric_escape4' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_numeric_escape4' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with numeric escape4 \u</p>
                                                             </div>
@@ -2063,7 +2063,7 @@
                                                             </a>
                                                             <span about='#literal_with_numeric_escape8' property='mf:name'>literal_with_numeric_escape8</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#literal_with_numeric_escape8' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#literal_with_numeric_escape8' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>literal with numeric escape8 \U</p>
                                                             </div>
@@ -2088,7 +2088,7 @@
                                                             </a>
                                                             <span about='#IRIREF_datatype' property='mf:name'>IRIREF_datatype</span>
                                                           </dt>
-                                                          <dd inlist property='mf:entry' resource='#IRIREF_datatype' typeof='rdft:TestTurtleEval'>
+                                                          <dd inlist='true' property='mf:entry' resource='#IRIREF_datatype' typeof='rdft:TestTurtleEval'>
                                                             <div property='rdfs:comment'>
                                                               <p>IRIREF datatype &quot;&quot;^^<t></p>
                                                               </div>
@@ -2113,7 +2113,7 @@
                                                               </a>
                                                               <span about='#prefixed_name_datatype' property='mf:name'>prefixed_name_datatype</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#prefixed_name_datatype' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#prefixed_name_datatype' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>prefixed name datatype &quot;&quot;^^p:t</p>
                                                               </div>
@@ -2138,7 +2138,7 @@
                                                               </a>
                                                               <span about='#bareword_integer' property='mf:name'>bareword_integer</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#bareword_integer' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#bareword_integer' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>bareword integer</p>
                                                               </div>
@@ -2163,7 +2163,7 @@
                                                               </a>
                                                               <span about='#bareword_decimal' property='mf:name'>bareword_decimal</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#bareword_decimal' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#bareword_decimal' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>bareword decimal</p>
                                                               </div>
@@ -2188,7 +2188,7 @@
                                                               </a>
                                                               <span about='#bareword_double' property='mf:name'>bareword_double</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#bareword_double' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#bareword_double' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>bareword double</p>
                                                               </div>
@@ -2213,7 +2213,7 @@
                                                               </a>
                                                               <span about='#double_lower_case_e' property='mf:name'>double_lower_case_e</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#double_lower_case_e' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#double_lower_case_e' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>double lower case e</p>
                                                               </div>
@@ -2238,7 +2238,7 @@
                                                               </a>
                                                               <span about='#negative_numeric' property='mf:name'>negative_numeric</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#negative_numeric' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#negative_numeric' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>negative numeric</p>
                                                               </div>
@@ -2263,7 +2263,7 @@
                                                               </a>
                                                               <span about='#positive_numeric' property='mf:name'>positive_numeric</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#positive_numeric' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#positive_numeric' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>positive numeric</p>
                                                               </div>
@@ -2288,7 +2288,7 @@
                                                               </a>
                                                               <span about='#numeric_with_leading_0' property='mf:name'>numeric_with_leading_0</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#numeric_with_leading_0' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#numeric_with_leading_0' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>numeric with leading 0</p>
                                                               </div>
@@ -2313,7 +2313,7 @@
                                                               </a>
                                                               <span about='#literal_true' property='mf:name'>literal_true</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#literal_true' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#literal_true' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>literal true</p>
                                                               </div>
@@ -2338,7 +2338,7 @@
                                                               </a>
                                                               <span about='#literal_false' property='mf:name'>literal_false</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#literal_false' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#literal_false' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>literal false</p>
                                                               </div>
@@ -2363,7 +2363,7 @@
                                                               </a>
                                                               <span about='#langtagged_non_LONG' property='mf:name'>langtagged_non_LONG</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#langtagged_non_LONG' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#langtagged_non_LONG' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>langtagged non-LONG &quot;x&quot;@en</p>
                                                               </div>
@@ -2388,7 +2388,7 @@
                                                               </a>
                                                               <span about='#langtagged_LONG' property='mf:name'>langtagged_LONG</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#langtagged_LONG' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#langtagged_LONG' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>langtagged LONG &quot;&quot;&quot;x&quot;&quot;&quot;@en</p>
                                                               </div>
@@ -2413,7 +2413,7 @@
                                                               </a>
                                                               <span about='#lantag_with_subtag' property='mf:name'>lantag_with_subtag</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#lantag_with_subtag' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#lantag_with_subtag' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>lantag with subtag &quot;x&quot;@en-us</p>
                                                               </div>
@@ -2438,7 +2438,7 @@
                                                               </a>
                                                               <span about='#objectList_with_two_objects' property='mf:name'>objectList_with_two_objects</span>
                                                             </dt>
-                                                            <dd inlist property='mf:entry' resource='#objectList_with_two_objects' typeof='rdft:TestTurtleEval'>
+                                                            <dd inlist='true' property='mf:entry' resource='#objectList_with_two_objects' typeof='rdft:TestTurtleEval'>
                                                               <div property='rdfs:comment'>
                                                                 <p>objectList with two objects … <o1>,<o2></p>
                                                                   </div>
@@ -2463,7 +2463,7 @@
                                                                   </a>
                                                                   <span about='#predicateObjectList_with_two_objectLists' property='mf:name'>predicateObjectList_with_two_objectLists</span>
                                                                 </dt>
-                                                                <dd inlist property='mf:entry' resource='#predicateObjectList_with_two_objectLists' typeof='rdft:TestTurtleEval'>
+                                                                <dd inlist='true' property='mf:entry' resource='#predicateObjectList_with_two_objectLists' typeof='rdft:TestTurtleEval'>
                                                                   <div property='rdfs:comment'>
                                                                     <p>predicateObjectList with two objectLists … <o1>,<o2></p>
                                                                       </div>
@@ -2488,7 +2488,7 @@
                                                                       </a>
                                                                       <span about='#predicateObjectList_with_blankNodePropertyList_as_object' property='mf:name'>predicateObjectList_with_blankNodePropertyList_as_object</span>
                                                                     </dt>
-                                                                    <dd inlist property='mf:entry' resource='#predicateObjectList_with_blankNodePropertyList_as_object' typeof='rdft:TestTurtleEval'>
+                                                                    <dd inlist='true' property='mf:entry' resource='#predicateObjectList_with_blankNodePropertyList_as_object' typeof='rdft:TestTurtleEval'>
                                                                       <div property='rdfs:comment'>
                                                                         <p>predicateObjectList<em>with</em>blankNodePropertyList<em>as</em>object <s> 
                                                                             <p> [ <p2> <o> ] ; <p3> [ <p4> <o2> , <o3> ]</p>
@@ -2514,7 +2514,7 @@
                                                                                       </a>
                                                                                       <span about='#repeated_semis_at_end' property='mf:name'>repeated_semis_at_end</span>
                                                                                     </dt>
-                                                                                    <dd inlist property='mf:entry' resource='#repeated_semis_at_end' typeof='rdft:TestTurtleEval'>
+                                                                                    <dd inlist='true' property='mf:entry' resource='#repeated_semis_at_end' typeof='rdft:TestTurtleEval'>
                                                                                       <div property='rdfs:comment'>
                                                                                         <p>repeated semis at end <s> 
                                                                                             <p> <o> ;; <p2> <o2> .</p>
@@ -2540,7 +2540,7 @@
                                                                                                 </a>
                                                                                                 <span about='#repeated_semis_not_at_end' property='mf:name'>repeated_semis_not_at_end</span>
                                                                                               </dt>
-                                                                                              <dd inlist property='mf:entry' resource='#repeated_semis_not_at_end' typeof='rdft:TestTurtleEval'>
+                                                                                              <dd inlist='true' property='mf:entry' resource='#repeated_semis_not_at_end' typeof='rdft:TestTurtleEval'>
                                                                                                 <div property='rdfs:comment'>
                                                                                                   <p>repeated semis not at end <s> 
                                                                                                       <p> <o> ;;.</p>
@@ -2566,7 +2566,7 @@
                                                                                                       </a>
                                                                                                       <span about='#comment_following_localName' property='mf:name'>comment_following_localName</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#comment_following_localName' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#comment_following_localName' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>comment following localName</p>
                                                                                                       </div>
@@ -2591,7 +2591,7 @@
                                                                                                       </a>
                                                                                                       <span about='#number_sign_following_localName' property='mf:name'>number_sign_following_localName</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#number_sign_following_localName' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#number_sign_following_localName' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>number sign following localName</p>
                                                                                                       </div>
@@ -2616,7 +2616,7 @@
                                                                                                       </a>
                                                                                                       <span about='#comment_following_PNAME_NS' property='mf:name'>comment_following_PNAME_NS</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#comment_following_PNAME_NS' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#comment_following_PNAME_NS' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>comment following PNAME_NS</p>
                                                                                                       </div>
@@ -2641,7 +2641,7 @@
                                                                                                       </a>
                                                                                                       <span about='#number_sign_following_PNAME_NS' property='mf:name'>number_sign_following_PNAME_NS</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#number_sign_following_PNAME_NS' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#number_sign_following_PNAME_NS' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>number sign following PNAME_NS</p>
                                                                                                       </div>
@@ -2666,7 +2666,7 @@
                                                                                                       </a>
                                                                                                       <span about='#LITERAL_LONG2_with_REVERSE_SOLIDUS' property='mf:name'>LITERAL_LONG2_with_REVERSE_SOLIDUS</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#LITERAL_LONG2_with_REVERSE_SOLIDUS' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#LITERAL_LONG2_with_REVERSE_SOLIDUS' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>REVERSE SOLIDUS at end of LITERAL_LONG2</p>
                                                                                                       </div>
@@ -2691,7 +2691,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-LITERAL2_with_langtag_and_datatype' property='mf:name'>turtle-syntax-bad-num-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-LITERAL2_with_langtag_and_datatype' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-LITERAL2_with_langtag_and_datatype' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad number format (negative test)</p>
                                                                                                       </div>
@@ -2712,7 +2712,7 @@
                                                                                                       </a>
                                                                                                       <span about='#two_LITERAL_LONG2s' property='mf:name'>two_LITERAL_LONG2s</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#two_LITERAL_LONG2s' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#two_LITERAL_LONG2s' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>two LITERAL_LONG2s testing quote delimiter overrun</p>
                                                                                                       </div>
@@ -2737,7 +2737,7 @@
                                                                                                       </a>
                                                                                                       <span about='#langtagged_LONG_with_subtag' property='mf:name'>langtagged_LONG_with_subtag</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#langtagged_LONG_with_subtag' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#langtagged_LONG_with_subtag' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>langtagged LONG with subtag &quot;&quot;&quot;Cheers&quot;&quot;&quot;@en-UK</p>
                                                                                                       </div>
@@ -2762,7 +2762,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-file-01' property='mf:name'>turtle-syntax-file-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-file-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-file-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Empty file</p>
                                                                                                       </div>
@@ -2783,7 +2783,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-file-02' property='mf:name'>turtle-syntax-file-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-file-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-file-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Only comment</p>
                                                                                                       </div>
@@ -2804,7 +2804,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-file-03' property='mf:name'>turtle-syntax-file-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-file-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-file-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>One comment, one empty line</p>
                                                                                                       </div>
@@ -2825,7 +2825,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-uri-01' property='mf:name'>turtle-syntax-uri-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-uri-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-uri-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Only IRIs</p>
                                                                                                       </div>
@@ -2846,7 +2846,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-uri-02' property='mf:name'>turtle-syntax-uri-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-uri-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-uri-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>IRIs with Unicode escape</p>
                                                                                                       </div>
@@ -2867,7 +2867,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-uri-03' property='mf:name'>turtle-syntax-uri-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-uri-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-uri-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>IRIs with long Unicode escape</p>
                                                                                                       </div>
@@ -2888,7 +2888,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-uri-04' property='mf:name'>turtle-syntax-uri-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-uri-04' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-uri-04' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Legal IRIs</p>
                                                                                                       </div>
@@ -2909,7 +2909,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-base-01' property='mf:name'>turtle-syntax-base-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-base-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-base-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@base</p>
                                                                                                       </div>
@@ -2930,7 +2930,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-base-02' property='mf:name'>turtle-syntax-base-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-base-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-base-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>BASE</p>
                                                                                                       </div>
@@ -2951,7 +2951,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-base-03' property='mf:name'>turtle-syntax-base-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-base-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-base-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@base with relative IRIs</p>
                                                                                                       </div>
@@ -2972,7 +2972,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-base-04' property='mf:name'>turtle-syntax-base-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-base-04' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-base-04' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>base with relative IRIs</p>
                                                                                                       </div>
@@ -2993,7 +2993,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-prefix-01' property='mf:name'>turtle-syntax-prefix-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-prefix-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-prefix-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@prefix</p>
                                                                                                       </div>
@@ -3014,7 +3014,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-prefix-02' property='mf:name'>turtle-syntax-prefix-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-prefix-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-prefix-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>PreFIX</p>
                                                                                                       </div>
@@ -3035,7 +3035,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-prefix-03' property='mf:name'>turtle-syntax-prefix-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-prefix-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-prefix-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Empty PREFIX</p>
                                                                                                       </div>
@@ -3056,7 +3056,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-prefix-04' property='mf:name'>turtle-syntax-prefix-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-prefix-04' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-prefix-04' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Empty @prefix with % escape</p>
                                                                                                       </div>
@@ -3077,7 +3077,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-prefix-05' property='mf:name'>turtle-syntax-prefix-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-prefix-05' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-prefix-05' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@prefix with no suffix</p>
                                                                                                       </div>
@@ -3098,7 +3098,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-prefix-06' property='mf:name'>turtle-syntax-prefix-06</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-prefix-06' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-prefix-06' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>colon is a legal pname character</p>
                                                                                                       </div>
@@ -3119,7 +3119,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-prefix-07' property='mf:name'>turtle-syntax-prefix-07</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-prefix-07' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-prefix-07' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>dash is a legal pname character</p>
                                                                                                       </div>
@@ -3140,7 +3140,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-prefix-08' property='mf:name'>turtle-syntax-prefix-08</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-prefix-08' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-prefix-08' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>underscore is a legal pname character</p>
                                                                                                       </div>
@@ -3161,7 +3161,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-prefix-09' property='mf:name'>turtle-syntax-prefix-09</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-prefix-09' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-prefix-09' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>percents in pnames</p>
                                                                                                       </div>
@@ -3182,7 +3182,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-01' property='mf:name'>turtle-syntax-string-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>string literal</p>
                                                                                                       </div>
@@ -3203,7 +3203,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-02' property='mf:name'>turtle-syntax-string-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>langString literal</p>
                                                                                                       </div>
@@ -3224,7 +3224,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-03' property='mf:name'>turtle-syntax-string-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>langString literal with region</p>
                                                                                                       </div>
@@ -3245,7 +3245,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-04' property='mf:name'>turtle-syntax-string-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-04' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-04' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>squote string literal</p>
                                                                                                       </div>
@@ -3266,7 +3266,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-05' property='mf:name'>turtle-syntax-string-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-05' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-05' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>squote langString literal</p>
                                                                                                       </div>
@@ -3287,7 +3287,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-06' property='mf:name'>turtle-syntax-string-06</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-06' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-06' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>squote langString literal with region</p>
                                                                                                       </div>
@@ -3308,7 +3308,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-07' property='mf:name'>turtle-syntax-string-07</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-07' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-07' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>long string literal with embedded single- and double-quotes</p>
                                                                                                       </div>
@@ -3329,7 +3329,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-08' property='mf:name'>turtle-syntax-string-08</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-08' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-08' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>long string literal with embedded newline</p>
                                                                                                       </div>
@@ -3350,7 +3350,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-09' property='mf:name'>turtle-syntax-string-09</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-09' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-09' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>squote long string literal with embedded single- and double-quotes</p>
                                                                                                       </div>
@@ -3371,7 +3371,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-10' property='mf:name'>turtle-syntax-string-10</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-10' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-10' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>long langString literal with embedded newline</p>
                                                                                                       </div>
@@ -3392,7 +3392,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-string-11' property='mf:name'>turtle-syntax-string-11</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-string-11' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-string-11' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>squote long langString literal with embedded newline</p>
                                                                                                       </div>
@@ -3413,7 +3413,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-str-esc-01' property='mf:name'>turtle-syntax-str-esc-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-str-esc-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-str-esc-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>string literal with escaped newline</p>
                                                                                                       </div>
@@ -3434,7 +3434,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-str-esc-02' property='mf:name'>turtle-syntax-str-esc-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-str-esc-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-str-esc-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>string literal with Unicode escape</p>
                                                                                                       </div>
@@ -3455,7 +3455,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-str-esc-03' property='mf:name'>turtle-syntax-str-esc-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-str-esc-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-str-esc-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>string literal with long Unicode escape</p>
                                                                                                       </div>
@@ -3476,7 +3476,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-pname-esc-01' property='mf:name'>turtle-syntax-pname-esc-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-pname-esc-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-pname-esc-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>pname with back-slash escapes</p>
                                                                                                       </div>
@@ -3497,7 +3497,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-pname-esc-02' property='mf:name'>turtle-syntax-pname-esc-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-pname-esc-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-pname-esc-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>pname with back-slash escapes (2)</p>
                                                                                                       </div>
@@ -3518,7 +3518,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-pname-esc-03' property='mf:name'>turtle-syntax-pname-esc-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-pname-esc-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-pname-esc-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>pname with back-slash escapes (3)</p>
                                                                                                       </div>
@@ -3539,7 +3539,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bnode-01' property='mf:name'>turtle-syntax-bnode-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bnode-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bnode-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>bnode subject</p>
                                                                                                       </div>
@@ -3560,7 +3560,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bnode-02' property='mf:name'>turtle-syntax-bnode-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bnode-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bnode-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>bnode object</p>
                                                                                                       </div>
@@ -3581,7 +3581,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bnode-03' property='mf:name'>turtle-syntax-bnode-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bnode-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bnode-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>bnode property list object</p>
                                                                                                       </div>
@@ -3602,7 +3602,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bnode-04' property='mf:name'>turtle-syntax-bnode-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bnode-04' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bnode-04' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>bnode property list object (2)</p>
                                                                                                       </div>
@@ -3623,7 +3623,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bnode-05' property='mf:name'>turtle-syntax-bnode-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bnode-05' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bnode-05' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>bnode property list subject</p>
                                                                                                       </div>
@@ -3644,7 +3644,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bnode-06' property='mf:name'>turtle-syntax-bnode-06</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bnode-06' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bnode-06' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>labeled bnode subject</p>
                                                                                                       </div>
@@ -3665,7 +3665,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bnode-07' property='mf:name'>turtle-syntax-bnode-07</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bnode-07' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bnode-07' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>labeled bnode subject and object</p>
                                                                                                       </div>
@@ -3686,7 +3686,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bnode-08' property='mf:name'>turtle-syntax-bnode-08</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bnode-08' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bnode-08' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>bare bnode property list</p>
                                                                                                       </div>
@@ -3707,7 +3707,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bnode-09' property='mf:name'>turtle-syntax-bnode-09</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bnode-09' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bnode-09' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>bnode property list</p>
                                                                                                       </div>
@@ -3728,7 +3728,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bnode-10' property='mf:name'>turtle-syntax-bnode-10</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bnode-10' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bnode-10' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>mixed bnode property list and triple</p>
                                                                                                       </div>
@@ -3749,7 +3749,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-01' property='mf:name'>turtle-syntax-number-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>integer literal</p>
                                                                                                       </div>
@@ -3770,7 +3770,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-02' property='mf:name'>turtle-syntax-number-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>negative integer literal</p>
                                                                                                       </div>
@@ -3791,7 +3791,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-03' property='mf:name'>turtle-syntax-number-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>positive integer literal</p>
                                                                                                       </div>
@@ -3812,7 +3812,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-04' property='mf:name'>turtle-syntax-number-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-04' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-04' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>decimal literal</p>
                                                                                                       </div>
@@ -3833,7 +3833,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-05' property='mf:name'>turtle-syntax-number-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-05' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-05' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>decimal literal (no leading digits)</p>
                                                                                                       </div>
@@ -3854,7 +3854,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-06' property='mf:name'>turtle-syntax-number-06</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-06' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-06' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>negative decimal literal</p>
                                                                                                       </div>
@@ -3875,7 +3875,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-07' property='mf:name'>turtle-syntax-number-07</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-07' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-07' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>positive decimal literal</p>
                                                                                                       </div>
@@ -3896,7 +3896,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-08' property='mf:name'>turtle-syntax-number-08</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-08' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-08' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>integer literal with decimal lexical confusion</p>
                                                                                                       </div>
@@ -3917,7 +3917,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-09' property='mf:name'>turtle-syntax-number-09</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-09' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-09' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>double literal</p>
                                                                                                       </div>
@@ -3938,7 +3938,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-10' property='mf:name'>turtle-syntax-number-10</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-10' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-10' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>negative double literal</p>
                                                                                                       </div>
@@ -3959,7 +3959,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-number-11' property='mf:name'>turtle-syntax-number-11</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-number-11' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-number-11' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>double literal no fraction</p>
                                                                                                       </div>
@@ -3980,7 +3980,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-datatypes-01' property='mf:name'>turtle-syntax-datatypes-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-datatypes-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-datatypes-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>xsd:byte literal</p>
                                                                                                       </div>
@@ -4001,7 +4001,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-datatypes-02' property='mf:name'>turtle-syntax-datatypes-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-datatypes-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-datatypes-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>integer as xsd:string</p>
                                                                                                       </div>
@@ -4022,7 +4022,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-kw-01' property='mf:name'>turtle-syntax-kw-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-kw-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-kw-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>boolean literal (true)</p>
                                                                                                       </div>
@@ -4043,7 +4043,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-kw-02' property='mf:name'>turtle-syntax-kw-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-kw-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-kw-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>boolean literal (false)</p>
                                                                                                       </div>
@@ -4064,7 +4064,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-kw-03' property='mf:name'>turtle-syntax-kw-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-kw-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-kw-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>&#39;a&#39; as keyword</p>
                                                                                                       </div>
@@ -4085,7 +4085,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-struct-01' property='mf:name'>turtle-syntax-struct-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-struct-01' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-struct-01' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>object list</p>
                                                                                                       </div>
@@ -4106,7 +4106,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-struct-02' property='mf:name'>turtle-syntax-struct-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-struct-02' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-struct-02' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>predicate list with object list</p>
                                                                                                       </div>
@@ -4127,7 +4127,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-struct-03' property='mf:name'>turtle-syntax-struct-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-struct-03' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-struct-03' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>predicate list with object list and dangling &#39;;&#39;</p>
                                                                                                       </div>
@@ -4148,7 +4148,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-struct-04' property='mf:name'>turtle-syntax-struct-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-struct-04' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-struct-04' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>predicate list with multiple ;;</p>
                                                                                                       </div>
@@ -4169,7 +4169,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-struct-05' property='mf:name'>turtle-syntax-struct-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-struct-05' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-struct-05' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>predicate list with multiple ;;</p>
                                                                                                       </div>
@@ -4190,7 +4190,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-eval-lists-01' property='mf:name'>turtle-eval-lists-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-eval-lists-01' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-eval-lists-01' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>empty list</p>
                                                                                                       </div>
@@ -4215,7 +4215,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-eval-lists-02' property='mf:name'>turtle-eval-lists-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-eval-lists-02' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-eval-lists-02' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>mixed list</p>
                                                                                                       </div>
@@ -4240,7 +4240,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-eval-lists-03' property='mf:name'>turtle-eval-lists-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-eval-lists-03' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-eval-lists-03' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>isomorphic list as subject and object</p>
                                                                                                       </div>
@@ -4265,7 +4265,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-eval-lists-04' property='mf:name'>turtle-eval-lists-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-eval-lists-04' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-eval-lists-04' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>lists of lists</p>
                                                                                                       </div>
@@ -4290,7 +4290,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-eval-lists-05' property='mf:name'>turtle-eval-lists-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-eval-lists-05' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-eval-lists-05' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>mixed lists with embedded lists</p>
                                                                                                       </div>
@@ -4315,7 +4315,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-eval-lists-06' property='mf:name'>turtle-eval-lists-06</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-eval-lists-06' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-eval-lists-06' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>list containing blank node with abbreviated term</p>
                                                                                                       </div>
@@ -4340,7 +4340,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-uri-01' property='mf:name'>turtle-syntax-bad-uri-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-uri-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-uri-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad IRI : space (negative test)</p>
                                                                                                       </div>
@@ -4361,7 +4361,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-uri-02' property='mf:name'>turtle-syntax-bad-uri-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-uri-02' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-uri-02' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad IRI : bad escape (negative test)</p>
                                                                                                       </div>
@@ -4382,7 +4382,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-uri-03' property='mf:name'>turtle-syntax-bad-uri-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-uri-03' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-uri-03' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad IRI : bad long escape (negative test)</p>
                                                                                                       </div>
@@ -4403,7 +4403,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-uri-04' property='mf:name'>turtle-syntax-bad-uri-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-uri-04' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-uri-04' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad IRI : character escapes not allowed (negative test)</p>
                                                                                                       </div>
@@ -4424,7 +4424,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-uri-05' property='mf:name'>turtle-syntax-bad-uri-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-uri-05' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-uri-05' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad IRI : character escapes not allowed (2) (negative test)</p>
                                                                                                       </div>
@@ -4445,7 +4445,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-prefix-01' property='mf:name'>turtle-syntax-bad-prefix-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-prefix-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-prefix-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>No prefix (negative test)</p>
                                                                                                       </div>
@@ -4466,7 +4466,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-prefix-02' property='mf:name'>turtle-syntax-bad-prefix-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-prefix-02' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-prefix-02' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>No prefix (2) (negative test)</p>
                                                                                                       </div>
@@ -4487,7 +4487,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-prefix-03' property='mf:name'>turtle-syntax-bad-prefix-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-prefix-03' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-prefix-03' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@prefix without URI (negative test)</p>
                                                                                                       </div>
@@ -4508,7 +4508,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-prefix-04' property='mf:name'>turtle-syntax-bad-prefix-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-prefix-04' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-prefix-04' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@prefix without prefix name (negative test)</p>
                                                                                                       </div>
@@ -4529,7 +4529,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-prefix-05' property='mf:name'>turtle-syntax-bad-prefix-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-prefix-05' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-prefix-05' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@prefix without &#39;:&#39; (negative test)</p>
                                                                                                       </div>
@@ -4550,7 +4550,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-base-01' property='mf:name'>turtle-syntax-bad-base-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-base-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-base-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@base without URI (negative test)</p>
                                                                                                       </div>
@@ -4571,7 +4571,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-base-02' property='mf:name'>turtle-syntax-bad-base-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-base-02' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-base-02' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@base in wrong case (negative test)</p>
                                                                                                       </div>
@@ -4592,7 +4592,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-base-03' property='mf:name'>turtle-syntax-bad-base-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-base-03' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-base-03' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>BASE without URI (negative test)</p>
                                                                                                       </div>
@@ -4613,7 +4613,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-bnode-01' property='mf:name'>turtle-syntax-bad-bnode-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-bnode-01' typeof='rdft:TestNTriplesNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-bnode-01' typeof='rdft:TestNTriplesNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Colon in bnode label not allowed (negative test)</p>
                                                                                                       </div>
@@ -4621,7 +4621,7 @@
                                                                                                         <dt>type</dt>
                                                                                                         <dd>rdft:TestNTriplesNegativeSyntax</dd>
                                                                                                         <dt>approval</dt>
-                                                                                                        <dd property='mf:approval'></dd>
+                                                                                                        <dd property='mf:approval' resource=''></dd>
                                                                                                         <dt>action</dt>
                                                                                                         <dd>
                                                                                                           <a href='turtle-syntax-bad-bnode-01.ttl' property='mf:action'>turtle-syntax-bad-bnode-01.ttl</a>
@@ -4634,7 +4634,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-bnode-02' property='mf:name'>turtle-syntax-bad-bnode-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-bnode-02' typeof='rdft:TestNTriplesNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-bnode-02' typeof='rdft:TestNTriplesNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Colon in bnode label not allowed (negative test)</p>
                                                                                                       </div>
@@ -4642,7 +4642,7 @@
                                                                                                         <dt>type</dt>
                                                                                                         <dd>rdft:TestNTriplesNegativeSyntax</dd>
                                                                                                         <dt>approval</dt>
-                                                                                                        <dd property='mf:approval'></dd>
+                                                                                                        <dd property='mf:approval' resource=''></dd>
                                                                                                         <dt>action</dt>
                                                                                                         <dd>
                                                                                                           <a href='turtle-syntax-bad-bnode-02.ttl' property='mf:action'>turtle-syntax-bad-bnode-02.ttl</a>
@@ -4655,7 +4655,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-01' property='mf:name'>turtle-syntax-bad-struct-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Turtle is not TriG (negative test)</p>
                                                                                                       </div>
@@ -4676,7 +4676,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-02' property='mf:name'>turtle-syntax-bad-struct-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-02' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-02' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Turtle is not N3 (negative test)</p>
                                                                                                       </div>
@@ -4697,7 +4697,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-03' property='mf:name'>turtle-syntax-bad-struct-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-03' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-03' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Turtle is not NQuads (negative test)</p>
                                                                                                       </div>
@@ -4718,7 +4718,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-04' property='mf:name'>turtle-syntax-bad-struct-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-04' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-04' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Turtle does not allow literals-as-subjects (negative test)</p>
                                                                                                       </div>
@@ -4739,7 +4739,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-05' property='mf:name'>turtle-syntax-bad-struct-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-05' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-05' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Turtle does not allow literals-as-predicates (negative test)</p>
                                                                                                       </div>
@@ -4760,7 +4760,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-06' property='mf:name'>turtle-syntax-bad-struct-06</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-06' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-06' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Turtle does not allow bnodes-as-predicates (negative test)</p>
                                                                                                       </div>
@@ -4781,7 +4781,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-07' property='mf:name'>turtle-syntax-bad-struct-07</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-07' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-07' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Turtle does not allow labeled bnodes-as-predicates (negative test)</p>
                                                                                                       </div>
@@ -4802,7 +4802,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-kw-01' property='mf:name'>turtle-syntax-bad-kw-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-kw-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-kw-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>&#39;A&#39; is not a keyword (negative test)</p>
                                                                                                       </div>
@@ -4823,7 +4823,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-kw-02' property='mf:name'>turtle-syntax-bad-kw-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-kw-02' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-kw-02' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>&#39;a&#39; cannot be used as subject (negative test)</p>
                                                                                                       </div>
@@ -4844,7 +4844,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-kw-03' property='mf:name'>turtle-syntax-bad-kw-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-kw-03' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-kw-03' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>&#39;a&#39; cannot be used as object (negative test)</p>
                                                                                                       </div>
@@ -4865,7 +4865,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-kw-04' property='mf:name'>turtle-syntax-bad-kw-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-kw-04' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-kw-04' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>&#39;true&#39; cannot be used as subject (negative test)</p>
                                                                                                       </div>
@@ -4886,7 +4886,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-kw-05' property='mf:name'>turtle-syntax-bad-kw-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-kw-05' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-kw-05' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>&#39;true&#39; cannot be used as object (negative test)</p>
                                                                                                       </div>
@@ -4907,7 +4907,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-01' property='mf:name'>turtle-syntax-bad-n3-extras-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>{} fomulae not in Turtle (negative test)</p>
                                                                                                       </div>
@@ -4928,7 +4928,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-02' property='mf:name'>turtle-syntax-bad-n3-extras-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-02' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-02' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>= is not Turtle (negative test)</p>
                                                                                                       </div>
@@ -4949,7 +4949,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-03' property='mf:name'>turtle-syntax-bad-n3-extras-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-03' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-03' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>N3 paths not in Turtle (negative test)</p>
                                                                                                       </div>
@@ -4970,7 +4970,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-04' property='mf:name'>turtle-syntax-bad-n3-extras-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-04' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-04' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>N3 paths not in Turtle (negative test)</p>
                                                                                                       </div>
@@ -4991,7 +4991,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-05' property='mf:name'>turtle-syntax-bad-n3-extras-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-05' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-05' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>N3 is...of not in Turtle (negative test)</p>
                                                                                                       </div>
@@ -5012,7 +5012,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-06' property='mf:name'>turtle-syntax-bad-n3-extras-06</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-06' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-06' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>N3 paths not in Turtle (negative test)</p>
                                                                                                       </div>
@@ -5033,7 +5033,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-07' property='mf:name'>turtle-syntax-bad-n3-extras-07</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-07' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-07' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@keywords is not Turtle (negative test)</p>
                                                                                                       </div>
@@ -5054,7 +5054,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-08' property='mf:name'>turtle-syntax-bad-n3-extras-08</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-08' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-08' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@keywords is not Turtle (negative test)</p>
                                                                                                       </div>
@@ -5075,7 +5075,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-09' property='mf:name'>turtle-syntax-bad-n3-extras-09</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-09' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-09' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>=&gt; is not Turtle (negative test)</p>
                                                                                                       </div>
@@ -5096,7 +5096,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-10' property='mf:name'>turtle-syntax-bad-n3-extras-10</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-10' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-10' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>&lt;= is not Turtle (negative test)</p>
                                                                                                       </div>
@@ -5117,7 +5117,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-11' property='mf:name'>turtle-syntax-bad-n3-extras-11</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-11' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-11' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@forSome is not Turtle (negative test)</p>
                                                                                                       </div>
@@ -5138,7 +5138,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-12' property='mf:name'>turtle-syntax-bad-n3-extras-12</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-12' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-12' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@forAll is not Turtle (negative test)</p>
                                                                                                       </div>
@@ -5159,7 +5159,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-n3-extras-13' property='mf:name'>turtle-syntax-bad-n3-extras-13</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-n3-extras-13' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-n3-extras-13' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@keywords is not Turtle (negative test)</p>
                                                                                                       </div>
@@ -5180,7 +5180,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-08' property='mf:name'>turtle-syntax-bad-struct-08</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-08' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-08' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>missing &#39;.&#39; (negative test)</p>
                                                                                                       </div>
@@ -5201,7 +5201,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-09' property='mf:name'>turtle-syntax-bad-struct-09</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-09' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-09' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>extra &#39;.&#39; (negative test)</p>
                                                                                                       </div>
@@ -5222,7 +5222,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-10' property='mf:name'>turtle-syntax-bad-struct-10</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-10' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-10' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>extra &#39;.&#39; (negative test)</p>
                                                                                                       </div>
@@ -5243,7 +5243,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-11' property='mf:name'>turtle-syntax-bad-struct-11</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-11' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-11' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>trailing &#39;;&#39; no &#39;.&#39; (negative test)</p>
                                                                                                       </div>
@@ -5264,7 +5264,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-12' property='mf:name'>turtle-syntax-bad-struct-12</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-12' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-12' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>subject, predicate, no object (negative test)</p>
                                                                                                       </div>
@@ -5285,7 +5285,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-13' property='mf:name'>turtle-syntax-bad-struct-13</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-13' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-13' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>subject, predicate, no object (negative test)</p>
                                                                                                       </div>
@@ -5306,7 +5306,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-14' property='mf:name'>turtle-syntax-bad-struct-14</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-14' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-14' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>literal as subject (negative test)</p>
                                                                                                       </div>
@@ -5327,7 +5327,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-15' property='mf:name'>turtle-syntax-bad-struct-15</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-15' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-15' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>literal as predicate (negative test)</p>
                                                                                                       </div>
@@ -5348,7 +5348,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-16' property='mf:name'>turtle-syntax-bad-struct-16</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-16' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-16' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>bnode as predicate (negative test)</p>
                                                                                                       </div>
@@ -5369,7 +5369,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-struct-17' property='mf:name'>turtle-syntax-bad-struct-17</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-struct-17' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-struct-17' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>labeled bnode as predicate (negative test)</p>
                                                                                                       </div>
@@ -5390,7 +5390,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-lang-01' property='mf:name'>turtle-syntax-bad-lang-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-lang-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-lang-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>langString with bad lang (negative test)</p>
                                                                                                       </div>
@@ -5411,7 +5411,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-esc-01' property='mf:name'>turtle-syntax-bad-esc-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-esc-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-esc-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad string escape (negative test)</p>
                                                                                                       </div>
@@ -5432,7 +5432,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-esc-02' property='mf:name'>turtle-syntax-bad-esc-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-esc-02' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-esc-02' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad string escape (negative test)</p>
                                                                                                       </div>
@@ -5453,7 +5453,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-esc-03' property='mf:name'>turtle-syntax-bad-esc-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-esc-03' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-esc-03' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad string escape (negative test)</p>
                                                                                                       </div>
@@ -5474,7 +5474,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-esc-04' property='mf:name'>turtle-syntax-bad-esc-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-esc-04' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-esc-04' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad string escape (negative test)</p>
                                                                                                       </div>
@@ -5495,7 +5495,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-pname-01' property='mf:name'>turtle-syntax-bad-pname-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-pname-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-pname-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>&#39;~&#39; must be escaped in pname (negative test)</p>
                                                                                                       </div>
@@ -5516,7 +5516,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-pname-02' property='mf:name'>turtle-syntax-bad-pname-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-pname-02' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-pname-02' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad %-sequence in pname (negative test)</p>
                                                                                                       </div>
@@ -5537,7 +5537,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-pname-03' property='mf:name'>turtle-syntax-bad-pname-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-pname-03' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-pname-03' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad unicode escape in pname (negative test)</p>
                                                                                                       </div>
@@ -5558,7 +5558,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-string-01' property='mf:name'>turtle-syntax-bad-string-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-string-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-string-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>mismatching string literal open/close (negative test)</p>
                                                                                                       </div>
@@ -5579,7 +5579,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-string-02' property='mf:name'>turtle-syntax-bad-string-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-string-02' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-string-02' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>mismatching string literal open/close (negative test)</p>
                                                                                                       </div>
@@ -5600,7 +5600,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-string-03' property='mf:name'>turtle-syntax-bad-string-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-string-03' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-string-03' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>mismatching string literal long/short (negative test)</p>
                                                                                                       </div>
@@ -5621,7 +5621,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-string-04' property='mf:name'>turtle-syntax-bad-string-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-string-04' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-string-04' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>mismatching long string literal open/close (negative test)</p>
                                                                                                       </div>
@@ -5642,7 +5642,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-string-05' property='mf:name'>turtle-syntax-bad-string-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-string-05' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-string-05' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Long literal with missing end (negative test)</p>
                                                                                                       </div>
@@ -5663,7 +5663,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-string-06' property='mf:name'>turtle-syntax-bad-string-06</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-string-06' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-string-06' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Long literal with extra quote (negative test)</p>
                                                                                                       </div>
@@ -5684,7 +5684,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-string-07' property='mf:name'>turtle-syntax-bad-string-07</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-string-07' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-string-07' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Long literal with extra squote (negative test)</p>
                                                                                                       </div>
@@ -5705,7 +5705,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-num-01' property='mf:name'>turtle-syntax-bad-num-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-num-01' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-num-01' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad number format (negative test)</p>
                                                                                                       </div>
@@ -5726,7 +5726,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-num-02' property='mf:name'>turtle-syntax-bad-num-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-num-02' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-num-02' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad number format (negative test)</p>
                                                                                                       </div>
@@ -5747,7 +5747,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-num-03' property='mf:name'>turtle-syntax-bad-num-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-num-03' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-num-03' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad number format (negative test)</p>
                                                                                                       </div>
@@ -5768,7 +5768,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-num-04' property='mf:name'>turtle-syntax-bad-num-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-num-04' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-num-04' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad number format (negative test)</p>
                                                                                                       </div>
@@ -5789,7 +5789,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-syntax-bad-num-05' property='mf:name'>turtle-syntax-bad-num-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-syntax-bad-num-05' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-num-05' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Bad number format (negative test)</p>
                                                                                                       </div>
@@ -5810,7 +5810,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-eval-struct-01' property='mf:name'>turtle-eval-struct-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-eval-struct-01' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-eval-struct-01' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>triple with IRIs</p>
                                                                                                       </div>
@@ -5835,7 +5835,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-eval-struct-02' property='mf:name'>turtle-eval-struct-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-eval-struct-02' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-eval-struct-02' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>triple with IRIs and embedded whitespace</p>
                                                                                                       </div>
@@ -5860,7 +5860,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-01' property='mf:name'>turtle-subm-01</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-01' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-01' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>Blank subject</p>
                                                                                                       </div>
@@ -5885,7 +5885,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-02' property='mf:name'>turtle-subm-02</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-02' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-02' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>@prefix and qnames</p>
                                                                                                       </div>
@@ -5910,7 +5910,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-03' property='mf:name'>turtle-subm-03</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-03' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-03' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>, operator</p>
                                                                                                       </div>
@@ -5935,7 +5935,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-04' property='mf:name'>turtle-subm-04</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-04' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-04' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>; operator</p>
                                                                                                       </div>
@@ -5960,7 +5960,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-05' property='mf:name'>turtle-subm-05</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-05' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-05' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>empty [] as subject and object</p>
                                                                                                       </div>
@@ -5985,7 +5985,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-06' property='mf:name'>turtle-subm-06</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-06' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-06' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>non-empty [] as subject and object</p>
                                                                                                       </div>
@@ -6010,7 +6010,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-07' property='mf:name'>turtle-subm-07</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-07' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-07' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>&#39;a&#39; as predicate</p>
                                                                                                       </div>
@@ -6035,7 +6035,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-08' property='mf:name'>turtle-subm-08</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-08' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-08' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>simple collection</p>
                                                                                                       </div>
@@ -6060,7 +6060,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-09' property='mf:name'>turtle-subm-09</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-09' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-09' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>empty collection</p>
                                                                                                       </div>
@@ -6085,7 +6085,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-10' property='mf:name'>turtle-subm-10</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-10' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-10' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>integer datatyped literal</p>
                                                                                                       </div>
@@ -6110,7 +6110,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-11' property='mf:name'>turtle-subm-11</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-11' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-11' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>decimal integer canonicalization</p>
                                                                                                       </div>
@@ -6135,7 +6135,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-12' property='mf:name'>turtle-subm-12</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-12' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-12' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <ul>
                                                                                                           <li>and _ in names and qnames</li>
@@ -6162,7 +6162,7 @@
                                                                                                       </a>
                                                                                                       <span about='#turtle-subm-13' property='mf:name'>turtle-subm-13</span>
                                                                                                     </dt>
-                                                                                                    <dd inlist property='mf:entry' resource='#turtle-subm-13' typeof='rdft:TestTurtleEval'>
+                                                                                                    <dd inlist='true' property='mf:entry' resource='#turtle-subm-13' typeof='rdft:TestTurtleEval'>
                                                                                                       <div property='rdfs:comment'>
                                                                                                         <p>tests for rdf:_<numbers> and other qnames starting with _</p>
                                                                                                         </div>
@@ -6187,7 +6187,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-14' property='mf:name'>turtle-subm-14</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-14' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-14' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>bare : allowed</p>
                                                                                                         </div>
@@ -6212,7 +6212,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-15' property='mf:name'>turtle-subm-15</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-15' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-15' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>simple long literal</p>
                                                                                                         </div>
@@ -6237,7 +6237,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-16' property='mf:name'>turtle-subm-16</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-16' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-16' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>long literals with escapes</p>
                                                                                                         </div>
@@ -6262,7 +6262,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-17' property='mf:name'>turtle-subm-17</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-17' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-17' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>floating point number</p>
                                                                                                         </div>
@@ -6287,7 +6287,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-18' property='mf:name'>turtle-subm-18</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-18' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-18' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>empty literals, normal and long variant</p>
                                                                                                         </div>
@@ -6312,7 +6312,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-19' property='mf:name'>turtle-subm-19</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-19' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-19' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>positive integer, decimal and doubles</p>
                                                                                                         </div>
@@ -6337,7 +6337,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-20' property='mf:name'>turtle-subm-20</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-20' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-20' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>negative integer, decimal and doubles</p>
                                                                                                         </div>
@@ -6362,7 +6362,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-21' property='mf:name'>turtle-subm-21</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-21' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-21' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>long literal ending in double quote</p>
                                                                                                         </div>
@@ -6387,7 +6387,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-22' property='mf:name'>turtle-subm-22</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-22' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-22' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>boolean literals</p>
                                                                                                         </div>
@@ -6412,7 +6412,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-23' property='mf:name'>turtle-subm-23</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-23' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-23' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>comments</p>
                                                                                                         </div>
@@ -6437,7 +6437,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-24' property='mf:name'>turtle-subm-24</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-24' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-24' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>no final mewline</p>
                                                                                                         </div>
@@ -6462,7 +6462,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-25' property='mf:name'>turtle-subm-25</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-25' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-25' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>repeating a @prefix changes pname definition</p>
                                                                                                         </div>
@@ -6487,7 +6487,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-26' property='mf:name'>turtle-subm-26</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-26' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-26' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Variations on decimal canonicalization</p>
                                                                                                         </div>
@@ -6512,7 +6512,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-subm-27' property='mf:name'>turtle-subm-27</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-subm-27' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-subm-27' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Repeating @base changes base for relative IRI lookup</p>
                                                                                                         </div>
@@ -6537,7 +6537,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-eval-bad-01' property='mf:name'>turtle-eval-bad-01</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-eval-bad-01' typeof='rdft:TestTurtleNegativeEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-eval-bad-01' typeof='rdft:TestTurtleNegativeEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Bad IRI : good escape, bad charcater (negative evaluation test)</p>
                                                                                                         </div>
@@ -6558,7 +6558,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-eval-bad-02' property='mf:name'>turtle-eval-bad-02</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-eval-bad-02' typeof='rdft:TestTurtleNegativeEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-eval-bad-02' typeof='rdft:TestTurtleNegativeEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Bad IRI : hex 3C is &lt; (negative evaluation test)</p>
                                                                                                         </div>
@@ -6579,7 +6579,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-eval-bad-03' property='mf:name'>turtle-eval-bad-03</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-eval-bad-03' typeof='rdft:TestTurtleNegativeEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-eval-bad-03' typeof='rdft:TestTurtleNegativeEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Bad IRI : hex 3E is (negative evaluation test)</p>
                                                                                                         </div>
@@ -6600,7 +6600,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-eval-bad-04' property='mf:name'>turtle-eval-bad-04</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-eval-bad-04' typeof='rdft:TestTurtleNegativeEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-eval-bad-04' typeof='rdft:TestTurtleNegativeEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Bad IRI : {abc} (negative evaluation test)</p>
                                                                                                         </div>
@@ -6621,7 +6621,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-bad-blank-label-dot-end' property='mf:name'>turtle-syntax-bad-blank-label-dot-end</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-bad-blank-label-dot-end' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-blank-label-dot-end' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Blank node label must not end in dot</p>
                                                                                                         </div>
@@ -6642,7 +6642,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-bad-ln-dash-start' property='mf:name'>turtle-syntax-bad-ln-dash-start</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-bad-ln-dash-start' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-ln-dash-start' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Local name must not begin with dash</p>
                                                                                                         </div>
@@ -6663,7 +6663,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-bad-ln-escape-start' property='mf:name'>turtle-syntax-bad-ln-escape-start</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-bad-ln-escape-start' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-ln-escape-start' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Bad hex escape at start of local name</p>
                                                                                                         </div>
@@ -6684,7 +6684,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-bad-ln-escape' property='mf:name'>turtle-syntax-bad-ln-escape</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-bad-ln-escape' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-ln-escape' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Bad hex escape in local name</p>
                                                                                                         </div>
@@ -6705,7 +6705,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-bad-missing-ns-dot-end' property='mf:name'>turtle-syntax-bad-missing-ns-dot-end</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-bad-missing-ns-dot-end' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-missing-ns-dot-end' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Prefix must not end in dot (error in triple, not prefix directive like turtle-syntax-bad-ns-dot-end)</p>
                                                                                                         </div>
@@ -6726,7 +6726,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-bad-missing-ns-dot-start' property='mf:name'>turtle-syntax-bad-missing-ns-dot-start</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-bad-missing-ns-dot-start' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-missing-ns-dot-start' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Prefix must not start with dot (error in triple, not prefix directive like turtle-syntax-bad-ns-dot-end)</p>
                                                                                                         </div>
@@ -6747,7 +6747,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-bad-ns-dot-end' property='mf:name'>turtle-syntax-bad-ns-dot-end</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-bad-ns-dot-end' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-ns-dot-end' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Prefix must not end in dot</p>
                                                                                                         </div>
@@ -6768,7 +6768,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-bad-ns-dot-start' property='mf:name'>turtle-syntax-bad-ns-dot-start</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-bad-ns-dot-start' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-ns-dot-start' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Prefix must not start with dot</p>
                                                                                                         </div>
@@ -6789,7 +6789,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-bad-number-dot-in-anon' property='mf:name'>turtle-syntax-bad-number-dot-in-anon</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-bad-number-dot-in-anon' typeof='rdft:TestTurtleNegativeSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-bad-number-dot-in-anon' typeof='rdft:TestTurtleNegativeSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Dot delimeter may not appear in anonymous nodes</p>
                                                                                                         </div>
@@ -6810,7 +6810,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-blank-label' property='mf:name'>turtle-syntax-blank-label</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-blank-label' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-blank-label' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Characters allowed in blank node labels</p>
                                                                                                         </div>
@@ -6831,7 +6831,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-ln-colons' property='mf:name'>turtle-syntax-ln-colons</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-ln-colons' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-ln-colons' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Colons in pname local names</p>
                                                                                                         </div>
@@ -6852,7 +6852,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-ln-dots' property='mf:name'>turtle-syntax-ln-dots</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-ln-dots' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-ln-dots' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Dots in pname local names</p>
                                                                                                         </div>
@@ -6873,7 +6873,7 @@
                                                                                                         </a>
                                                                                                         <span about='#turtle-syntax-ns-dots' property='mf:name'>turtle-syntax-ns-dots</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#turtle-syntax-ns-dots' typeof='rdft:TestTurtlePositiveSyntax'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#turtle-syntax-ns-dots' typeof='rdft:TestTurtlePositiveSyntax'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>Dots in namespace names</p>
                                                                                                         </div>
@@ -6894,7 +6894,7 @@
                                                                                                         </a>
                                                                                                         <span about='#IRI-resolution-01' property='mf:name'>IRI-resolution-01</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#IRI-resolution-01' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#IRI-resolution-01' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>IRI resolution (RFC3986 original cases)</p>
                                                                                                         </div>
@@ -6919,7 +6919,7 @@
                                                                                                         </a>
                                                                                                         <span about='#IRI-resolution-02' property='mf:name'>IRI-resolution-02</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#IRI-resolution-02' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#IRI-resolution-02' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>IRI resolution (RFC3986 using base IRI with trailing slash)</p>
                                                                                                         </div>
@@ -6944,7 +6944,7 @@
                                                                                                         </a>
                                                                                                         <span about='#IRI-resolution-07' property='mf:name'>IRI-resolution-07</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#IRI-resolution-07' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#IRI-resolution-07' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>IRI resolution (RFC3986 using base IRI with file path)</p>
                                                                                                         </div>
@@ -6969,7 +6969,7 @@
                                                                                                         </a>
                                                                                                         <span about='#IRI-resolution-08' property='mf:name'>IRI-resolution-08</span>
                                                                                                       </dt>
-                                                                                                      <dd inlist property='mf:entry' resource='#IRI-resolution-08' typeof='rdft:TestTurtleEval'>
+                                                                                                      <dd inlist='true' property='mf:entry' resource='#IRI-resolution-08' typeof='rdft:TestTurtleEval'>
                                                                                                         <div property='rdfs:comment'>
                                                                                                           <p>IRI resolution (miscellaneous cases)</p>
                                                                                                         </div>

--- a/rdf/rdf11/rdf-xml/index.html
+++ b/rdf/rdf11/rdf-xml/index.html
@@ -83,7 +83,7 @@
           </a>
           <span about='#amp-in-url-test001' property='mf:name'>amp-in-url-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#amp-in-url-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#amp-in-url-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Description: the purpose of this test case is to show how one of XML&#39;s Predefined Entities - in this case the ampersand - is represented when it is used in the value of an rdf:about attribute. The ampersand is represented by its numeric character reference as specified in: http://www.w3.org/TR/REC-xml#sec-predefined-ent In the associated N-Triples file, the ampersand will be represented with a single ampersand character (and not the ampersand&#39;s numeric character reference). Note: when a XML/HTML browser is used to display this file, a single ampersand character may be displayed and not the ampersand&#39;s numeric character reference. In this case, the browser may provide an alternate way to view the file (such as viewing the file&#39;s source or saving to a file).</p>
           </div>
@@ -108,7 +108,7 @@
           </a>
           <span about='#datatypes-test001' property='mf:name'>datatypes-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#datatypes-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#datatypes-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>A simple datatype production; a language+datatype production.</p>
           </div>
@@ -133,7 +133,7 @@
           </a>
           <span about='#datatypes-test002' property='mf:name'>datatypes-test002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#datatypes-test002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#datatypes-test002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>A parser is not required to know about well-formed datatyped literals.</p>
           </div>
@@ -158,7 +158,7 @@
           </a>
           <span about='#rdf-charmod-literals-test001' property='mf:name'>rdf-charmod-literals-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-charmod-literals-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-charmod-literals-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Does the treatment of literals conform to charmod ? Test for success of legal Normal Form C literal</p>
           </div>
@@ -183,7 +183,7 @@
           </a>
           <span about='#rdf-charmod-uris-test001' property='mf:name'>rdf-charmod-uris-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-charmod-uris-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-charmod-uris-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>A uriref is allowed to match non-US ASCII forms conforming to Unicode Normal Form C. No escaping algorithm is applied.</p>
           </div>
@@ -208,7 +208,7 @@
           </a>
           <span about='#rdf-charmod-uris-test002' property='mf:name'>rdf-charmod-uris-test002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-charmod-uris-test002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-charmod-uris-test002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>A uriref which already has % escaping is permitted. No unescaping algorithm is applied.</p>
           </div>
@@ -233,7 +233,7 @@
           </a>
           <span about='#rdf-containers-syntax-vs-schema-error001' property='mf:name'>rdf-containers-syntax-vs-schema-error001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-containers-syntax-vs-schema-error001' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-containers-syntax-vs-schema-error001' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>rdf:li is not allowed as as an attribute</p>
           </div>
@@ -254,7 +254,7 @@
           </a>
           <span about='#rdf-containers-syntax-vs-schema-error002' property='mf:name'>rdf-containers-syntax-vs-schema-error002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-containers-syntax-vs-schema-error002' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-containers-syntax-vs-schema-error002' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>rdf:li elements as typed nodes - a bizarre case As specified in http://lists.w3.org/Archives/Public/w3c-rdfcore-wg/2001Nov/0651.html is not an error.</p>
           </div>
@@ -275,7 +275,7 @@
           </a>
           <span about='#rdf-containers-syntax-vs-schema-test001' property='mf:name'>rdf-containers-syntax-vs-schema-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Simple container</p>
           </div>
@@ -300,7 +300,7 @@
           </a>
           <span about='#rdf-containers-syntax-vs-schema-test002' property='mf:name'>rdf-containers-syntax-vs-schema-test002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:li is unaffected by other rdf:<em>nnn properties. This test case is concerned only with defining the triples that this particular example RDF/XML represents. It is not concerned with whether that collection of triples violates any other constraints, e.g. restrictions on the number of rdf:</em>1 properties that may be defined for a resource.</p>
           </div>
@@ -325,7 +325,7 @@
           </a>
           <span about='#rdf-containers-syntax-vs-schema-test003' property='mf:name'>rdf-containers-syntax-vs-schema-test003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test003' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test003' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:li elements can exist in any description element</p>
           </div>
@@ -350,7 +350,7 @@
           </a>
           <span about='#rdf-containers-syntax-vs-schema-test004' property='mf:name'>rdf-containers-syntax-vs-schema-test004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test004' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test004' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:li elements match any of the property element productions</p>
           </div>
@@ -375,7 +375,7 @@
           </a>
           <span about='#rdf-containers-syntax-vs-schema-test006' property='mf:name'>rdf-containers-syntax-vs-schema-test006</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test006' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test006' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>containers match the typed node production</p>
           </div>
@@ -400,7 +400,7 @@
           </a>
           <span about='#rdf-containers-syntax-vs-schema-test007' property='mf:name'>rdf-containers-syntax-vs-schema-test007</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test007' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test007' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:li processing within each element is independent</p>
           </div>
@@ -425,7 +425,7 @@
           </a>
           <span about='#rdf-containers-syntax-vs-schema-test008' property='mf:name'>rdf-containers-syntax-vs-schema-test008</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test008' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-containers-syntax-vs-schema-test008' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:li processing is per element, not per resource.</p>
           </div>
@@ -450,7 +450,7 @@
           </a>
           <span about='#rdf-element-not-mandatory-test001' property='mf:name'>rdf-element-not-mandatory-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-element-not-mandatory-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-element-not-mandatory-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>A surrounding rdf:RDF element is no longer mandatory.</p>
           </div>
@@ -475,7 +475,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0001' property='mf:name'>rdf-ns-prefix-confusion-test0001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>RDF attributes that are required to have an rdf: prefix about aboutEach ID bagID type resource parseType</p>
           </div>
@@ -500,7 +500,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0003' property='mf:name'>rdf-ns-prefix-confusion-test0003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0003' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0003' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>RDF attributes that are required to have an rdf: prefix about aboutEach ID bagID type resource parseType</p>
           </div>
@@ -525,7 +525,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0004' property='mf:name'>rdf-ns-prefix-confusion-test0004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0004' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0004' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>RDF attributes that are required to have an rdf: prefix about aboutEach ID bagID type resource parseType</p>
           </div>
@@ -550,7 +550,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0005' property='mf:name'>rdf-ns-prefix-confusion-test0005</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0005' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0005' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>RDF attributes that are required to have an rdf: prefix about aboutEach ID bagID type resource parseType</p>
           </div>
@@ -575,7 +575,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0006' property='mf:name'>rdf-ns-prefix-confusion-test0006</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0006' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0006' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>RDF attributes that are required to have an rdf: prefix about aboutEach ID bagID type resource parseType</p>
           </div>
@@ -600,7 +600,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0009' property='mf:name'>rdf-ns-prefix-confusion-test0009</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0009' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0009' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Namespace qualification <em class="rfc2119">MUST</em> be used for all property attributes.</p>
           </div>
@@ -625,7 +625,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0010' property='mf:name'>rdf-ns-prefix-confusion-test0010</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0010' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0010' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Non-prefixed RDF elements (NOT attributes) are allowed when a default XML element namespace is defined with an xmlns=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot; attribute.</p>
           </div>
@@ -650,7 +650,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0011' property='mf:name'>rdf-ns-prefix-confusion-test0011</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0011' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0011' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Non-prefixed RDF elements (NOT attributes) are allowed when a default XML element namespace is defined with an xmlns=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot; attribute.</p>
           </div>
@@ -675,7 +675,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0012' property='mf:name'>rdf-ns-prefix-confusion-test0012</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0012' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0012' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Non-prefixed RDF elements (NOT attributes) are allowed when a default XML element namespace is defined with an xmlns=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot; attribute.</p>
           </div>
@@ -700,7 +700,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0013' property='mf:name'>rdf-ns-prefix-confusion-test0013</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0013' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0013' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Non-prefixed RDF elements (NOT attributes) are allowed when a default XML element namespace is defined with an xmlns=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot; attribute.</p>
           </div>
@@ -725,7 +725,7 @@
           </a>
           <span about='#rdf-ns-prefix-confusion-test0014' property='mf:name'>rdf-ns-prefix-confusion-test0014</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdf-ns-prefix-confusion-test0014' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdf-ns-prefix-confusion-test0014' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Non-prefixed RDF elements (NOT attributes) are allowed when a default XML element namespace is defined with an xmlns=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot; attribute.</p>
           </div>
@@ -750,7 +750,7 @@
           </a>
           <span about='#rdfms-abouteach-error001' property='mf:name'>rdfms-abouteach-error001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-abouteach-error001' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-abouteach-error001' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>aboutEach removed from the RDF specifications. See URI above for further details.</p>
           </div>
@@ -771,7 +771,7 @@
           </a>
           <span about='#rdfms-abouteach-error002' property='mf:name'>rdfms-abouteach-error002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-abouteach-error002' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-abouteach-error002' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>aboutEach removed from the RDF specifications. See URI above for further details.</p>
           </div>
@@ -792,7 +792,7 @@
           </a>
           <span about='#rdfms-difference-between-ID-and-about-error1' property='mf:name'>rdfms-difference-between-ID-and-about-error1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-difference-between-ID-and-about-error1' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-difference-between-ID-and-about-error1' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>two elements cannot use the same ID</p>
           </div>
@@ -813,7 +813,7 @@
           </a>
           <span about='#rdfms-difference-between-ID-and-about-test1' property='mf:name'>rdfms-difference-between-ID-and-about-test1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-difference-between-ID-and-about-test1' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-difference-between-ID-and-about-test1' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>A statement with an rdf:ID creates a regular triple.</p>
           </div>
@@ -838,7 +838,7 @@
           </a>
           <span about='#rdfms-difference-between-ID-and-about-test2' property='mf:name'>rdfms-difference-between-ID-and-about-test2</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-difference-between-ID-and-about-test2' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-difference-between-ID-and-about-test2' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>This test shows the treatment of non-ASCII characters in the value of rdf:ID attribute.</p>
           </div>
@@ -863,7 +863,7 @@
           </a>
           <span about='#rdfms-difference-between-ID-and-about-test3' property='mf:name'>rdfms-difference-between-ID-and-about-test3</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-difference-between-ID-and-about-test3' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-difference-between-ID-and-about-test3' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>This test shows the treatment of non-ASCII characters in the value of rdf:about attribute.</p>
           </div>
@@ -888,7 +888,7 @@
           </a>
           <span about='#rdfms-duplicate-member-props-test001' property='mf:name'>rdfms-duplicate-member-props-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-duplicate-member-props-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-duplicate-member-props-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>The question posed to the RDF WG was: should an RDF document containing multiple rdf:_n properties (with the same n) on an element be rejected as illegal? The WG decided that a parser should accept that case as legal RDF.</p>
           </div>
@@ -913,7 +913,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-error001' property='mf:name'>rdfms-empty-property-elements-error001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-error001' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-error001' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>This is not legal RDF; specifying an rdf:parseType of &quot;Literal&quot; and an rdf:resource attribute at the same time is an error.</p>
           </div>
@@ -934,7 +934,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-error002' property='mf:name'>rdfms-empty-property-elements-error002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-error002' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-error002' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>This is not legal RDF; specifying an rdf:parseType of &quot;Literal&quot; and an rdf:resource attribute at the same time is an error.</p>
           </div>
@@ -955,7 +955,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test001' property='mf:name'>rdfms-empty-property-elements-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>The rdf:resource attribute means that the value of this property element is a resource.</p>
           </div>
@@ -980,7 +980,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test002' property='mf:name'>rdfms-empty-property-elements-test002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>The basic case. An empty property element just gives an empty literal.</p>
           </div>
@@ -1005,7 +1005,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test004' property='mf:name'>rdfms-empty-property-elements-test004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test004' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test004' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>If the parseType indicates the value is a resource, we must create one. With no additional information, the resource is anonymous.</p>
           </div>
@@ -1030,7 +1030,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test005' property='mf:name'>rdfms-empty-property-elements-test005</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test005' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test005' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>An empty property element just gives an empty literal. We reify the statement at the same time.</p>
           </div>
@@ -1055,7 +1055,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test006' property='mf:name'>rdfms-empty-property-elements-test006</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test006' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test006' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Here the parseType indicates that we should create a resource. We also reify the generated statement.</p>
           </div>
@@ -1080,7 +1080,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test007' property='mf:name'>rdfms-empty-property-elements-test007</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test007' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test007' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>As test001.rdf; this uses an explicit closing tag.</p>
           </div>
@@ -1105,7 +1105,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test008' property='mf:name'>rdfms-empty-property-elements-test008</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test008' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test008' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>As test002.rdf; this uses an explicit closing tag.</p>
           </div>
@@ -1130,7 +1130,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test010' property='mf:name'>rdfms-empty-property-elements-test010</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test010' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test010' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>As test004.rdf; this uses an explicit closing tag.</p>
           </div>
@@ -1155,7 +1155,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test011' property='mf:name'>rdfms-empty-property-elements-test011</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test011' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test011' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>As test005.rdf; this uses an explicit closing tag.</p>
           </div>
@@ -1180,7 +1180,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test012' property='mf:name'>rdfms-empty-property-elements-test012</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test012' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test012' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>As test006.rdf; this uses an explicit closing tag.</p>
           </div>
@@ -1205,7 +1205,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test013' property='mf:name'>rdfms-empty-property-elements-test013</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test013' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test013' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Test of the last alternative for production [6.12], interpreted according to RDFMS paragraphs 229-234: http://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229</p>
           </div>
@@ -1230,7 +1230,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test014' property='mf:name'>rdfms-empty-property-elements-test014</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test014' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test014' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Test of the last alternative for production [6.12], interpreted according to RDFMS paragraphs 229-234: http://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229</p>
           </div>
@@ -1255,7 +1255,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test015' property='mf:name'>rdfms-empty-property-elements-test015</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test015' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test015' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Test of the last alternative for production [6.12], interpreted according to RDFMS paragraphs 229-234: http://lists.w3.org/Archives/Public/www-archive/2001Jun/att-0021/00-part#229 Here we have an explicit closing tag. This does not match any of the productions in the original document, but is indistinguishable from test014 as far as XML is concerned.</p>
           </div>
@@ -1280,7 +1280,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test016' property='mf:name'>rdfms-empty-property-elements-test016</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test016' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test016' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Like rdfms-empty-property-elements/test001.rdf but with a processing instruction as the only content of the otherwise empty element.</p>
           </div>
@@ -1305,7 +1305,7 @@
           </a>
           <span about='#rdfms-empty-property-elements-test017' property='mf:name'>rdfms-empty-property-elements-test017</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-empty-property-elements-test017' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-empty-property-elements-test017' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Like rdfms-empty-property-elements/test001.rdf but with a comment as the only content of the otherwise empty element.</p>
           </div>
@@ -1330,7 +1330,7 @@
           </a>
           <span about='#rdfms-identity-anon-resources-test001' property='mf:name'>rdfms-identity-anon-resources-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-identity-anon-resources-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-identity-anon-resources-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>a RDF Description with no ID or about attribute describes an un-named resource, aka a bNode.</p>
           </div>
@@ -1355,7 +1355,7 @@
           </a>
           <span about='#rdfms-identity-anon-resources-test002' property='mf:name'>rdfms-identity-anon-resources-test002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-identity-anon-resources-test002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-identity-anon-resources-test002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>a RDF Description with no ID or about attribute describes an un-named resource, aka a bNode.</p>
           </div>
@@ -1380,7 +1380,7 @@
           </a>
           <span about='#rdfms-identity-anon-resources-test003' property='mf:name'>rdfms-identity-anon-resources-test003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-identity-anon-resources-test003' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-identity-anon-resources-test003' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>a RDF container (in this case a Bag) without an ID attribute describes an un-named resource, aka a bNode.</p>
           </div>
@@ -1405,7 +1405,7 @@
           </a>
           <span about='#rdfms-identity-anon-resources-test004' property='mf:name'>rdfms-identity-anon-resources-test004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-identity-anon-resources-test004' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-identity-anon-resources-test004' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>a RDF container (in this case an Alt) without an ID attribute describes an un-named resource, aka a bNode.</p>
           </div>
@@ -1430,7 +1430,7 @@
           </a>
           <span about='#rdfms-identity-anon-resources-test005' property='mf:name'>rdfms-identity-anon-resources-test005</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-identity-anon-resources-test005' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-identity-anon-resources-test005' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>a RDF container (in this case an Seq) without an ID attribute describes an un-named resource, aka a bNode.</p>
           </div>
@@ -1455,7 +1455,7 @@
           </a>
           <span about='#rdfms-not-id-and-resource-attr-test001' property='mf:name'>rdfms-not-id-and-resource-attr-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-not-id-and-resource-attr-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-not-id-and-resource-attr-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:ID on an empty property element indicates reification.</p>
           </div>
@@ -1480,7 +1480,7 @@
           </a>
           <span about='#rdfms-not-id-and-resource-attr-test002' property='mf:name'>rdfms-not-id-and-resource-attr-test002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-not-id-and-resource-attr-test002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-not-id-and-resource-attr-test002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:reource on an empty property element indicates the URI of the object.</p>
           </div>
@@ -1505,7 +1505,7 @@
           </a>
           <span about='#rdfms-not-id-and-resource-attr-test004' property='mf:name'>rdfms-not-id-and-resource-attr-test004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-not-id-and-resource-attr-test004' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-not-id-and-resource-attr-test004' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:ID and rdf:resource are allowed together on empty property element.</p>
           </div>
@@ -1530,7 +1530,7 @@
           </a>
           <span about='#rdfms-not-id-and-resource-attr-test005' property='mf:name'>rdfms-not-id-and-resource-attr-test005</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-not-id-and-resource-attr-test005' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-not-id-and-resource-attr-test005' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:ID and rdf:resource are allowed together on empty property element.</p>
           </div>
@@ -1555,7 +1555,7 @@
           </a>
           <span about='#rdfms-para196-test001' property='mf:name'>rdfms-para196-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-para196-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-para196-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>test case showing that the 2nd URI in M Paragraph 196 is permitted as a namespace URI (and any namespace URI starting with that URI)</p>
           </div>
@@ -1580,7 +1580,7 @@
           </a>
           <span about='#rdfms-rdf-id-error001' property='mf:name'>rdfms-rdf-id-error001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-id-error001' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-id-error001' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>The value of rdf:ID must match the XML Name production, (as modified by XML Namespaces).</p>
           </div>
@@ -1601,7 +1601,7 @@
           </a>
           <span about='#rdfms-rdf-id-error002' property='mf:name'>rdfms-rdf-id-error002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-id-error002' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-id-error002' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>The value of rdf:ID must match the XML Name production, (as modified by XML Namespaces).</p>
           </div>
@@ -1622,7 +1622,7 @@
           </a>
           <span about='#rdfms-rdf-id-error003' property='mf:name'>rdfms-rdf-id-error003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-id-error003' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-id-error003' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>The value of rdf:ID must match the XML Name production, (as modified by XML Namespaces).</p>
           </div>
@@ -1643,7 +1643,7 @@
           </a>
           <span about='#rdfms-rdf-id-error004' property='mf:name'>rdfms-rdf-id-error004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-id-error004' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-id-error004' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>The value of rdf:ID must match the XML Name production, (as modified by XML Namespaces).</p>
           </div>
@@ -1664,7 +1664,7 @@
           </a>
           <span about='#rdfms-rdf-id-error005' property='mf:name'>rdfms-rdf-id-error005</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-id-error005' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-id-error005' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>The value of rdf:ID must match the XML Name production, (as modified by XML Namespaces).</p>
           </div>
@@ -1685,7 +1685,7 @@
           </a>
           <span about='#rdfms-rdf-id-error006' property='mf:name'>rdfms-rdf-id-error006</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-id-error006' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-id-error006' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>The value of rdf:bagID must match the XML Name production, (as modified by XML Namespaces).</p>
           </div>
@@ -1706,7 +1706,7 @@
           </a>
           <span about='#rdfms-rdf-id-error007' property='mf:name'>rdfms-rdf-id-error007</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-id-error007' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-id-error007' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>The value of rdf:bagID must match the XML Name production, (as modified by XML Namespaces).</p>
           </div>
@@ -1727,7 +1727,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-001' property='mf:name'>rdfms-rdf-names-use-error-001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-001' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-001' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>RDF is forbidden as a node element name.</p>
           </div>
@@ -1748,7 +1748,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-002' property='mf:name'>rdfms-rdf-names-use-error-002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-002' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-002' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>ID is forbidden as a node element name.</p>
           </div>
@@ -1769,7 +1769,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-003' property='mf:name'>rdfms-rdf-names-use-error-003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-003' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-003' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>about is forbidden as a node element name.</p>
           </div>
@@ -1790,7 +1790,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-004' property='mf:name'>rdfms-rdf-names-use-error-004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-004' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-004' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>bagID is forbidden as a node element name.</p>
           </div>
@@ -1811,7 +1811,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-005' property='mf:name'>rdfms-rdf-names-use-error-005</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-005' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-005' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>parseType is forbidden as a node element name.</p>
           </div>
@@ -1832,7 +1832,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-006' property='mf:name'>rdfms-rdf-names-use-error-006</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-006' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-006' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>resource is forbidden as a node element name.</p>
           </div>
@@ -1853,7 +1853,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-007' property='mf:name'>rdfms-rdf-names-use-error-007</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-007' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-007' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>nodeID is forbidden as a node element name.</p>
           </div>
@@ -1874,7 +1874,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-008' property='mf:name'>rdfms-rdf-names-use-error-008</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-008' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-008' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>li is forbidden as a node element name.</p>
           </div>
@@ -1895,7 +1895,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-009' property='mf:name'>rdfms-rdf-names-use-error-009</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-009' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-009' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>aboutEach is forbidden as a node element name.</p>
           </div>
@@ -1916,7 +1916,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-010' property='mf:name'>rdfms-rdf-names-use-error-010</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-010' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-010' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>aboutEachPrefix is forbidden as a node element name.</p>
           </div>
@@ -1937,7 +1937,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-011' property='mf:name'>rdfms-rdf-names-use-error-011</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-011' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-011' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Description is forbidden as a property element name.</p>
           </div>
@@ -1958,7 +1958,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-012' property='mf:name'>rdfms-rdf-names-use-error-012</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-012' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-012' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>RDF is forbidden as a property element name.</p>
           </div>
@@ -1979,7 +1979,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-013' property='mf:name'>rdfms-rdf-names-use-error-013</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-013' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-013' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>ID is forbidden as a property element name.</p>
           </div>
@@ -2000,7 +2000,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-014' property='mf:name'>rdfms-rdf-names-use-error-014</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-014' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-014' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>about is forbidden as a property element name.</p>
           </div>
@@ -2021,7 +2021,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-015' property='mf:name'>rdfms-rdf-names-use-error-015</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-015' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-015' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>bagID is forbidden as a property element name.</p>
           </div>
@@ -2042,7 +2042,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-016' property='mf:name'>rdfms-rdf-names-use-error-016</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-016' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-016' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>parseType is forbidden as a property element name.</p>
           </div>
@@ -2063,7 +2063,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-017' property='mf:name'>rdfms-rdf-names-use-error-017</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-017' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-017' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>resource is forbidden as a property element name.</p>
           </div>
@@ -2084,7 +2084,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-018' property='mf:name'>rdfms-rdf-names-use-error-018</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-018' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-018' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>nodeID is forbidden as a property element name.</p>
           </div>
@@ -2105,7 +2105,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-019' property='mf:name'>rdfms-rdf-names-use-error-019</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-019' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-019' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>aboutEach is forbidden as a property element name.</p>
           </div>
@@ -2126,7 +2126,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-error-020' property='mf:name'>rdfms-rdf-names-use-error-020</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-error-020' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-error-020' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>aboutEachPrefix is forbidden as a property element name.</p>
           </div>
@@ -2147,7 +2147,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-001' property='mf:name'>rdfms-rdf-names-use-test-001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Description is allowed as a node element name.</p>
           </div>
@@ -2172,7 +2172,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-002' property='mf:name'>rdfms-rdf-names-use-test-002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Seq is allowed as a node element name.</p>
           </div>
@@ -2197,7 +2197,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-003' property='mf:name'>rdfms-rdf-names-use-test-003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-003' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-003' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Bag is allowed as a node element name.</p>
           </div>
@@ -2222,7 +2222,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-004' property='mf:name'>rdfms-rdf-names-use-test-004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-004' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-004' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Alt is allowed as a node element name.</p>
           </div>
@@ -2247,7 +2247,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-005' property='mf:name'>rdfms-rdf-names-use-test-005</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-005' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-005' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Statement is allowed as a node element name.</p>
           </div>
@@ -2272,7 +2272,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-006' property='mf:name'>rdfms-rdf-names-use-test-006</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-006' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-006' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Property is allowed as a node element name.</p>
           </div>
@@ -2297,7 +2297,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-007' property='mf:name'>rdfms-rdf-names-use-test-007</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-007' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-007' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>List is allowed as a node element name.</p>
           </div>
@@ -2322,7 +2322,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-008' property='mf:name'>rdfms-rdf-names-use-test-008</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-008' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-008' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>subject is allowed as a node element name.</p>
           </div>
@@ -2347,7 +2347,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-009' property='mf:name'>rdfms-rdf-names-use-test-009</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-009' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-009' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>predicate is allowed as a node element name.</p>
           </div>
@@ -2372,7 +2372,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-010' property='mf:name'>rdfms-rdf-names-use-test-010</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-010' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-010' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>object is allowed as a node element name.</p>
           </div>
@@ -2397,7 +2397,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-011' property='mf:name'>rdfms-rdf-names-use-test-011</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-011' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-011' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>type is allowed as a node element name.</p>
           </div>
@@ -2422,7 +2422,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-012' property='mf:name'>rdfms-rdf-names-use-test-012</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-012' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-012' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>value is allowed as a node element name.</p>
           </div>
@@ -2447,7 +2447,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-013' property='mf:name'>rdfms-rdf-names-use-test-013</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-013' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-013' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>first is allowed as a node element name.</p>
           </div>
@@ -2472,7 +2472,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-014' property='mf:name'>rdfms-rdf-names-use-test-014</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-014' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-014' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rest is allowed as a node element name.</p>
           </div>
@@ -2497,7 +2497,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-015' property='mf:name'>rdfms-rdf-names-use-test-015</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-015' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-015' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>_1 is allowed as a node element name.</p>
           </div>
@@ -2522,7 +2522,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-016' property='mf:name'>rdfms-rdf-names-use-test-016</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-016' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-016' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>nil is allowed as a node element name.</p>
           </div>
@@ -2547,7 +2547,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-017' property='mf:name'>rdfms-rdf-names-use-test-017</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-017' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-017' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Seq is allowed as a property element name.</p>
           </div>
@@ -2572,7 +2572,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-018' property='mf:name'>rdfms-rdf-names-use-test-018</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-018' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-018' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Bag is allowed as a property element name.</p>
           </div>
@@ -2597,7 +2597,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-019' property='mf:name'>rdfms-rdf-names-use-test-019</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-019' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-019' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Alt is allowed as a property element name.</p>
           </div>
@@ -2622,7 +2622,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-020' property='mf:name'>rdfms-rdf-names-use-test-020</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-020' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-020' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Statement is allowed as a property element name.</p>
           </div>
@@ -2647,7 +2647,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-021' property='mf:name'>rdfms-rdf-names-use-test-021</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-021' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-021' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Property is allowed as a property element name.</p>
           </div>
@@ -2672,7 +2672,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-022' property='mf:name'>rdfms-rdf-names-use-test-022</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-022' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-022' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>List is allowed as a property element name.</p>
           </div>
@@ -2697,7 +2697,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-023' property='mf:name'>rdfms-rdf-names-use-test-023</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-023' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-023' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>subject is allowed as a property element name.</p>
           </div>
@@ -2722,7 +2722,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-024' property='mf:name'>rdfms-rdf-names-use-test-024</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-024' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-024' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>predicate is allowed as a property element name.</p>
           </div>
@@ -2747,7 +2747,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-025' property='mf:name'>rdfms-rdf-names-use-test-025</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-025' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-025' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>object is allowed as a property element name.</p>
           </div>
@@ -2772,7 +2772,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-026' property='mf:name'>rdfms-rdf-names-use-test-026</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-026' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-026' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>type is allowed as a property element name.</p>
           </div>
@@ -2797,7 +2797,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-027' property='mf:name'>rdfms-rdf-names-use-test-027</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-027' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-027' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>value is allowed as a property element name.</p>
           </div>
@@ -2822,7 +2822,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-028' property='mf:name'>rdfms-rdf-names-use-test-028</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-028' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-028' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>first is allowed as a property element name.</p>
           </div>
@@ -2847,7 +2847,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-029' property='mf:name'>rdfms-rdf-names-use-test-029</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-029' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-029' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rest is allowed as a property element name.</p>
           </div>
@@ -2872,7 +2872,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-030' property='mf:name'>rdfms-rdf-names-use-test-030</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-030' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-030' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>_1 is allowed as a property element name.</p>
           </div>
@@ -2897,7 +2897,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-031' property='mf:name'>rdfms-rdf-names-use-test-031</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-031' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-031' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>li is allowed as a property element name.</p>
           </div>
@@ -2922,7 +2922,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-032' property='mf:name'>rdfms-rdf-names-use-test-032</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-032' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-032' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Seq is allowed as a property element name.</p>
           </div>
@@ -2947,7 +2947,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-033' property='mf:name'>rdfms-rdf-names-use-test-033</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-033' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-033' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Bag is allowed as a property element name.</p>
           </div>
@@ -2972,7 +2972,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-034' property='mf:name'>rdfms-rdf-names-use-test-034</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-034' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-034' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Alt is allowed as a property element name.</p>
           </div>
@@ -2997,7 +2997,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-035' property='mf:name'>rdfms-rdf-names-use-test-035</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-035' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-035' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Statement is allowed as a property element name.</p>
           </div>
@@ -3022,7 +3022,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-036' property='mf:name'>rdfms-rdf-names-use-test-036</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-036' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-036' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Property is allowed as a property element name.</p>
           </div>
@@ -3047,7 +3047,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-test-037' property='mf:name'>rdfms-rdf-names-use-test-037</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-test-037' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-test-037' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>List is allowed as a property element name.</p>
           </div>
@@ -3072,7 +3072,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-warn-001' property='mf:name'>rdfms-rdf-names-use-warn-001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-warn-001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-warn-001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>foo is allowed with warnings as a node element name.</p>
           </div>
@@ -3097,7 +3097,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-warn-002' property='mf:name'>rdfms-rdf-names-use-warn-002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-warn-002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-warn-002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>foo is allowed with warnings as a property element name.</p>
           </div>
@@ -3122,7 +3122,7 @@
           </a>
           <span about='#rdfms-rdf-names-use-warn-003' property='mf:name'>rdfms-rdf-names-use-warn-003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-rdf-names-use-warn-003' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-rdf-names-use-warn-003' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>foo is allowed with warnings as a property attribute name.</p>
           </div>
@@ -3147,7 +3147,7 @@
           </a>
           <span about='#rdfms-reification-required-test001' property='mf:name'>rdfms-reification-required-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-reification-required-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-reification-required-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>A parser is not required to generate a bag of reified statements for all description elements.</p>
           </div>
@@ -3172,7 +3172,7 @@
           </a>
           <span about='#rdfms-seq-representation-test001' property='mf:name'>rdfms-seq-representation-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-seq-representation-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-seq-representation-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:parseType=&quot;Collection&quot; is parsed like the nonstandard daml:collection.</p>
           </div>
@@ -3197,7 +3197,7 @@
           </a>
           <span about='#rdfms-syntax-incomplete-test001' property='mf:name'>rdfms-syntax-incomplete-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-syntax-incomplete-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-syntax-incomplete-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:nodeID can be used to label a blank node.</p>
           </div>
@@ -3222,7 +3222,7 @@
           </a>
           <span about='#rdfms-syntax-incomplete-test002' property='mf:name'>rdfms-syntax-incomplete-test002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-syntax-incomplete-test002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-syntax-incomplete-test002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>rdf:nodeID can be used to label a blank node. These have file scope and are distinct from any unlabelled blank nodes.</p>
           </div>
@@ -3247,7 +3247,7 @@
           </a>
           <span about='#rdfms-syntax-incomplete-test003' property='mf:name'>rdfms-syntax-incomplete-test003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-syntax-incomplete-test003' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-syntax-incomplete-test003' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>On an rdf:Description or typed node rdf:nodeID behaves similarly to an rdf:about.</p>
           </div>
@@ -3272,7 +3272,7 @@
           </a>
           <span about='#rdfms-syntax-incomplete-test004' property='mf:name'>rdfms-syntax-incomplete-test004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-syntax-incomplete-test004' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-syntax-incomplete-test004' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>On a property element rdf:nodeID behaves similarly to rdf:resource.</p>
           </div>
@@ -3297,7 +3297,7 @@
           </a>
           <span about='#rdfms-syntax-incomplete-error001' property='mf:name'>rdfms-syntax-incomplete-error001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-syntax-incomplete-error001' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-syntax-incomplete-error001' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>The value of rdf:nodeID must match the XML Name production, (as modified by XML Namespaces).</p>
           </div>
@@ -3318,7 +3318,7 @@
           </a>
           <span about='#rdfms-syntax-incomplete-error002' property='mf:name'>rdfms-syntax-incomplete-error002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-syntax-incomplete-error002' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-syntax-incomplete-error002' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>The value of rdf:nodeID must match the XML Name production, (as modified by XML Namespaces).</p>
           </div>
@@ -3339,7 +3339,7 @@
           </a>
           <span about='#rdfms-syntax-incomplete-error003' property='mf:name'>rdfms-syntax-incomplete-error003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-syntax-incomplete-error003' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-syntax-incomplete-error003' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>The value of rdf:nodeID must match the XML Name production, (as modified by XML Namespaces).</p>
           </div>
@@ -3360,7 +3360,7 @@
           </a>
           <span about='#rdfms-syntax-incomplete-error004' property='mf:name'>rdfms-syntax-incomplete-error004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-syntax-incomplete-error004' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-syntax-incomplete-error004' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Cannot have rdf:nodeID and rdf:ID.</p>
           </div>
@@ -3381,7 +3381,7 @@
           </a>
           <span about='#rdfms-syntax-incomplete-error005' property='mf:name'>rdfms-syntax-incomplete-error005</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-syntax-incomplete-error005' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-syntax-incomplete-error005' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Cannot have rdf:nodeID and rdf:about.</p>
           </div>
@@ -3402,7 +3402,7 @@
           </a>
           <span about='#rdfms-syntax-incomplete-error006' property='mf:name'>rdfms-syntax-incomplete-error006</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-syntax-incomplete-error006' typeof='rdft:TestXMLNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-syntax-incomplete-error006' typeof='rdft:TestXMLNegativeSyntax'>
           <div property='rdfs:comment'>
             <p>Cannot have rdf:nodeID and rdf:resource.</p>
           </div>
@@ -3423,7 +3423,7 @@
           </a>
           <span about='#rdfms-uri-substructure-test001' property='mf:name'>rdfms-uri-substructure-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-uri-substructure-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-uri-substructure-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Demonstrates the Recommended partitioning of a URI into a namespace part and a localname part</p>
           </div>
@@ -3448,7 +3448,7 @@
           </a>
           <span about='#rdfms-xmllang-test003' property='mf:name'>rdfms-xmllang-test003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-xmllang-test003' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-xmllang-test003' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>In-scope xml:lang applies to element content literal values</p>
           </div>
@@ -3473,7 +3473,7 @@
           </a>
           <span about='#rdfms-xmllang-test004' property='mf:name'>rdfms-xmllang-test004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-xmllang-test004' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-xmllang-test004' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>In-scope xml:lang applies to element content literal values</p>
           </div>
@@ -3498,7 +3498,7 @@
           </a>
           <span about='#rdfms-xmllang-test005' property='mf:name'>rdfms-xmllang-test005</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-xmllang-test005' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-xmllang-test005' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>In-scope xml:lang applies to element content literal values</p>
           </div>
@@ -3523,7 +3523,7 @@
           </a>
           <span about='#rdfms-xmllang-test006' property='mf:name'>rdfms-xmllang-test006</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfms-xmllang-test006' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfms-xmllang-test006' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>In-scope xml:lang applies to element content literal values</p>
           </div>
@@ -3548,7 +3548,7 @@
           </a>
           <span about='#rdfs-domain-and-range-test001' property='mf:name'>rdfs-domain-and-range-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfs-domain-and-range-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfs-domain-and-range-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>a RDF Property may have more than one domain property</p>
           </div>
@@ -3573,7 +3573,7 @@
           </a>
           <span about='#rdfs-domain-and-range-test002' property='mf:name'>rdfs-domain-and-range-test002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#rdfs-domain-and-range-test002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#rdfs-domain-and-range-test002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>a RDF Property may have more than one domain property</p>
           </div>
@@ -3598,7 +3598,7 @@
           </a>
           <span about='#unrecognised-xml-attributes-test001' property='mf:name'>unrecognised-xml-attributes-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#unrecognised-xml-attributes-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#unrecognised-xml-attributes-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Unrecognized attributes in the xml namespace should be ignored.</p>
           </div>
@@ -3623,7 +3623,7 @@
           </a>
           <span about='#unrecognised-xml-attributes-test002' property='mf:name'>unrecognised-xml-attributes-test002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#unrecognised-xml-attributes-test002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#unrecognised-xml-attributes-test002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Unrecognized attributes in the xml namespace should be ignored.</p>
           </div>
@@ -3648,7 +3648,7 @@
           </a>
           <span about='#xml-canon-test001' property='mf:name'>xml-canon-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xml-canon-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xml-canon-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Demonstrating the canonicalisation of XMLLiterals.</p>
           </div>
@@ -3673,7 +3673,7 @@
           </a>
           <span about='#xmlbase-test001' property='mf:name'>xmlbase-test001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test001' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test001' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>xml:base applies to an rdf:ID on an rdf:Description element.</p>
           </div>
@@ -3698,7 +3698,7 @@
           </a>
           <span about='#xmlbase-test002' property='mf:name'>xmlbase-test002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test002' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test002' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>xml:base applies to an rdf:resource attribute.</p>
           </div>
@@ -3723,7 +3723,7 @@
           </a>
           <span about='#xmlbase-test003' property='mf:name'>xmlbase-test003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test003' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test003' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>xml:base applies to an rdf:about attribute.</p>
           </div>
@@ -3748,7 +3748,7 @@
           </a>
           <span about='#xmlbase-test004' property='mf:name'>xmlbase-test004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test004' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test004' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>xml:base applies to an rdf:ID on a property element.</p>
           </div>
@@ -3773,7 +3773,7 @@
           </a>
           <span about='#xmlbase-test006' property='mf:name'>xmlbase-test006</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test006' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test006' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>xml:base scoping.</p>
           </div>
@@ -3798,7 +3798,7 @@
           </a>
           <span about='#xmlbase-test007' property='mf:name'>xmlbase-test007</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test007' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test007' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>example of relative URI resolution.</p>
           </div>
@@ -3823,7 +3823,7 @@
           </a>
           <span about='#xmlbase-test008' property='mf:name'>xmlbase-test008</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test008' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test008' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>example of empty same document ref resolution.</p>
           </div>
@@ -3848,7 +3848,7 @@
           </a>
           <span about='#xmlbase-test009' property='mf:name'>xmlbase-test009</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test009' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test009' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Example of relative uri with absolute path resolution.</p>
           </div>
@@ -3873,7 +3873,7 @@
           </a>
           <span about='#xmlbase-test010' property='mf:name'>xmlbase-test010</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test010' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test010' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Example of relative uri with net path resolution.</p>
           </div>
@@ -3898,7 +3898,7 @@
           </a>
           <span about='#xmlbase-test011' property='mf:name'>xmlbase-test011</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test011' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test011' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Example of xml:base with no path component.</p>
           </div>
@@ -3923,7 +3923,7 @@
           </a>
           <span about='#xmlbase-test013' property='mf:name'>xmlbase-test013</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test013' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test013' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>With an xml:base with fragment the fragment is ignored.</p>
           </div>
@@ -3948,7 +3948,7 @@
           </a>
           <span about='#xmlbase-test014' property='mf:name'>xmlbase-test014</span>
         </dt>
-        <dd inlist property='mf:entry' resource='#xmlbase-test014' typeof='rdft:TestXMLEval'>
+        <dd inlist='true' property='mf:entry' resource='#xmlbase-test014' typeof='rdft:TestXMLEval'>
           <div property='rdfs:comment'>
             <p>Test output corrected to use correct base URL.</p>
           </div>

--- a/rdf/rdf11/template.haml
+++ b/rdf/rdf11/template.haml
@@ -65,7 +65,7 @@
             #{Array(man['comment']).join(' ').gsub(/\s+/m, ' ').strip.gsub(/(MUST|SHOULD|MAY)/, '<em class="rfc2119">\\1</em>')}
 
       :markdown
-        This page describes W3C RDF test suite, comprising tests for RDF 1.1 and RDF 1.2.
+        This page describes W3C RDF 1.1 Working Group's test suite.
 
         ### Contributing Tests
         The test manifests and entries are built automatically from [manifest.ttl](manifest.ttl) using a Rake task. Tests may be contributed via pull request to [https://github.com/w3c/rdf-tests](https://github.com/w3c/rdf-tests) with suitable changes to the [manifest.ttl](manifest.ttl) and referenced files.

--- a/rdf/rdf12/index.html
+++ b/rdf/rdf12/index.html
@@ -31,7 +31,7 @@
       footer {text-align: center;}
     </style>
     <title>
-      RDF 1.1 tests
+      RDF 1.2 tests
     </title>
     <style>
       em.rfc2119 {
@@ -51,21 +51,23 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
       </a>
     </p>
-    <h1 property='rdfs:label'>RDF 1.1 tests</h1>
+    <h1 property='rdfs:label'>RDF 1.2 tests</h1>
     <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
     <hr title='Separator for header'>
     <div>
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
-        <p>These test suites are a product previous RDF working groups, and has been maintained by the <a href="https://www.w3.org/community/rdf-tests/">RDF Test Curation Community Group</a>. Community maintained at <a href="https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/">https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11</a>. Conformance with RDF 1.1 specifications can be determined via successfully running the tests for relevant specifications.</p>
+        <p>These test suites are a product of the <a href="">W3C RDF-star Working Group</a> as well as the RDF-star Interest Group within the W3C RDF-DEV Community Group, and has been maintained by the <a href="https://www.w3.org/community/rdf-tests/">RDF Test Curation Community Group</a> at <a href="https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/">https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11</a>. Conformance with RDF 1.2 specifications can be determined via successfully running the tests for relevant specifications along with the relevant RDF 1.1 tests.</p>
       </p>
-      <p>This page describes W3C RDF 1.1 Working Group&#39;s test suite.</p>
+      <p>This page describes W3C RDF-star Working Group&#39;s test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.</p>
       <h3>Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3>Distribution</h3>
@@ -80,22 +82,22 @@
       </h2>
       <ul>
         <li>
-          <a href='rdf-n-triples/index.html' inlist='true' property='mf:include'>rdf-n-triples/</a>
+          <a href='rdf-n-triples/syntax/index.html' inlist='true' property='mf:include'>rdf-n-triples/syntax/</a>
         </li>
         <li>
-          <a href='rdf-n-quads/index.html' inlist='true' property='mf:include'>rdf-n-quads/</a>
+          <a href='rdf-semantics/index.html' inlist='true' property='mf:include'>rdf-semantics/</a>
         </li>
         <li>
-          <a href='rdf-mt/index.html' inlist='true' property='mf:include'>rdf-mt/</a>
+          <a href='rdf-turtle/syntax/index.html' inlist='true' property='mf:include'>rdf-turtle/syntax/</a>
         </li>
         <li>
-          <a href='rdf-turtle/index.html' inlist='true' property='mf:include'>rdf-turtle/</a>
+          <a href='rdf-turtle/eval/index.html' inlist='true' property='mf:include'>rdf-turtle/eval/</a>
         </li>
         <li>
-          <a href='rdf-trig/index.html' inlist='true' property='mf:include'>rdf-trig/</a>
+          <a href='rdf-trig/syntax/index.html' inlist='true' property='mf:include'>rdf-trig/syntax/</a>
         </li>
         <li>
-          <a href='rdf-xml/index.html' inlist='true' property='mf:include'>rdf-xml/</a>
+          <a href='rdf-trig/eval/index.html' inlist='true' property='mf:include'>rdf-trig/eval/</a>
         </li>
       </ul>
     </div>

--- a/rdf/rdf12/manifest.ttl
+++ b/rdf/rdf12/manifest.ttl
@@ -1,0 +1,42 @@
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+trs:manifest  rdf:type mf:Manifest ;
+  rdfs:label "RDF 1.2 tests"@en ;
+  skos:prefLabel "La suite des tests pour RDF 1.2"@fr;
+  skos:prefLabel "Conjunto de pruebas para RDF 1.2"@es;
+  dct:issued "2023-07-20"^^xsd:date ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+  dct:modified "2023-07-20"^^xsd:date ;
+  dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+  rdfs:comment """
+    These test suites are a product of the [W3C RDF-star Working Group]() as well as the
+    RDF-star Interest Group within the W3C RDF-DEV Community Group,
+    and has been maintained by the
+    [RDF Test Curation Community Group](https://www.w3.org/community/rdf-tests/)
+    at [https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/).
+
+    Conformance with RDF 1.2 specifications can be determined via successfully running the
+    tests for relevant specifications
+    along with the relevant RDF 1.1 tests.
+  """;
+  mf:include (
+    <rdf-n-triples/syntax/manifest.ttl>
+    <rdf-semantics/manifest.ttl>
+    <rdf-turtle/syntax/manifest.ttl>
+    <rdf-turtle/eval/manifest.ttl>
+    <rdf-trig/syntax/manifest.ttl>
+    <rdf-trig/eval/manifest.ttl>
+  ) .
+

--- a/rdf/rdf12/rdf-n-triples/syntax/index.html
+++ b/rdf/rdf12/rdf-n-triples/syntax/index.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang='en' prefix='mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+  <!-- This file is generated automatciallly from manifest.ttl, and should not be edited directly. -->
+  <head>
+    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+    <meta content='width=device-width, initial-scale=1.0' name='viewport'>
+    <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' type='text/css'>
+    <style>
+      body: {bacground-image: none;}
+      dl.editor>dd {
+        margin: 0 0 0 40px;
+      }
+      dl.test-detail {
+        padding: 0.5em;
+      }
+      dl.test-detail>dt {
+        float: left;
+        clear: left;
+        text-align: right;
+        font-weight: bold;
+        color: green;
+      }
+      dl.test-detail>dt:after {content: ": "}
+      dl.test-detail>dd {
+        margin: 0 0 0 110px;
+        padding: 0 0 0.5em 0;
+      }
+      dl.test-description>dt {margin-top: 2em;}
+      dd {margin-left: 0;}
+      dd code {display: inline;}
+      footer {text-align: center;}
+    </style>
+    <title>
+      N-Triples 1.2 Syntax Tests
+    </title>
+    <style>
+      em.rfc2119 {
+        text-transform: lowercase;
+        font-variant:   small-caps;
+        font-style:     normal;
+        color:          #900;
+      }
+      a.testlink {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.testlink:hover {
+        text-decoration: underline;
+      }
+      .warning {color: orange;}
+      .error {color: red;}
+    </style>
+  </head>
+  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#manifest' typeof='mf:Manifest'>
+    <p>
+      <a href='http://www.w3.org/'>
+        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
+      </a>
+    </p>
+    <h1 property='rdfs:label'>N-Triples 1.2 Syntax Tests</h1>
+    <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    <hr title='Separator for header'>
+    <div>
+      <h2 id='abstract'>Abstract</h2>
+      <p>This page describes W3C RDF-star Working Group&#39;s test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.</p>
+      <h3>Contributing Tests</h3>
+      <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
+      <h3>Distribution</h3>
+      <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
+      <h3>Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+        COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+    </div>
+    <div>
+      <h2>
+        Test Descriptions
+      </h2>
+      <dl class='test-description'>
+        <dt id='ntriples-star-1'>
+          <a class='testlink' href='#ntriples-star-1'>
+            ntriples-star-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-1' property='mf:name'>N-Triples-star - subject quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-1' typeof='rdft:TestNTriplesPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-syntax-1.nt' property='mf:action'>ntriples-star-syntax-1.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-2'>
+          <a class='testlink' href='#ntriples-star-2'>
+            ntriples-star-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-2' property='mf:name'>N-Triples-star - object quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-2' typeof='rdft:TestNTriplesPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-syntax-2.nt' property='mf:action'>ntriples-star-syntax-2.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-3'>
+          <a class='testlink' href='#ntriples-star-3'>
+            ntriples-star-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-3' property='mf:name'>N-Triples-star - subject and object quoted triples</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-3' typeof='rdft:TestNTriplesPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-syntax-3.nt' property='mf:action'>ntriples-star-syntax-3.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-4'>
+          <a class='testlink' href='#ntriples-star-4'>
+            ntriples-star-4:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-4' property='mf:name'>N-Triples-star - whitespace and terms</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-4' typeof='rdft:TestNTriplesPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-syntax-4.nt' property='mf:action'>ntriples-star-syntax-4.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-5'>
+          <a class='testlink' href='#ntriples-star-5'>
+            ntriples-star-5:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-5' property='mf:name'>N-Triples-star - Nested, no whitespace</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-5' typeof='rdft:TestNTriplesPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-syntax-5.nt' property='mf:action'>ntriples-star-syntax-5.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-bnode-1'>
+          <a class='testlink' href='#ntriples-star-bnode-1'>
+            ntriples-star-bnode-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-1' property='mf:name'>N-Triples-star - Blank node subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-1' typeof='rdft:TestNTriplesPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-bnode-1.nt' property='mf:action'>ntriples-star-bnode-1.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-bnode-2'>
+          <a class='testlink' href='#ntriples-star-bnode-2'>
+            ntriples-star-bnode-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-2' property='mf:name'>N-Triples-star - Blank node object</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-2' typeof='rdft:TestNTriplesPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-bnode-2.nt' property='mf:action'>ntriples-star-bnode-2.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-nested-1'>
+          <a class='testlink' href='#ntriples-star-nested-1'>
+            ntriples-star-nested-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-1' property='mf:name'>N-Triples-star - Nested subject term</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-1' typeof='rdft:TestNTriplesPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-nested-1.nt' property='mf:action'>ntriples-star-nested-1.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-nested-2'>
+          <a class='testlink' href='#ntriples-star-nested-2'>
+            ntriples-star-nested-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-2' property='mf:name'>N-Triples-star - Nested object term</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-2' typeof='rdft:TestNTriplesPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-nested-2.nt' property='mf:action'>ntriples-star-nested-2.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-bad-1'>
+          <a class='testlink' href='#ntriples-star-bad-1'>
+            ntriples-star-bad-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-1' property='mf:name'>N-Triples-star - Bad - quoted triple as predicate</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-1' typeof='rdft:TestNTriplesNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-bad-syntax-1.nt' property='mf:action'>ntriples-star-bad-syntax-1.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-bad-2'>
+          <a class='testlink' href='#ntriples-star-bad-2'>
+            ntriples-star-bad-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-2' property='mf:name'>N-Triples-star - Bad - quoted triple, literal subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-2' typeof='rdft:TestNTriplesNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-bad-syntax-2.nt' property='mf:action'>ntriples-star-bad-syntax-2.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-bad-3'>
+          <a class='testlink' href='#ntriples-star-bad-3'>
+            ntriples-star-bad-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-3' property='mf:name'>N-Triples-star - Bad - quoted triple, literal predicate</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-3' typeof='rdft:TestNTriplesNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-bad-syntax-3.nt' property='mf:action'>ntriples-star-bad-syntax-3.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-bad-4'>
+          <a class='testlink' href='#ntriples-star-bad-4'>
+            ntriples-star-bad-4:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-4' property='mf:name'>N-Triples-star - Bad - quoted triple, blank node predicate</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-4' typeof='rdft:TestNTriplesNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-bad-syntax-4.nt' property='mf:action'>ntriples-star-bad-syntax-4.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-bnode-bad-annotated-syntax-1'>
+          <a class='testlink' href='#ntriples-star-bnode-bad-annotated-syntax-1'>
+            ntriples-star-bnode-bad-annotated-syntax-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-bad-annotated-syntax-1' property='mf:name'>N-Triples-star - Bad - annotated triple, blank node subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-bad-annotated-syntax-1' typeof='rdft:TestNTriplesNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-bnode-bad-annotated-syntax-1.nt' property='mf:action'>ntriples-star-bnode-bad-annotated-syntax-1.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-bnode-bad-annotated-syntax-2'>
+          <a class='testlink' href='#ntriples-star-bnode-bad-annotated-syntax-2'>
+            ntriples-star-bnode-bad-annotated-syntax-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-bad-annotated-syntax-2' property='mf:name'>N-Triples-star - Bad - annotated triple, blank node object</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-bad-annotated-syntax-2' typeof='rdft:TestNTriplesNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-bnode-bad-annotated-syntax-2.nt' property='mf:action'>ntriples-star-bnode-bad-annotated-syntax-2.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-nested-bad-annotated-syntax-1'>
+          <a class='testlink' href='#ntriples-star-nested-bad-annotated-syntax-1'>
+            ntriples-star-nested-bad-annotated-syntax-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-bad-annotated-syntax-1' property='mf:name'>N-Triples-star - Bad - annotated triple, nested subject term</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-bad-annotated-syntax-1' typeof='rdft:TestNTriplesNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-nested-bad-annotated-syntax-1.nt' property='mf:action'>ntriples-star-nested-bad-annotated-syntax-1.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='ntriples-star-nested-bad-annotated-syntax-2'>
+          <a class='testlink' href='#ntriples-star-nested-bad-annotated-syntax-2'>
+            ntriples-star-nested-bad-annotated-syntax-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-bad-annotated-syntax-2' property='mf:name'>N-Triples-star - Bad - annotated triple, nested object term</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-bad-annotated-syntax-2' typeof='rdft:TestNTriplesNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestNTriplesNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='ntriples-star-nested-bad-annotated-syntax-2.nt' property='mf:action'>ntriples-star-nested-bad-annotated-syntax-2.nt</a>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+    </div>
+    <footer>
+      <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    </footer>
+  </body>
+</html>

--- a/rdf/rdf12/rdf-n-triples/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-n-triples/syntax/manifest.ttl
@@ -1,0 +1,139 @@
+## Distributed under both the "W3C Test Suite License" [1]
+## and the "W3C 3-clause BSD License".
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+trs:manifest  rdf:type mf:Manifest ;
+   rdfs:label "N-Triples 1.2 Syntax Tests"@en ;
+   skos:prefLabel "La suite des tests pour N-Triples 1.2"@fr;
+   skos:prefLabel "Conjunto de pruebas para N-Triples 1.2r"@es;
+   dct:issued "2023-07-20"^^xsd:date ;
+   dct:modified "2023-07-20"^^xsd:date ;
+   dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+   dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+   rdfs:seeAlso <README>;
+    mf:entries
+    (
+        trs:ntriples-star-1
+        trs:ntriples-star-2
+        trs:ntriples-star-3
+        trs:ntriples-star-4
+        trs:ntriples-star-5
+
+        trs:ntriples-star-bnode-1
+        trs:ntriples-star-bnode-2
+
+        trs:ntriples-star-nested-1
+        trs:ntriples-star-nested-2
+
+        trs:ntriples-star-bad-1
+        trs:ntriples-star-bad-2
+        trs:ntriples-star-bad-3
+        trs:ntriples-star-bad-4
+
+        trs:ntriples-star-bnode-bad-annotated-syntax-1
+        trs:ntriples-star-bnode-bad-annotated-syntax-2
+        trs:ntriples-star-nested-bad-annotated-syntax-1
+        trs:ntriples-star-nested-bad-annotated-syntax-2
+    ) .
+
+trs:ntriples-star-1 rdf:type rdft:TestNTriplesPositiveSyntax ;
+   mf:name      "N-Triples-star - subject quoted triple" ;
+   mf:action    <ntriples-star-syntax-1.nt> ;
+   .
+
+trs:ntriples-star-2 rdf:type rdft:TestNTriplesPositiveSyntax ;
+   mf:name      "N-Triples-star - object quoted triple" ;
+   mf:action    <ntriples-star-syntax-2.nt> ;
+   .
+
+trs:ntriples-star-3 rdf:type rdft:TestNTriplesPositiveSyntax ;
+   mf:name      "N-Triples-star - subject and object quoted triples" ;
+   mf:action    <ntriples-star-syntax-3.nt> ;
+   .
+
+trs:ntriples-star-4 rdf:type rdft:TestNTriplesPositiveSyntax ;
+   mf:name      "N-Triples-star - whitespace and terms" ;
+   mf:action    <ntriples-star-syntax-4.nt> ;
+   .
+
+trs:ntriples-star-5 rdf:type rdft:TestNTriplesPositiveSyntax ;
+   mf:name      "N-Triples-star - Nested, no whitespace" ;
+   mf:action    <ntriples-star-syntax-5.nt> ;
+   .
+
+# Blank nodes
+
+trs:ntriples-star-bnode-1 rdf:type rdft:TestNTriplesPositiveSyntax ;
+   mf:name      "N-Triples-star - Blank node subject" ;
+   mf:action    <ntriples-star-bnode-1.nt> ;
+   .
+
+trs:ntriples-star-bnode-2 rdf:type rdft:TestNTriplesPositiveSyntax ;
+   mf:name      "N-Triples-star - Blank node object" ;
+   mf:action    <ntriples-star-bnode-2.nt> ;
+   .
+
+trs:ntriples-star-nested-1 rdf:type rdft:TestNTriplesPositiveSyntax ;
+   mf:name      "N-Triples-star - Nested subject term" ;
+   mf:action    <ntriples-star-nested-1.nt> ;
+   .
+
+trs:ntriples-star-nested-2 rdf:type rdft:TestNTriplesPositiveSyntax ;
+   mf:name      "N-Triples-star - Nested object term" ;
+   mf:action    <ntriples-star-nested-2.nt> ;
+   .
+
+## Bad syntax
+
+trs:ntriples-star-bad-1 rdf:type rdft:TestNTriplesNegativeSyntax ;
+    mf:name      "N-Triples-star - Bad - quoted triple as predicate" ;
+    mf:action    <ntriples-star-bad-syntax-1.nt> ;
+    .
+
+trs:ntriples-star-bad-2 rdf:type rdft:TestNTriplesNegativeSyntax ;
+    mf:name      "N-Triples-star - Bad - quoted triple, literal subject" ;
+    mf:action    <ntriples-star-bad-syntax-2.nt> ;
+    .
+
+trs:ntriples-star-bad-3 rdf:type rdft:TestNTriplesNegativeSyntax ;
+    mf:name      "N-Triples-star - Bad - quoted triple, literal predicate" ;
+    mf:action    <ntriples-star-bad-syntax-3.nt> ;
+    .
+
+trs:ntriples-star-bad-4 rdf:type rdft:TestNTriplesNegativeSyntax ;
+    mf:name      "N-Triples-star - Bad - quoted triple, blank node predicate" ;
+    mf:action    <ntriples-star-bad-syntax-4.nt> ;
+    .
+
+# Annotation syntax is not permitted in nt
+
+trs:ntriples-star-bnode-bad-annotated-syntax-1 rdf:type rdft:TestNTriplesNegativeSyntax ;
+    mf:name      "N-Triples-star - Bad - annotated triple, blank node subject" ;
+    mf:action    <ntriples-star-bnode-bad-annotated-syntax-1.nt> ;
+    .
+
+trs:ntriples-star-bnode-bad-annotated-syntax-2 rdf:type rdft:TestNTriplesNegativeSyntax ;
+    mf:name      "N-Triples-star - Bad - annotated triple, blank node object" ;
+    mf:action    <ntriples-star-bnode-bad-annotated-syntax-2.nt> ;
+    .
+
+trs:ntriples-star-nested-bad-annotated-syntax-1 rdf:type rdft:TestNTriplesNegativeSyntax ;
+    mf:name      "N-Triples-star - Bad - annotated triple, nested subject term" ;
+    mf:action    <ntriples-star-nested-bad-annotated-syntax-1.nt> ;
+    .
+
+trs:ntriples-star-nested-bad-annotated-syntax-2 rdf:type rdft:TestNTriplesNegativeSyntax ;
+    mf:name      "N-Triples-star - Bad - annotated triple, nested object term" ;
+    mf:action    <ntriples-star-nested-bad-annotated-syntax-2.nt> ;
+    .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bad-syntax-1.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bad-syntax-1.nt
@@ -1,0 +1,1 @@
+<http://example/a> << <http://example/s> <http://example/p>  <http://example/o> >>  <http://example/z> .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bad-syntax-2.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bad-syntax-2.nt
@@ -1,0 +1,1 @@
+<< "XYZ" <http://example/p> <http://example/o> >> <http://example/q> <http://example/z> .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bad-syntax-3.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bad-syntax-3.nt
@@ -1,0 +1,1 @@
+<< <http://example/s> "XYZ" <http://example/o> >> <http://example/q> <http://example/z> .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bad-syntax-4.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bad-syntax-4.nt
@@ -1,0 +1,1 @@
+<< <http://example/s> _:label <http://example/o> >> <http://example/q> <http://example/z> .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bnode-1.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bnode-1.nt
@@ -1,0 +1,2 @@
+_:b0 <http://example/p> <http://example/o> .
+<< _:b0 <http://example/p> <http://example/o> >> <http://example/q> "ABC" .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bnode-2.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bnode-2.nt
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> _:b1 .
+<< <http://example/s> <http://example/p> _:b1 >> <http://example/q> "456"^^<http://www.w3.org/2001/XMLSchema#integer> .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bnode-bad-annotated-syntax-1.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bnode-bad-annotated-syntax-1.nt
@@ -1,0 +1,1 @@
+_:b0 <http://example/p> <http://example/o> {| <http://example/q> "ABC" |} .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bnode-bad-annotated-syntax-2.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-bnode-bad-annotated-syntax-2.nt
@@ -1,0 +1,1 @@
+<http://example/s> <http://example/p> _:b1 {| <http://example/q> "456"^^<http://www.w3.org/2001/XMLSchema#integer> |} .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-nested-1.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-nested-1.nt
@@ -1,0 +1,3 @@
+<http://example/s> <http://example/p> <http://example/o> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/r> <http://example/z> .
+<< << <http://example/s> <http://example/p> <http://example/o> >> <http://example/r> <http://example/z> >> <http://example/q> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-nested-2.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-nested-2.nt
@@ -1,0 +1,3 @@
+<http://example/s> <http://example/p> <http://example/o> .
+<http://example/a> <http://example/q> << <http://example/s> <http://example/p> <http://example/o> >> .
+<< <http://example/a> <http://example/q> << <http://example/s> <http://example/p> <http://example/o> >> >> <http://example/r> <http://example/z> .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-nested-bad-annotated-syntax-1.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-nested-bad-annotated-syntax-1.nt
@@ -1,0 +1,1 @@
+<http://example/s> <http://example/p> <http://example/o> {| <http://example/r> <http://example/z> {| <http://example/q> "1"^^<http://www.w3.org/2001/XMLSchema#integer> |} |} .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-nested-bad-annotated-syntax-2.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-nested-bad-annotated-syntax-2.nt
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <http://example/o> .
+<http://example/a> <http://example/q> << <http://example/s> <http://example/p> <http://example/o> >> {| <http://example/r> <http://example/z> |} .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-syntax-1.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-syntax-1.nt
@@ -1,0 +1,1 @@
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/q> <http://example/z> .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-syntax-2.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-syntax-2.nt
@@ -1,0 +1,1 @@
+<http://example/x> <http://example/p> << <http://example/s> <http://example/p> <http://example/o> >> .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-syntax-3.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-syntax-3.nt
@@ -1,0 +1,1 @@
+<< <http://example/s1> <http://example/p1> <http://example/o1> >> <http://example/q> << <http://example/s2> <http://example/p2> <http://example/o2> >> .

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-syntax-4.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-syntax-4.nt
@@ -1,0 +1,1 @@
+<<<http://example/s1><http://example/p1><http://example/o1>>><http://example/q><<<http://example/s2><http://example/p2><http://example/o2>>>.

--- a/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-syntax-5.nt
+++ b/rdf/rdf12/rdf-n-triples/syntax/ntriples-star-syntax-5.nt
@@ -1,0 +1,1 @@
+<<<<<http://example/s1><http://example/p1><http://example/o1>>><http://example/q1><<<http://example/s2><http://example/p2><http://example/o2>>>>><http://example/q2><<<<<http://example/s3><http://example/p3><http://example/o3>>><http://example/q3><<<http://example/s4><http://example/p4><http://example/o4>>>>>.

--- a/rdf/rdf12/rdf-semantics/README
+++ b/rdf/rdf12/rdf-semantics/README
@@ -1,0 +1,49 @@
+This README is for the RDF-star Semantics test suite,
+by the W3C RDF-DEV Community Group task force on RDF*.
+This test suite contains two kinds of tests:
+
+  Positive Entailment Tests (PositiveEntailmentTest)
+  Negative Entailment Tests (NegativeEntailmentTest)
+
+The manifest.jsonld file in this directory lists all of the approved tests in the
+RDF WG's RDF Entailment test suite.
+
+Each test is one of the above kinds of tests. All tests have
+- a name (name),
+- an input RDF graph URL (action),
+- an output RDF graph URL or the special marker false (result),
+- an entailment regime, which is "simple", "RDF", "RDFS" or "RDFS-Plus" (entailmentRegime),
+- a list of recognized datatypes (recognizedDatatypes),
+- a list of unrecognized datatypes (unrecognizedDatatypes).
+
+An implementation passes a Positive (Negative) Entailment Test if, when
+configured to
+1/ perform entailment under the entailment regime of the test or some
+   entailment regime that is stronger (weaker) than the entailment regime and
+2/ recognize all the datatypes in the list of recognized datatypes and
+   none of the datatypes in the list of unrecognized datatypes,
+- for tests that have an output graph, determines that the input RDF graph
+  entails (does not entail) the output RDF graph
+- for tests that have false as output, either determines that the input
+  RDF graph entails (does not entail) an inconsistent RDF graph or that the
+  input RDF graph is inconsistent (consistent).
+
+An implementation also passes a test if when configured differently from a
+correct configuration as given above nonetheless produces the given result,
+and the result is correct in the configured entailment regime with the
+configured recognized datatypes.
+
+The home of the test suite should eventually be
+<http://w3c.github.io/rdf-star/tests/semantics/>.
+Per RFC 3986 section 5.1.3, the base IRI for parsing each file is the
+retrieval IRI for that file, but changing base IRIs should not affect any
+testing results.
+
+
+Test results should be submitted as EARL reports.   See
+http://www.w3.org/TR/EARL10-Schema/ for information on EARL.
+
+A document on the results of the testing will eventually be at
+http://w3c.github.io/rdf-star/tests/reports.html .
+This document will have more information on submitting reports, including examples
+of what the reports should contain.

--- a/rdf/rdf12/rdf-semantics/canonical-literal-control.ttl
+++ b/rdf/rdf12/rdf-semantics/canonical-literal-control.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:a :b "42"^^xsd:integer.

--- a/rdf/rdf12/rdf-semantics/canonical-literal.ttl
+++ b/rdf/rdf12/rdf-semantics/canonical-literal.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b "42"^^xsd:integer >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/control-sameas-a.ttl
+++ b/rdf/rdf12/rdf-semantics/control-sameas-a.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+
+:superman :can :fly .
+:clark owl:sameAs :superman.

--- a/rdf/rdf12/rdf-semantics/control-sameas-r.ttl
+++ b/rdf/rdf12/rdf-semantics/control-sameas-r.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+:clark :can :fly .

--- a/rdf/rdf12/rdf-semantics/index.html
+++ b/rdf/rdf12/rdf-semantics/index.html
@@ -1,0 +1,754 @@
+<!DOCTYPE html>
+<html lang='en' prefix='mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+  <!-- This file is generated automatciallly from manifest.ttl, and should not be edited directly. -->
+  <head>
+    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+    <meta content='width=device-width, initial-scale=1.0' name='viewport'>
+    <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' type='text/css'>
+    <style>
+      body: {bacground-image: none;}
+      dl.editor>dd {
+        margin: 0 0 0 40px;
+      }
+      dl.test-detail {
+        padding: 0.5em;
+      }
+      dl.test-detail>dt {
+        float: left;
+        clear: left;
+        text-align: right;
+        font-weight: bold;
+        color: green;
+      }
+      dl.test-detail>dt:after {content: ": "}
+      dl.test-detail>dd {
+        margin: 0 0 0 110px;
+        padding: 0 0 0.5em 0;
+      }
+      dl.test-description>dt {margin-top: 2em;}
+      dd {margin-left: 0;}
+      dd code {display: inline;}
+      footer {text-align: center;}
+    </style>
+    <title>
+      RDF 1.2 Semantics tests
+    </title>
+    <style>
+      em.rfc2119 {
+        text-transform: lowercase;
+        font-variant:   small-caps;
+        font-style:     normal;
+        color:          #900;
+      }
+      a.testlink {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.testlink:hover {
+        text-decoration: underline;
+      }
+      .warning {color: orange;}
+      .error {color: red;}
+    </style>
+  </head>
+  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#manifest' typeof='mf:Manifest'>
+    <p>
+      <a href='http://www.w3.org/'>
+        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
+      </a>
+    </p>
+    <h1 property='rdfs:label'>RDF 1.2 Semantics tests</h1>
+    <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    <hr title='Separator for header'>
+    <div>
+      <h2 id='abstract'>Abstract</h2>
+      <p>This page describes W3C RDF-star Working Group&#39;s test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.</p>
+      <h3>Contributing Tests</h3>
+      <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
+      <h3>Distribution</h3>
+      <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
+      <h3>Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+        COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+    </div>
+    <div>
+      <h2>
+        Test Descriptions
+      </h2>
+      <dl class='test-description'>
+        <dt id='all-identical-quoted-triples-are-the-same'>
+          <a class='testlink' href='#all-identical-quoted-triples-are-the-same'>
+            all-identical-quoted-triples-are-the-same:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#all-identical-quoted-triples-are-the-same' property='mf:name'>all-identical-quoted-triples-are-the-same</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#all-identical-quoted-triples-are-the-same' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Multiple occurences of the same quoted triples are undistinguishable in the abstract model.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test001a.ttl' property='mf:action'>test001a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test001r.ttl' property='mf:result'>test001r.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='quoted-triples-no-spurious'>
+          <a class='testlink' href='#quoted-triples-no-spurious'>
+            quoted-triples-no-spurious:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#quoted-triples-no-spurious' property='mf:name'>quoted-triples-no-spurious</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#quoted-triples-no-spurious' typeof='mf:NegativeEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>This test ensures that other entailments are not spurious.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:NegativeEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test002a.ttl' property='mf:action'>test002a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test005.ttl' property='mf:result'>test005.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='bnodes-in-quoted-subject'>
+          <a class='testlink' href='#bnodes-in-quoted-subject'>
+            bnodes-in-quoted-subject:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject' property='mf:name'>bnodes-in-quoted-subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Terms inside quoted triples can be replaced by fresh bnodes.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test002a.ttl' property='mf:action'>test002a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test002sr.ttl' property='mf:result'>test002sr.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='bnodes-in-quoted-object'>
+          <a class='testlink' href='#bnodes-in-quoted-object'>
+            bnodes-in-quoted-object:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-object' property='mf:name'>bnodes-in-quoted-object</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-object' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Terms inside quoted triples can be replaced by fresh bnodes.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test002a.ttl' property='mf:action'>test002a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test002or.ttl' property='mf:result'>test002or.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='bnodes-in-quoted-subject-and-object'>
+          <a class='testlink' href='#bnodes-in-quoted-subject-and-object'>
+            bnodes-in-quoted-subject-and-object:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject-and-object' property='mf:name'>bnodes-in-quoted-subject-and-object</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject-and-object' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Terms inside quoted triples can be replaced by fresh bnodes.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test002a.ttl' property='mf:action'>test002a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test002sor.ttl' property='mf:result'>test002sor.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='bnodes-in-quoted-subject-and-object-fail'>
+          <a class='testlink' href='#bnodes-in-quoted-subject-and-object-fail'>
+            bnodes-in-quoted-subject-and-object-fail:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject-and-object-fail' property='mf:name'>bnodes-in-quoted-subject-and-object-fail</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject-and-object-fail' typeof='mf:NegativeEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>The same bnode can not match different quoted terms.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:NegativeEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test002a.ttl' property='mf:action'>test002a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test002sbr.ttl' property='mf:result'>test002sbr.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='same-bnode-same-quoted-term'>
+          <a class='testlink' href='#same-bnode-same-quoted-term'>
+            same-bnode-same-quoted-term:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#same-bnode-same-quoted-term' property='mf:name'>same-bnode-same-quoted-term</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#same-bnode-same-quoted-term' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Identical quoted term can be replaced by the same fresh bnode multiple times.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test003a.ttl' property='mf:action'>test003a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test002sbr.ttl' property='mf:result'>test002sbr.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='different-bnodes-same-quoted-term'>
+          <a class='testlink' href='#different-bnodes-same-quoted-term'>
+            different-bnodes-same-quoted-term:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#different-bnodes-same-quoted-term' property='mf:name'>different-bnodes-same-quoted-term</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#different-bnodes-same-quoted-term' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Different bnodes can match identical quoted terms.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test003a.ttl' property='mf:action'>test003a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test002sor.ttl' property='mf:result'>test002sor.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='constrained-bnodes-in-quoted-subject'>
+          <a class='testlink' href='#constrained-bnodes-in-quoted-subject'>
+            constrained-bnodes-in-quoted-subject:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-subject' property='mf:name'>constrained-bnodes-in-quoted-subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-subject' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Terms inside and outside quoted triples can be replaced by fresh bnodes</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test004a.ttl' property='mf:action'>test004a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test004sr.ttl' property='mf:result'>test004sr.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='constrained-bnodes-in-quoted-object'>
+          <a class='testlink' href='#constrained-bnodes-in-quoted-object'>
+            constrained-bnodes-in-quoted-object:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-object' property='mf:name'>constrained-bnodes-in-quoted-object</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-object' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Terms inside and outside quoted triples can be replaced by fresh bnodes.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test004a.ttl' property='mf:action'>test004a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test004or.ttl' property='mf:result'>test004or.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='constrained-bnodes-in-quoted-fail'>
+          <a class='testlink' href='#constrained-bnodes-in-quoted-fail'>
+            constrained-bnodes-in-quoted-fail:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-fail' property='mf:name'>constrained-bnodes-in-quoted-fail</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-fail' typeof='mf:NegativeEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Quoted bnode identifiers share the same scope as non-quoted ones. A bnode that occurs both inside quoted triples and inside asserted triples must satisfy all occurrences at the same time.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:NegativeEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test004a.ttl' property='mf:action'>test004a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test004fr.ttl' property='mf:result'>test004fr.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='constrained-bnodes-on-literal'>
+          <a class='testlink' href='#constrained-bnodes-on-literal'>
+            constrained-bnodes-on-literal:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-on-literal' property='mf:name'>constrained-bnodes-on-literal</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-on-literal' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Literals inside and outside quoted triples can be replaced by fresh bnodes.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test006a.ttl' property='mf:action'>test006a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test006r.ttl' property='mf:result'>test006r.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='malformed-literal-control'>
+          <a class='testlink' href='#malformed-literal-control'>
+            malformed-literal-control:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-control' property='mf:name'>malformed-literal-control</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-control' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='malformed-literal-control.ttl' property='mf:action'>malformed-literal-control.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='malformed-literal'>
+          <a class='testlink' href='#malformed-literal'>
+            malformed-literal:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal' property='mf:name'>malformed-literal</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal' typeof='mf:NegativeEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Malformed literals are allowed when quoted.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:NegativeEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='malformed-literal.ttl' property='mf:action'>malformed-literal.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='malformed-literal-accepted'>
+          <a class='testlink' href='#malformed-literal-accepted'>
+            malformed-literal-accepted:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-accepted' property='mf:name'>malformed-literal-accepted</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-accepted' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Malformed literals are allowed when quoted.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='malformed-literal.ttl' property='mf:action'>malformed-literal.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='malformed-literal.ttl' property='mf:result'>malformed-literal.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='malformed-literal-no-spurious'>
+          <a class='testlink' href='#malformed-literal-no-spurious'>
+            malformed-literal-no-spurious:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-no-spurious' property='mf:name'>malformed-literal-no-spurious</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-no-spurious' typeof='mf:NegativeEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Quoted malformed literals do not lead to spurious entailment.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:NegativeEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='malformed-literal.ttl' property='mf:action'>malformed-literal.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='malformed-literal-other.ttl' property='mf:result'>malformed-literal-other.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='malformed-literal-bnode-neg'>
+          <a class='testlink' href='#malformed-literal-bnode-neg'>
+            malformed-literal-bnode-neg:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-bnode-neg' property='mf:name'>malformed-literal-bnode</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-bnode-neg' typeof='mf:NegativeEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Malformed literals can not be replaced by blank nodes.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:NegativeEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='malformed-literal.ttl' property='mf:action'>malformed-literal.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test002or.ttl' property='mf:result'>test002or.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='opaque-literal-control'>
+          <a class='testlink' href='#opaque-literal-control'>
+            opaque-literal-control:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-literal-control' property='mf:name'>opaque-literal-control</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-literal-control' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='non-canonical-literal-control.ttl' property='mf:action'>non-canonical-literal-control.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='canonical-literal-control.ttl' property='mf:result'>canonical-literal-control.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='opaque-literal'>
+          <a class='testlink' href='#opaque-literal'>
+            opaque-literal:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-literal' property='mf:name'>opaque-literal</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-literal' typeof='mf:NegativeEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Quoted literals are opaque, even when their datatype is recognized.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:NegativeEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='non-canonical-literal.ttl' property='mf:action'>non-canonical-literal.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='canonical-literal.ttl' property='mf:result'>canonical-literal.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='opaque-language-string-control'>
+          <a class='testlink' href='#opaque-language-string-control'>
+            opaque-language-string-control:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-language-string-control' property='mf:name'>opaque-language-string-control</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-language-string-control' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='lowercase-language-string-control.ttl' property='mf:action'>lowercase-language-string-control.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='upercase-language-string-control.ttl' property='mf:result'>upercase-language-string-control.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='opaque-language-string'>
+          <a class='testlink' href='#opaque-language-string'>
+            opaque-language-string:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-language-string' property='mf:name'>opaque-language-string</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-language-string' typeof='mf:NegativeEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Quoted literals (including language strings) are opaque, even when their datatype is recognized.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:NegativeEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='lowercase-language-string.ttl' property='mf:action'>lowercase-language-string.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='upercase-language-string.ttl' property='mf:result'>upercase-language-string.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='opaque-iri-control'>
+          <a class='testlink' href='#opaque-iri-control'>
+            opaque-iri-control:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-iri-control' property='mf:name'>opaque-iri-control</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-iri-control' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='control-sameas-a.ttl' property='mf:action'>control-sameas-a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='control-sameas-r.ttl' property='mf:result'>control-sameas-r.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='opaque-iri'>
+          <a class='testlink' href='#opaque-iri'>
+            opaque-iri:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-iri' property='mf:name'>opaque-iri</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-iri' typeof='mf:NegativeEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Quoted IRIs are opaque.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:NegativeEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='superman.ttl' property='mf:action'>superman.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='superman_undesired_entailment.ttl' property='mf:result'>superman_undesired_entailment.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='quoted-not-asserted'>
+          <a class='testlink' href='#quoted-not-asserted'>
+            quoted-not-asserted:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#quoted-not-asserted' property='mf:name'>quoted-not-asserted</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#quoted-not-asserted' typeof='mf:NegativeEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Quoted triples are not asserted.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:NegativeEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test002a.ttl' property='mf:action'>test002a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test002pgr.ttl' property='mf:result'>test002pgr.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='annotated-asserted'>
+          <a class='testlink' href='#annotated-asserted'>
+            annotated-asserted:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotated-asserted' property='mf:name'>annotated-asserted</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotated-asserted' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Annotated triples are asserted.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test007a.ttl' property='mf:action'>test007a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test007r1.ttl' property='mf:result'>test007r1.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='annotation'>
+          <a class='testlink' href='#annotation'>
+            annotation:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotation' property='mf:name'>annotation</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotation' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Annotation are about the annotated triple.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test007a.ttl' property='mf:action'>test007a.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test007r2.ttl' property='mf:result'>test007r2.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='annotation-unfolded'>
+          <a class='testlink' href='#annotation-unfolded'>
+            annotation-unfolded:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotation-unfolded' property='mf:name'>annotation-unfolded</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotation-unfolded' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Annotation is the same as separate assertions.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test007a2.ttl' property='mf:action'>test007a2.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test007a.ttl' property='mf:result'>test007a.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+    </div>
+    <footer>
+      <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    </footer>
+  </body>
+</html>

--- a/rdf/rdf12/rdf-semantics/lowercase-language-string-control.ttl
+++ b/rdf/rdf12/rdf-semantics/lowercase-language-string-control.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:a :b "hello"@en-us.

--- a/rdf/rdf12/rdf-semantics/lowercase-language-string.ttl
+++ b/rdf/rdf12/rdf-semantics/lowercase-language-string.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b "hello"@en-us >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-2a.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-2a.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b "c"^^xsd:integer >> :p1 :o1.
+<< :d :b "c"^^xsd:integer >> :p2 :o2.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-2r.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-2r.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b _:x >> :p1 :o1.
+<< :d :b _:x >> :p2 :o2.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-3a.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-3a.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b "c"^^xsd:integer >> :p1 :o1.
+<< :d :b "d"^^xsd:integer >> :p2 :o2.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-3r.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-3r.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b _:x >> :p1 :o1.
+<< :d :b _:x >> :p2 :o2.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-control.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-control.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:a :b "c"^^xsd:integer.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-other.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-other.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b "d"^^xsd:integer >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/malformed-literal.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b "c"^^xsd:integer >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/manifest.ttl
+++ b/rdf/rdf12/rdf-semantics/manifest.ttl
@@ -1,0 +1,375 @@
+## Distributed under both the "W3C Test Suite License" [1]
+## and the "W3C 3-clause BSD License".
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+PREFIX test:    <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+
+trs:manifest a mf:Manifest;
+  rdfs:label "RDF 1.2 Semantics tests"@en ;
+  skos:prefLabel "La suite des tests pour la sémantique de RDF 1.2"@fr;
+  skos:prefLabel "Conjunto de pruebas para la semántica de RDF 1.2"@es;
+  dct:issued "2023-07-20"^^xsd:date ;
+  dct:modified "2023-07-20"^^xsd:date ;
+  dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+  rdfs:seeAlso <README>;
+  mf:entries (
+    trs:all-identical-quoted-triples-are-the-same
+    trs:quoted-triples-no-spurious
+    trs:bnodes-in-quoted-subject
+    trs:bnodes-in-quoted-object
+    trs:bnodes-in-quoted-subject-and-object
+    trs:bnodes-in-quoted-subject-and-object-fail
+    trs:same-bnode-same-quoted-term
+    trs:different-bnodes-same-quoted-term
+    trs:constrained-bnodes-in-quoted-subject
+    trs:constrained-bnodes-in-quoted-object
+    trs:constrained-bnodes-in-quoted-fail
+    trs:constrained-bnodes-on-literal
+    trs:malformed-literal-control
+    trs:malformed-literal
+    trs:malformed-literal-accepted
+    trs:malformed-literal-no-spurious
+    trs:malformed-literal-bnode-neg
+    trs:opaque-literal-control
+    trs:opaque-literal
+    trs:opaque-language-string-control
+    trs:opaque-language-string
+    trs:opaque-iri-control
+    trs:opaque-iri
+    trs:quoted-not-asserted
+    trs:annotated-asserted
+    trs:annotation
+    trs:annotation-unfolded
+  ) .
+
+trs:all-identical-quoted-triples-are-the-same a mf:PositiveEntailmentTest;
+  rdfs:comment "Multiple occurences of the same quoted triples are undistinguishable in the abstract model.";
+  mf:action <test001a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "all-identical-quoted-triples-are-the-same";
+  mf:recognizedDatatypes ();
+  mf:result <test001r.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:annotated-asserted a mf:PositiveEntailmentTest;
+  rdfs:comment "Annotated triples are asserted.";
+  mf:action <test007a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "annotated-asserted";
+  mf:recognizedDatatypes ();
+  mf:result <test007r1.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:annotation a mf:PositiveEntailmentTest;
+  rdfs:comment "Annotation are about the annotated triple.";
+  mf:action <test007a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "annotation";
+  mf:recognizedDatatypes ();
+  mf:result <test007r2.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:annotation-unfolded a mf:PositiveEntailmentTest;
+  rdfs:comment "Annotation is the same as separate assertions.";
+  mf:action <test007a2.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "annotation-unfolded";
+  mf:recognizedDatatypes ();
+  mf:result <test007a.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:bnodes-in-quoted-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms inside quoted triples can be replaced by fresh bnodes.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "bnodes-in-quoted-object";
+  mf:recognizedDatatypes ();
+  mf:result <test002or.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:bnodes-in-quoted-subject a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms inside quoted triples can be replaced by fresh bnodes.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "bnodes-in-quoted-subject";
+  mf:recognizedDatatypes ();
+  mf:result <test002sr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:bnodes-in-quoted-subject-and-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms inside quoted triples can be replaced by fresh bnodes.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "bnodes-in-quoted-subject-and-object";
+  mf:recognizedDatatypes ();
+  mf:result <test002sor.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:bnodes-in-quoted-subject-and-object-fail a mf:NegativeEntailmentTest;
+  rdfs:comment "The same bnode can not match different quoted terms.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "bnodes-in-quoted-subject-and-object-fail";
+  mf:recognizedDatatypes ();
+  mf:result <test002sbr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:constrained-bnodes-in-quoted-fail a mf:NegativeEntailmentTest;
+  rdfs:comment "Quoted bnode identifiers share the same scope as non-quoted ones. A bnode that occurs both inside quoted triples and inside asserted triples must satisfy all occurrences at the same time.";
+  mf:action <test004a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "constrained-bnodes-in-quoted-fail";
+  mf:recognizedDatatypes ();
+  mf:result <test004fr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:constrained-bnodes-in-quoted-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms inside and outside quoted triples can be replaced by fresh bnodes.";
+  mf:action <test004a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "constrained-bnodes-in-quoted-object";
+  mf:recognizedDatatypes ();
+  mf:result <test004or.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:constrained-bnodes-in-quoted-subject a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms inside and outside quoted triples can be replaced by fresh bnodes";
+  mf:action <test004a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "constrained-bnodes-in-quoted-subject";
+  mf:recognizedDatatypes ();
+  mf:result <test004sr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:constrained-bnodes-on-literal a mf:PositiveEntailmentTest;
+  rdfs:comment "Literals inside and outside quoted triples can be replaced by fresh bnodes.";
+  mf:action <test006a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "constrained-bnodes-on-literal";
+  mf:recognizedDatatypes ();
+  mf:result <test006r.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:different-bnodes-same-quoted-term a mf:PositiveEntailmentTest;
+  rdfs:comment "Different bnodes can match identical quoted terms.";
+  mf:action <test003a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "different-bnodes-same-quoted-term";
+  mf:recognizedDatatypes ();
+  mf:result <test002sor.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:quoted-not-asserted a mf:NegativeEntailmentTest;
+  rdfs:comment "Quoted triples are not asserted.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "quoted-not-asserted";
+  mf:recognizedDatatypes ();
+  mf:result <test002pgr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:quoted-triples-no-spurious a mf:NegativeEntailmentTest;
+  rdfs:comment "This test ensures that other entailments are not spurious.";
+  mf:action <test002a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "quoted-triples-no-spurious";
+  mf:recognizedDatatypes ();
+  mf:result <test005.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:malformed-literal a mf:NegativeEntailmentTest;
+  rdfs:comment "Malformed literals are allowed when quoted.";
+  mf:action <malformed-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result false;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:malformed-literal-accepted a mf:PositiveEntailmentTest;
+  rdfs:comment "Malformed literals are allowed when quoted.";
+  mf:action <malformed-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-accepted";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <malformed-literal.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:malformed-literal-bnode a mf:PositiveEntailmentTest;
+  rdfs:comment "Malformed literals can be replaced by blank nodes (withdrawn as the current semantics does not enforce this).";
+  mf:action <malformed-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-bnode";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <test002or.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Withdrawn .
+
+trs:malformed-literal-bnode-neg a mf:NegativeEntailmentTest;
+  rdfs:comment "Malformed literals can not be replaced by blank nodes.";
+  mf:action <malformed-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-bnode";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <test002or.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:malformed-literal-bnode-2 a mf:PositiveEntailmentTest;
+  rdfs:comment "Identical malformed literals can be replaced with the same blank node  (withdrawn as the current semantics does not enforce this).";
+  mf:action <malformed-literal-2a.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-bnode-2";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <malformed-literal-2r.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Withdrawn .
+
+trs:malformed-literal-bnode-3 a mf:NegativeEntailmentTest;
+  rdfs:comment "Identical malformed literals can not be replaced with the same blank node (withdrawn as the current semantics does not enforce this).";
+  mf:action <malformed-literal-3a.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-bnode-3";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <malformed-literal-3r.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Withdrawn .
+
+trs:malformed-literal-control a mf:PositiveEntailmentTest;
+  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.";
+  mf:action <malformed-literal-control.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-control";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result false;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:malformed-literal-no-spurious a mf:NegativeEntailmentTest;
+  rdfs:comment "Quoted malformed literals do not lead to spurious entailment.";
+  mf:action <malformed-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "malformed-literal-no-spurious";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <malformed-literal-other.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:opaque-iri a mf:NegativeEntailmentTest;
+  rdfs:comment "Quoted IRIs are opaque.";
+  mf:action <superman.ttl>;
+  mf:entailmentRegime "RDFS-Plus";
+  mf:name "opaque-iri";
+  mf:recognizedDatatypes ();
+  mf:result <superman_undesired_entailment.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:opaque-iri-control a mf:PositiveEntailmentTest;
+  rdfs:comment "Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.";
+  mf:action <control-sameas-a.ttl>;
+  mf:entailmentRegime "RDFS-Plus";
+  mf:name "opaque-iri-control";
+  mf:recognizedDatatypes ();
+  mf:result <control-sameas-r.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:opaque-language-string a mf:NegativeEntailmentTest;
+  rdfs:comment "Quoted literals (including language strings) are opaque, even when their datatype is recognized.";
+  mf:action <lowercase-language-string.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "opaque-language-string";
+  mf:recognizedDatatypes ();
+  mf:result <upercase-language-string.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:opaque-language-string-control a mf:PositiveEntailmentTest;
+  rdfs:comment "Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.";
+  mf:action <lowercase-language-string-control.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "opaque-language-string-control";
+  mf:recognizedDatatypes ();
+  mf:result <upercase-language-string-control.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:opaque-literal a mf:NegativeEntailmentTest;
+  rdfs:comment "Quoted literals are opaque, even when their datatype is recognized.";
+  mf:action <non-canonical-literal.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "opaque-literal";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <canonical-literal.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:opaque-literal-control a mf:PositiveEntailmentTest;
+  rdfs:comment "Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.";
+  mf:action <non-canonical-literal-control.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "opaque-literal-control";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <canonical-literal-control.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:same-bnode-same-quoted-term a mf:PositiveEntailmentTest;
+  rdfs:comment "Identical quoted term can be replaced by the same fresh bnode multiple times.";
+  mf:action <test003a.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "same-bnode-same-quoted-term";
+  mf:recognizedDatatypes ();
+  mf:result <test002sbr.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
+
+trs:triple-in-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Quoted triples can appear in object position (withdrawn, as it belongs to concrete syntax test-suites).";
+  mf:action <test000o.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "triple-in-object";
+  mf:recognizedDatatypes ();
+  mf:result <test000o.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Withdrawn .
+
+trs:triple-in-subject a mf:PositiveEntailmentTest;
+  rdfs:comment "Quoted triples can appear in subject position (withdrawn, as it belongs to concrete syntax test-suites).";
+  mf:action <test000s.ttl>;
+  mf:entailmentRegime "simple";
+  mf:name "triple-in-subject";
+  mf:recognizedDatatypes ();
+  mf:result <test000s.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:Withdrawn .

--- a/rdf/rdf12/rdf-semantics/non-canonical-literal-control.ttl
+++ b/rdf/rdf12/rdf-semantics/non-canonical-literal-control.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:a :b "042"^^xsd:integer.

--- a/rdf/rdf12/rdf-semantics/non-canonical-literal.ttl
+++ b/rdf/rdf12/rdf-semantics/non-canonical-literal.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b "042"^^xsd:integer >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/superman.ttl
+++ b/rdf/rdf12/rdf-semantics/superman.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+
+<< :superman :can :fly >> :reportedBy :clark.
+:clark owl:sameAs :superman.

--- a/rdf/rdf12/rdf-semantics/superman_undesired_entailment.ttl
+++ b/rdf/rdf12/rdf-semantics/superman_undesired_entailment.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :clark :can :fly >> :reportedBy :clark.

--- a/rdf/rdf12/rdf-semantics/test000o.ttl
+++ b/rdf/rdf12/rdf-semantics/test000o.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+:s1 :p1 << :x :y :z >>.

--- a/rdf/rdf12/rdf-semantics/test000s.ttl
+++ b/rdf/rdf12/rdf-semantics/test000s.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b :c >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test001a.ttl
+++ b/rdf/rdf12/rdf-semantics/test001a.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b :c >> :p1 :o1.
+<< :a :b :c >> :p2 :o2.

--- a/rdf/rdf12/rdf-semantics/test001r.ttl
+++ b/rdf/rdf12/rdf-semantics/test001r.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b :c >> :p1 :o1; :p2 :o2.

--- a/rdf/rdf12/rdf-semantics/test002a.ttl
+++ b/rdf/rdf12/rdf-semantics/test002a.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b :c >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test002or.ttl
+++ b/rdf/rdf12/rdf-semantics/test002or.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b _:x >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test002pgr.ttl
+++ b/rdf/rdf12/rdf-semantics/test002pgr.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+:a :b :c.

--- a/rdf/rdf12/rdf-semantics/test002r.ttl
+++ b/rdf/rdf12/rdf-semantics/test002r.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b :c >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test002sbr.ttl
+++ b/rdf/rdf12/rdf-semantics/test002sbr.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< _:x :b _:x >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test002sor.ttl
+++ b/rdf/rdf12/rdf-semantics/test002sor.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< _:x :b _:y >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test002sr.ttl
+++ b/rdf/rdf12/rdf-semantics/test002sr.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< _:x :b :c >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test003a.ttl
+++ b/rdf/rdf12/rdf-semantics/test003a.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b :a >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test003r.ttl
+++ b/rdf/rdf12/rdf-semantics/test003r.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b :a >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test004a.ttl
+++ b/rdf/rdf12/rdf-semantics/test004a.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b :c >> :p1 :o1.
+:a :label "A".
+:c :label "C".

--- a/rdf/rdf12/rdf-semantics/test004fr.ttl
+++ b/rdf/rdf12/rdf-semantics/test004fr.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+
+<< _:x :b :c >> :p1 :o1.
+_:x :label "C".

--- a/rdf/rdf12/rdf-semantics/test004or.ttl
+++ b/rdf/rdf12/rdf-semantics/test004or.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b _:x >> :p1 :o1.
+_:x :label "C".

--- a/rdf/rdf12/rdf-semantics/test004sr.ttl
+++ b/rdf/rdf12/rdf-semantics/test004sr.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+
+<< _:x :b :c >> :p1 :o1.
+_:x :label "A".

--- a/rdf/rdf12/rdf-semantics/test005.ttl
+++ b/rdf/rdf12/rdf-semantics/test005.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b :d >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test006a.ttl
+++ b/rdf/rdf12/rdf-semantics/test006a.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b "42"^^xsd:integer >> :p1 :o1.
+:s2 :p2 "42"^^xsd:integer.

--- a/rdf/rdf12/rdf-semantics/test006r.ttl
+++ b/rdf/rdf12/rdf-semantics/test006r.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<< :a :b _:x >> :p1 :o1.
+:s2 :p2 _:x.

--- a/rdf/rdf12/rdf-semantics/test007a.ttl
+++ b/rdf/rdf12/rdf-semantics/test007a.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+:a :b :c {| :p1 :o1 |}.

--- a/rdf/rdf12/rdf-semantics/test007a2.ttl
+++ b/rdf/rdf12/rdf-semantics/test007a2.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+
+:a :b :c.
+<< :a :b :c >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test007r1.ttl
+++ b/rdf/rdf12/rdf-semantics/test007r1.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+:a :b :c.

--- a/rdf/rdf12/rdf-semantics/test007r2.ttl
+++ b/rdf/rdf12/rdf-semantics/test007r2.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b :c >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/upercase-language-string-control.ttl
+++ b/rdf/rdf12/rdf-semantics/upercase-language-string-control.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+:a :b "hello"@en-US.

--- a/rdf/rdf12/rdf-semantics/upercase-language-string.ttl
+++ b/rdf/rdf12/rdf-semantics/upercase-language-string.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<< :a :b "hello"@en-US >> :p1 :o1.

--- a/rdf/rdf12/rdf-trig/eval/index.html
+++ b/rdf/rdf12/rdf-trig/eval/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang='en' prefix='mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+  <!-- This file is generated automatciallly from manifest.ttl, and should not be edited directly. -->
+  <head>
+    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+    <meta content='width=device-width, initial-scale=1.0' name='viewport'>
+    <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' type='text/css'>
+    <style>
+      body: {bacground-image: none;}
+      dl.editor>dd {
+        margin: 0 0 0 40px;
+      }
+      dl.test-detail {
+        padding: 0.5em;
+      }
+      dl.test-detail>dt {
+        float: left;
+        clear: left;
+        text-align: right;
+        font-weight: bold;
+        color: green;
+      }
+      dl.test-detail>dt:after {content: ": "}
+      dl.test-detail>dd {
+        margin: 0 0 0 110px;
+        padding: 0 0 0.5em 0;
+      }
+      dl.test-description>dt {margin-top: 2em;}
+      dd {margin-left: 0;}
+      dd code {display: inline;}
+      footer {text-align: center;}
+    </style>
+    <title>
+      RDF 1.2 TriG Evaluation Tests
+    </title>
+    <style>
+      em.rfc2119 {
+        text-transform: lowercase;
+        font-variant:   small-caps;
+        font-style:     normal;
+        color:          #900;
+      }
+      a.testlink {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.testlink:hover {
+        text-decoration: underline;
+      }
+      .warning {color: orange;}
+      .error {color: red;}
+    </style>
+  </head>
+  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#manifest' typeof='mf:Manifest'>
+    <p>
+      <a href='http://www.w3.org/'>
+        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
+      </a>
+    </p>
+    <h1 property='rdfs:label'>RDF 1.2 TriG Evaluation Tests</h1>
+    <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    <hr title='Separator for header'>
+    <div>
+      <h2 id='abstract'>Abstract</h2>
+      <p>This page describes W3C RDF-star Working Group&#39;s test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.</p>
+      <h3>Contributing Tests</h3>
+      <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
+      <h3>Distribution</h3>
+      <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
+      <h3>Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+        COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+    </div>
+    <div>
+      <h2>
+        Test Descriptions
+      </h2>
+      <dl class='test-description'>
+        <dt id='trig-star-1'>
+          <a class='testlink' href='#trig-star-1'>
+            trig-star-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-1' property='mf:name'>TriG-star - subject quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-1' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-01.trig' property='mf:action'>trig-star-eval-01.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-01.nq' property='mf:result'>trig-star-eval-01.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-2'>
+          <a class='testlink' href='#trig-star-2'>
+            trig-star-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-2' property='mf:name'>TriG-star - object quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-2' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-02.trig' property='mf:action'>trig-star-eval-02.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-02.nq' property='mf:result'>trig-star-eval-02.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bnode-1'>
+          <a class='testlink' href='#trig-star-bnode-1'>
+            trig-star-bnode-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-bnode-1' property='mf:name'>TriG-star - blank node label</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-bnode-1' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-bnode-1.trig' property='mf:action'>trig-star-eval-bnode-1.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-bnode-1.nq' property='mf:result'>trig-star-eval-bnode-1.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bnode-2'>
+          <a class='testlink' href='#trig-star-bnode-2'>
+            trig-star-bnode-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-bnode-2' property='mf:name'>TriG-star - blank node labels</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-bnode-2' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-bnode-2.trig' property='mf:action'>trig-star-eval-bnode-2.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-bnode-2.nq' property='mf:result'>trig-star-eval-bnode-2.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-annotation-1'>
+          <a class='testlink' href='#trig-star-annotation-1'>
+            trig-star-annotation-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-1' property='mf:name'>TriG-star - Annotation form</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-1' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-annotation-1.trig' property='mf:action'>trig-star-eval-annotation-1.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-annotation-1.nq' property='mf:result'>trig-star-eval-annotation-1.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-annotation-2'>
+          <a class='testlink' href='#trig-star-annotation-2'>
+            trig-star-annotation-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-2' property='mf:name'>TriG-star - Annotation example</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-2' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-annotation-2.trig' property='mf:action'>trig-star-eval-annotation-2.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-annotation-2.nq' property='mf:result'>trig-star-eval-annotation-2.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-annotation-3'>
+          <a class='testlink' href='#trig-star-annotation-3'>
+            trig-star-annotation-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-3' property='mf:name'>TriG-star - Annotation - predicate and object lists</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-3' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-annotation-3.trig' property='mf:action'>trig-star-eval-annotation-3.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-annotation-3.nq' property='mf:result'>trig-star-eval-annotation-3.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-annotation-4'>
+          <a class='testlink' href='#trig-star-annotation-4'>
+            trig-star-annotation-4:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-4' property='mf:name'>TriG-star - Annotation - nested</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-4' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-annotation-4.trig' property='mf:action'>trig-star-eval-annotation-4.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-annotation-4.nq' property='mf:result'>trig-star-eval-annotation-4.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-annotation-5'>
+          <a class='testlink' href='#trig-star-annotation-5'>
+            trig-star-annotation-5:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-5' property='mf:name'>TriG-star - Annotation object list</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-5' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-annotation-5.trig' property='mf:action'>trig-star-eval-annotation-5.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-annotation-5.nq' property='mf:result'>trig-star-eval-annotation-5.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-quoted-annotation-1'>
+          <a class='testlink' href='#trig-star-quoted-annotation-1'>
+            trig-star-quoted-annotation-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-1' property='mf:name'>TriG-star - Annotation with quoting</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-1' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-quoted-annotation-1.trig' property='mf:action'>trig-star-eval-quoted-annotation-1.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-quoted-annotation-1.nq' property='mf:result'>trig-star-eval-quoted-annotation-1.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-quoted-annotation-2'>
+          <a class='testlink' href='#trig-star-quoted-annotation-2'>
+            trig-star-quoted-annotation-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-2' property='mf:name'>TriG-star - Annotation on triple with quoted subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-2' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-quoted-annotation-2.trig' property='mf:action'>trig-star-eval-quoted-annotation-2.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-quoted-annotation-2.nq' property='mf:result'>trig-star-eval-quoted-annotation-2.nq</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-quoted-annotation-3'>
+          <a class='testlink' href='#trig-star-quoted-annotation-3'>
+            trig-star-quoted-annotation-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-3' property='mf:name'>TriG-star - Annotation on triple with quoted object</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-3' typeof='rdft:TestTrigEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-eval-quoted-annotation-3.trig' property='mf:action'>trig-star-eval-quoted-annotation-3.trig</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='trig-star-eval-quoted-annotation-3.nq' property='mf:result'>trig-star-eval-quoted-annotation-3.nq</a>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+    </div>
+    <footer>
+      <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    </footer>
+  </body>
+</html>

--- a/rdf/rdf12/rdf-trig/eval/manifest.ttl
+++ b/rdf/rdf12/rdf-trig/eval/manifest.ttl
@@ -1,0 +1,112 @@
+## Distributed under both the "W3C Test Suite License" [1]
+## and the "W3C 3-clause BSD License".
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+trs:manifest  rdf:type mf:Manifest ;
+   rdfs:label "RDF 1.2 TriG Evaluation Tests"@en ;
+   skos:prefLabel "La suite des tests pour évaluation de RDF 1.2 TriG"@fr;
+   skos:prefLabel "Conjunto de pruebas para evaluar RDF 1.2 TriG"@es;
+   dct:issued "2023-07-20"^^xsd:date ;
+   rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+   dct:modified "2023-07-20"^^xsd:date ;
+   dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+   dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+   mf:entries
+    (
+        trs:trig-star-1
+        trs:trig-star-2
+        trs:trig-star-bnode-1
+        trs:trig-star-bnode-2
+        trs:trig-star-annotation-1
+        trs:trig-star-annotation-2
+        trs:trig-star-annotation-3
+        trs:trig-star-annotation-4
+        trs:trig-star-annotation-5
+        trs:trig-star-quoted-annotation-1
+        trs:trig-star-quoted-annotation-2
+        trs:trig-star-quoted-annotation-3
+    ) .
+
+trs:trig-star-1 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - subject quoted triple" ;
+   mf:action    <trig-star-eval-01.trig> ;
+   mf:result    <trig-star-eval-01.nq> ;
+   .
+
+trs:trig-star-2 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - object quoted triple" ;
+   mf:action    <trig-star-eval-02.trig> ;
+   mf:result    <trig-star-eval-02.nq> ;
+   .
+
+trs:trig-star-bnode-1 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - blank node label" ;
+   mf:action    <trig-star-eval-bnode-1.trig> ;
+   mf:result    <trig-star-eval-bnode-1.nq> ;
+   .
+
+trs:trig-star-bnode-2 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - blank node labels" ;
+   mf:action    <trig-star-eval-bnode-2.trig> ;
+   mf:result    <trig-star-eval-bnode-2.nq> ;
+   .
+
+trs:trig-star-annotation-1 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation form" ;
+   mf:action    <trig-star-eval-annotation-1.trig> ;
+   mf:result    <trig-star-eval-annotation-1.nq> ;
+   .
+
+trs:trig-star-annotation-2 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation example" ;
+   mf:action    <trig-star-eval-annotation-2.trig> ;
+   mf:result    <trig-star-eval-annotation-2.nq> ;
+   .
+
+trs:trig-star-annotation-3 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation - predicate and object lists" ;
+   mf:action    <trig-star-eval-annotation-3.trig> ;
+   mf:result    <trig-star-eval-annotation-3.nq> ;
+   .
+
+trs:trig-star-annotation-4 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation - nested" ;
+   mf:action    <trig-star-eval-annotation-4.trig> ;
+   mf:result    <trig-star-eval-annotation-4.nq> ;
+   .
+
+trs:trig-star-annotation-5 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation object list" ;
+   mf:action    <trig-star-eval-annotation-5.trig> ;
+   mf:result    <trig-star-eval-annotation-5.nq> ;
+   .
+
+trs:trig-star-quoted-annotation-1 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation with quoting" ;
+   mf:action    <trig-star-eval-quoted-annotation-1.trig> ;
+   mf:result    <trig-star-eval-quoted-annotation-1.nq> ;
+   .
+   
+trs:trig-star-quoted-annotation-2 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation on triple with quoted subject" ;
+   mf:action    <trig-star-eval-quoted-annotation-2.trig> ;
+   mf:result    <trig-star-eval-quoted-annotation-2.nq> ;
+   .
+   
+trs:trig-star-quoted-annotation-3 rdf:type rdft:TestTrigEval ;
+   mf:name      "TriG-star - Annotation on triple with quoted object" ;
+   mf:action    <trig-star-eval-quoted-annotation-3.trig> ;
+   mf:result    <trig-star-eval-quoted-annotation-3.nq> ;
+   .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-01.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-01.nq
@@ -1,0 +1,1 @@
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/q> <http://example/z> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-01.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-01.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {<<:s :p :o>> :q :z .}

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-02.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-02.nq
@@ -1,0 +1,1 @@
+<http://example/a> <http://example/q> << <http://example/s> <http://example/p> <http://example/o> >> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-02.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-02.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:a :q <<:s :p :o>> .}

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-1.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-1.nq
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <http://example/o> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/r> <http://example/z> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-1.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-1.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p :o {| :r :z |} .}

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-2.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-2.nq
@@ -1,0 +1,7 @@
+<http://example/s> <http://example/p> <http://example/o> <http://example/G> .
+_:b1 <http://example/graph> <http://host1/> <http://example/G> .
+_:b1 <http://example/date> "2020-01-20"^^<http://www.w3.org/2001/XMLSchema#date> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/source> _:b1 <http://example/G> .
+_:b2 <http://example/graph> <http://host2/> <http://example/G> .
+_:b2 <http://example/date> "2020-12-31"^^<http://www.w3.org/2001/XMLSchema#date> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/source> _:b2 <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-2.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-2.trig
@@ -1,0 +1,12 @@
+PREFIX :       <http://example/>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+:G {
+  :s :p :o {| :source [ :graph <http://host1/> ;
+                        :date "2020-01-20"^^xsd:date
+                      ] ;
+              :source [ :graph <http://host2/> ;
+                        :date "2020-12-31"^^xsd:date
+                      ]
+            |} .
+}

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-3.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-3.nq
@@ -1,0 +1,6 @@
+<http://example/s> <http://example/p> <http://example/o> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/a> <http://example/b> <http://example/G> .
+<http://example/s> <http://example/p2> <http://example/o2> <http://example/G> .
+<< <http://example/s> <http://example/p2> <http://example/o2> >> <http://example/a2> <http://example/b2> <http://example/G> .
+<http://example/s> <http://example/p2> <http://example/o3> <http://example/G> .
+<< <http://example/s> <http://example/p2> <http://example/o3> >> <http://example/a3> <http://example/b3> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-3.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-3.trig
@@ -1,0 +1,7 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o {| :a :b |};
+      :p2 :o2 {| :a2 :b2 |},
+          :o3 {| :a3 :b3 |}.
+}

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-4.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-4.nq
@@ -1,0 +1,3 @@
+<http://example/s> <http://example/p> <http://example/o> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/a> <http://example/b> <http://example/G> .
+<< << <http://example/s> <http://example/p> <http://example/o> >> <http://example/a> <http://example/b> >> <http://example/a2> <http://example/b2> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-4.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-4.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p :o {| :a :b {| :a2 :b2 |} |}.}

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-5.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-5.nq
@@ -1,0 +1,3 @@
+<http://example/s> <http://example/p> <http://example/o1> <http://example/G> .
+<http://example/s> <http://example/p> <http://example/o2> <http://example/G> .
+<< <http://example/s> <http://example/p> <http://example/o2> >> <http://example/a> <http://example/b> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-5.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-annotation-5.trig
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:G {:s :p :o1, :o2 {| :a :b |} .}
+

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-bnode-1.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-bnode-1.nq
@@ -1,0 +1,2 @@
+_:b9 <http://example/p> <http://example/o> <http://example/G> .
+<< _:b9 <http://example/p> <http://example/o> >> <http://example/q> <http://example/z> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-bnode-1.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-bnode-1.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  _:b :p :o .
+  <<_:b :p :o>> :q :z .
+}

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-bnode-2.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-bnode-2.nq
@@ -1,0 +1,2 @@
+_:label1 <http://example/p1> _:label1 <http://example/G> .
+<< _:label1 <http://example/p1> _:label1 >> <http://example/q> << _:label1 <http://example/p2> <http://example/o> >> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-bnode-2.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-bnode-2.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  _:a :p1 _:a .
+  <<_:a :p1 _:a >> :q <<_:a :p2 :o>> .
+}

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-1.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-1.nq
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <http://example/o> <http://example/G> .
+<<<http://example/s> <http://example/p> <http://example/o>>> <http://example/r> <<<http://example/s1> <http://example/p1> <http://example/o1>>> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-1.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-1.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p :o {| :r <<:s1 :p1 :o1>> |} .}

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-2.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-2.nq
@@ -1,0 +1,2 @@
+<<<http://example/s1> <http://example/p1> <http://example/o1>>> <http://example/p> <http://example/o> <http://example/G> .
+<<<<<http://example/s1> <http://example/p1> <http://example/o1>>> <http://example/p> <http://example/o>>> <http://example/r> <http://example/z> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-2.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-2.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {<<:s1 :p1 :o1>> :p :o {| :r :z |} .}

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-3.nq
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-3.nq
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <<<http://example/s2> <http://example/p2> <http://example/o2>>> <http://example/G> .
+<<<http://example/s> <http://example/p> <<<http://example/s2> <http://example/p2> <http://example/o2>>>>> <http://example/r> <http://example/z> <http://example/G> .

--- a/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-3.trig
+++ b/rdf/rdf12/rdf-trig/eval/trig-star-eval-quoted-annotation-3.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p <<:s2 :p2 :o2>> {| :r :z |} .}

--- a/rdf/rdf12/rdf-trig/syntax/index.html
+++ b/rdf/rdf12/rdf-trig/syntax/index.html
@@ -1,0 +1,527 @@
+<!DOCTYPE html>
+<html lang='en' prefix='mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+  <!-- This file is generated automatciallly from manifest.ttl, and should not be edited directly. -->
+  <head>
+    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+    <meta content='width=device-width, initial-scale=1.0' name='viewport'>
+    <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' type='text/css'>
+    <style>
+      body: {bacground-image: none;}
+      dl.editor>dd {
+        margin: 0 0 0 40px;
+      }
+      dl.test-detail {
+        padding: 0.5em;
+      }
+      dl.test-detail>dt {
+        float: left;
+        clear: left;
+        text-align: right;
+        font-weight: bold;
+        color: green;
+      }
+      dl.test-detail>dt:after {content: ": "}
+      dl.test-detail>dd {
+        margin: 0 0 0 110px;
+        padding: 0 0 0.5em 0;
+      }
+      dl.test-description>dt {margin-top: 2em;}
+      dd {margin-left: 0;}
+      dd code {display: inline;}
+      footer {text-align: center;}
+    </style>
+    <title>
+      RDF 1.2 TriG Syntax Tests
+    </title>
+    <style>
+      em.rfc2119 {
+        text-transform: lowercase;
+        font-variant:   small-caps;
+        font-style:     normal;
+        color:          #900;
+      }
+      a.testlink {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.testlink:hover {
+        text-decoration: underline;
+      }
+      .warning {color: orange;}
+      .error {color: red;}
+    </style>
+  </head>
+  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#manifest' typeof='mf:Manifest'>
+    <p>
+      <a href='http://www.w3.org/'>
+        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
+      </a>
+    </p>
+    <h1 property='rdfs:label'>RDF 1.2 TriG Syntax Tests</h1>
+    <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    <hr title='Separator for header'>
+    <div>
+      <h2 id='abstract'>Abstract</h2>
+      <p>This page describes W3C RDF-star Working Group&#39;s test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.</p>
+      <h3>Contributing Tests</h3>
+      <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
+      <h3>Distribution</h3>
+      <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
+      <h3>Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+        COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+    </div>
+    <div>
+      <h2>
+        Test Descriptions
+      </h2>
+      <dl class='test-description'>
+        <dt id='trig-star-1'>
+          <a class='testlink' href='#trig-star-1'>
+            trig-star-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-1' property='mf:name'>TriG-star - subject quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-1' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-basic-01.trig' property='mf:action'>trig-star-syntax-basic-01.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-2'>
+          <a class='testlink' href='#trig-star-2'>
+            trig-star-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-2' property='mf:name'>TriG-star - object quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-2' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-basic-02.trig' property='mf:action'>trig-star-syntax-basic-02.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-inside-1'>
+          <a class='testlink' href='#trig-star-inside-1'>
+            trig-star-inside-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-inside-1' property='mf:name'>TriG-star - quoted triple inside blankNodePropertyList</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-inside-1' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-inside-01.trig' property='mf:action'>trig-star-syntax-inside-01.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-inside-2'>
+          <a class='testlink' href='#trig-star-inside-2'>
+            trig-star-inside-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-inside-2' property='mf:name'>TriG-star - quoted triple inside collection</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-inside-2' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-inside-02.trig' property='mf:action'>trig-star-syntax-inside-02.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-nested-1'>
+          <a class='testlink' href='#trig-star-nested-1'>
+            trig-star-nested-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-nested-1' property='mf:name'>TriG-star - nested quoted triple, subject position</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-nested-1' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-nested-01.trig' property='mf:action'>trig-star-syntax-nested-01.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-nested-2'>
+          <a class='testlink' href='#trig-star-nested-2'>
+            trig-star-nested-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-nested-2' property='mf:name'>TriG-star - nested quoted triple, object position</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-nested-2' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-nested-02.trig' property='mf:action'>trig-star-syntax-nested-02.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-compound-1'>
+          <a class='testlink' href='#trig-star-compound-1'>
+            trig-star-compound-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-compound-1' property='mf:name'>TriG-star - compound forms</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-compound-1' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-compound.trig' property='mf:action'>trig-star-syntax-compound.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bnode-1'>
+          <a class='testlink' href='#trig-star-bnode-1'>
+            trig-star-bnode-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-1' property='mf:name'>TriG-star - blank node subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-1' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bnode-01.trig' property='mf:action'>trig-star-syntax-bnode-01.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bnode-2'>
+          <a class='testlink' href='#trig-star-bnode-2'>
+            trig-star-bnode-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-2' property='mf:name'>TriG-star - blank node object</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-2' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bnode-02.trig' property='mf:action'>trig-star-syntax-bnode-02.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bnode-3'>
+          <a class='testlink' href='#trig-star-bnode-3'>
+            trig-star-bnode-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-3' property='mf:name'>TriG-star - blank node</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-3' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bnode-03.trig' property='mf:action'>trig-star-syntax-bnode-03.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bad-1'>
+          <a class='testlink' href='#trig-star-bad-1'>
+            trig-star-bad-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-1' property='mf:name'>TriG-star - bad - quoted triple as predicate</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-1' typeof='rdft:TestTrigNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bad-01.trig' property='mf:action'>trig-star-syntax-bad-01.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bad-2'>
+          <a class='testlink' href='#trig-star-bad-2'>
+            trig-star-bad-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-2' property='mf:name'>TriG-star - bad - quoted triple outside triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-2' typeof='rdft:TestTrigNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bad-02.trig' property='mf:action'>trig-star-syntax-bad-02.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bad-3'>
+          <a class='testlink' href='#trig-star-bad-3'>
+            trig-star-bad-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-3' property='mf:name'>TriG-star - bad - collection list in quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-3' typeof='rdft:TestTrigNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bad-03.trig' property='mf:action'>trig-star-syntax-bad-03.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bad-4'>
+          <a class='testlink' href='#trig-star-bad-4'>
+            trig-star-bad-4:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-4' property='mf:name'>TriG-star - bad - literal in subject position of quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-4' typeof='rdft:TestTrigNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bad-04.trig' property='mf:action'>trig-star-syntax-bad-04.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bad-5'>
+          <a class='testlink' href='#trig-star-bad-5'>
+            trig-star-bad-5:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-5' property='mf:name'>TriG-star - bad - blank node  as predicate in quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-5' typeof='rdft:TestTrigNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bad-05.trig' property='mf:action'>trig-star-syntax-bad-05.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bad-6'>
+          <a class='testlink' href='#trig-star-bad-6'>
+            trig-star-bad-6:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-6' property='mf:name'>TriG-star - bad - compound blank node expression</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-6' typeof='rdft:TestTrigNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bad-06.trig' property='mf:action'>trig-star-syntax-bad-06.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bad-7'>
+          <a class='testlink' href='#trig-star-bad-7'>
+            trig-star-bad-7:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-7' property='mf:name'>TriG-star - bad - incomplete quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-7' typeof='rdft:TestTrigNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bad-07.trig' property='mf:action'>trig-star-syntax-bad-07.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bad-8'>
+          <a class='testlink' href='#trig-star-bad-8'>
+            trig-star-bad-8:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-8' property='mf:name'>TriG-star - bad - over-long quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-8' typeof='rdft:TestTrigNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bad-08.trig' property='mf:action'>trig-star-syntax-bad-08.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-ann-1'>
+          <a class='testlink' href='#trig-star-ann-1'>
+            trig-star-ann-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-ann-1' property='mf:name'>TriG-star - Annotation form</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-ann-1' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-annotation-1.trig' property='mf:action'>trig-star-annotation-1.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-ann-2'>
+          <a class='testlink' href='#trig-star-ann-2'>
+            trig-star-ann-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-ann-2' property='mf:name'>TriG-star - Annotation example</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-ann-2' typeof='rdft:TestTrigPositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigPositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-annotation-2.trig' property='mf:action'>trig-star-annotation-2.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bad-ann-1'>
+          <a class='testlink' href='#trig-star-bad-ann-1'>
+            trig-star-bad-ann-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-ann-1' property='mf:name'>TriG-star - bad - empty annotation</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-ann-1' typeof='rdft:TestTrigNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bad-ann-1.trig' property='mf:action'>trig-star-syntax-bad-ann-1.trig</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='trig-star-bad-ann-2'>
+          <a class='testlink' href='#trig-star-bad-ann-2'>
+            trig-star-bad-ann-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-ann-2' property='mf:name'>TriG-star - bad - triple as annotation</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-ann-2' typeof='rdft:TestTrigNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTrigNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='trig-star-syntax-bad-ann-2.trig' property='mf:action'>trig-star-syntax-bad-ann-2.trig</a>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+    </div>
+    <footer>
+      <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    </footer>
+  </body>
+</html>

--- a/rdf/rdf12/rdf-trig/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-trig/syntax/manifest.ttl
@@ -1,0 +1,175 @@
+## Distributed under both the "W3C Test Suite License" [1]
+## and the "W3C 3-clause BSD License".
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+trs:manifest  rdf:type mf:Manifest ;
+    rdfs:label "RDF 1.2 TriG Syntax Tests"@en ;
+    skos:prefLabel "La suite des tests pour la syntaxe de RDF 1.2 TriG"@fr ;
+    skos:prefLabel "Conjunto de pruebas para la sintaxis de RDF 1.2 TriG"@es ;
+    dct:issued "2023-07-20"^^xsd:date ;
+    rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+    dct:modified "2023-07-20"^^xsd:date ;
+    dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+    dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+    mf:entries
+    (
+        trs:trig-star-1
+        trs:trig-star-2
+
+        trs:trig-star-inside-1
+        trs:trig-star-inside-2
+
+        trs:trig-star-nested-1
+        trs:trig-star-nested-2
+
+        trs:trig-star-compound-1
+
+        trs:trig-star-bnode-1
+        trs:trig-star-bnode-2
+        trs:trig-star-bnode-3
+
+        trs:trig-star-bad-1
+        trs:trig-star-bad-2
+        trs:trig-star-bad-3
+        trs:trig-star-bad-4
+        trs:trig-star-bad-5
+        trs:trig-star-bad-6
+        trs:trig-star-bad-7
+        trs:trig-star-bad-8
+
+        trs:trig-star-ann-1
+        trs:trig-star-ann-2
+
+        trs:trig-star-bad-ann-1
+        trs:trig-star-bad-ann-2
+    ) .
+
+## Good Syntax
+
+trs:trig-star-1 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - subject quoted triple" ;
+   mf:action    <trig-star-syntax-basic-01.trig> ;
+   .
+
+trs:trig-star-2 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - object quoted triple" ;
+   mf:action    <trig-star-syntax-basic-02.trig> ;
+   .
+
+trs:trig-star-inside-1 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - quoted triple inside blankNodePropertyList" ;
+   mf:action    <trig-star-syntax-inside-01.trig> ;
+   .
+
+trs:trig-star-inside-2 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - quoted triple inside collection" ;
+   mf:action    <trig-star-syntax-inside-02.trig> ;
+   .
+
+trs:trig-star-nested-1 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - nested quoted triple, subject position" ;
+   mf:action    <trig-star-syntax-nested-01.trig> ;
+   .
+
+trs:trig-star-nested-2 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - nested quoted triple, object position" ;
+   mf:action     <trig-star-syntax-nested-02.trig> ;
+   .
+
+trs:trig-star-compound-1 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - compound forms" ;
+   mf:action    <trig-star-syntax-compound.trig> ;
+   .
+
+trs:trig-star-bnode-1 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - blank node subject" ;
+   mf:action    <trig-star-syntax-bnode-01.trig> ;
+   .
+
+trs:trig-star-bnode-2 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - blank node object" ;
+   mf:action    <trig-star-syntax-bnode-02.trig> ;
+   .
+
+trs:trig-star-bnode-3 rdf:type rdft:TestTrigPositiveSyntax ;
+   mf:name      "TriG-star - blank node" ;
+   mf:action    <trig-star-syntax-bnode-03.trig> ;
+   .
+
+## Bad Syntax
+
+trs:trig-star-bad-1 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - quoted triple as predicate" ;
+    mf:action    <trig-star-syntax-bad-01.trig> ;
+    .
+
+trs:trig-star-bad-2 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - quoted triple outside triple" ;
+    mf:action    <trig-star-syntax-bad-02.trig> ;
+    .
+
+trs:trig-star-bad-3 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - collection list in quoted triple" ;
+    mf:action    <trig-star-syntax-bad-03.trig> ;
+    .
+
+trs:trig-star-bad-4 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - literal in subject position of quoted triple" ;
+    mf:action    <trig-star-syntax-bad-04.trig> ;
+    .
+
+trs:trig-star-bad-5 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - blank node  as predicate in quoted triple";
+    mf:action    <trig-star-syntax-bad-05.trig> ;
+    .
+
+trs:trig-star-bad-6 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - compound blank node expression";
+    mf:action    <trig-star-syntax-bad-06.trig> ;
+    .
+
+trs:trig-star-bad-7 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - incomplete quoted triple";
+    mf:action    <trig-star-syntax-bad-07.trig> ;
+    .
+
+trs:trig-star-bad-8 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - over-long quoted triple";
+    mf:action    <trig-star-syntax-bad-08.trig> ;
+    .
+
+## Annotation syntax
+
+trs:trig-star-ann-1 rdf:type rdft:TestTrigPositiveSyntax ;
+    mf:name      "TriG-star - Annotation form" ;
+    mf:action    <trig-star-annotation-1.trig> ;
+   .
+
+trs:trig-star-ann-2 rdf:type rdft:TestTrigPositiveSyntax ;
+    mf:name      "TriG-star - Annotation example" ;
+    mf:action    <trig-star-annotation-2.trig> ;
+    .
+
+## Bad annotation syntax
+
+trs:trig-star-bad-ann-1 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - empty annotation" ;
+    mf:action    <trig-star-syntax-bad-ann-1.trig> ;
+   .
+
+trs:trig-star-bad-ann-2 rdf:type rdft:TestTrigNegativeSyntax ;
+    mf:name      "TriG-star - bad - triple as annotation" ;
+    mf:action    <trig-star-syntax-bad-ann-2.trig> ;
+   .
+

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-annotation-1.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-annotation-1.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p :o {| :r :z |} }

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-annotation-2.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-annotation-2.trig
@@ -1,0 +1,12 @@
+PREFIX :       <http://example/>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+:G {
+  :s :p :o {| :source [ :graph <http://host1/> ;
+                        :date "2020-01-20"^^xsd:date
+                      ] ;
+              :source [ :graph <http://host2/> ;
+                        :date "2020-12-31"^^xsd:date
+                      ]
+            |} .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-01.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-01.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  :x <<:s :p :o>> 123 .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-02.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-02.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  <<:s :p :o>> .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-03.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-03.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p ("abc") .
+  <<:s :p ("abc") >> :q 123 .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-04.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-04.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  <<3 :p :o >> :q :z .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-05.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-05.trig
@@ -1,0 +1,5 @@
+PREFIX : <http://example/>
+
+:G {
+  <<:s [] :o>> :q 123 .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-06.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-06.trig
@@ -1,0 +1,5 @@
+PREFIX : <http://example/>
+
+:G {
+  <<:s :p [ :p1 :o1 ]  >> :q 123 .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-07.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-07.trig
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+
+:G {:s :p << :p :r >> .}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-08.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-08.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {:s :p << :g :s :p :o >> .}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-ann-1.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-ann-1.trig
@@ -1,0 +1,4 @@
+PREFIX : <http://example.com/ns#>
+
+:G {:s :p :o {|  |} .}
+

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-ann-2.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bad-ann-2.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example.com/ns#>
+
+:G {:a :b :c {| :s :p :o |} .}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-basic-01.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-basic-01.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  <<:s :p :o>> :q 123 .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-basic-02.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-basic-02.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  :x :p <<:s :p :o>> .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bnode-01.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bnode-01.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  _:a :p :o .
+  <<_:a :p :o >> :q 456 .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bnode-02.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bnode-02.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p _:a .
+  <<:s :p _:a >> :q 456 .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bnode-03.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-bnode-03.trig
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:G {<<[] :p [] >> :q :z .}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-compound.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-compound.trig
@@ -1,0 +1,12 @@
+PREFIX : <http://example/>
+
+:G {
+  :x :r :z .
+  :a :b :c .
+  <<:a :b :c>> :r :z .
+  <<:x :r :z >> :p <<:a :b :c>> .
+
+  << <<:x :r :z >> :p <<:a :b :c>> >>
+     :q
+  << <<:x :r :z >> :p <<:a :b :c>> >> .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-inside-01.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-inside-01.trig
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  [ :q <<:s :p :o>> ] :b :c .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-inside-02.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-inside-02.trig
@@ -1,0 +1,7 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o1 .
+  :s :p :o2 .
+  ( <<:s :p :o1>> <<:s :p :o2>> )  :q 123 .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-nested-01.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-nested-01.trig
@@ -1,0 +1,9 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+
+  <<:s :p :o >> :r :z .
+
+  << <<:s :p :o >> :r :z >> :q 1 .
+}

--- a/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-nested-02.trig
+++ b/rdf/rdf12/rdf-trig/syntax/trig-star-syntax-nested-02.trig
@@ -1,0 +1,7 @@
+PREFIX : <http://example/>
+
+:G {
+  :s :p :o .
+  :a :q <<:s :p :o >> .
+  << :a :q <<:s :p :o >>>> :r :z .
+}

--- a/rdf/rdf12/rdf-turtle/eval/index.html
+++ b/rdf/rdf12/rdf-turtle/eval/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang='en' prefix='mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+  <!-- This file is generated automatciallly from manifest.ttl, and should not be edited directly. -->
+  <head>
+    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+    <meta content='width=device-width, initial-scale=1.0' name='viewport'>
+    <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' type='text/css'>
+    <style>
+      body: {bacground-image: none;}
+      dl.editor>dd {
+        margin: 0 0 0 40px;
+      }
+      dl.test-detail {
+        padding: 0.5em;
+      }
+      dl.test-detail>dt {
+        float: left;
+        clear: left;
+        text-align: right;
+        font-weight: bold;
+        color: green;
+      }
+      dl.test-detail>dt:after {content: ": "}
+      dl.test-detail>dd {
+        margin: 0 0 0 110px;
+        padding: 0 0 0.5em 0;
+      }
+      dl.test-description>dt {margin-top: 2em;}
+      dd {margin-left: 0;}
+      dd code {display: inline;}
+      footer {text-align: center;}
+    </style>
+    <title>
+      RDF 1.2 Turtle Evaluation Tests
+    </title>
+    <style>
+      em.rfc2119 {
+        text-transform: lowercase;
+        font-variant:   small-caps;
+        font-style:     normal;
+        color:          #900;
+      }
+      a.testlink {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.testlink:hover {
+        text-decoration: underline;
+      }
+      .warning {color: orange;}
+      .error {color: red;}
+    </style>
+  </head>
+  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#manifest' typeof='mf:Manifest'>
+    <p>
+      <a href='http://www.w3.org/'>
+        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
+      </a>
+    </p>
+    <h1 property='rdfs:label'>RDF 1.2 Turtle Evaluation Tests</h1>
+    <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    <hr title='Separator for header'>
+    <div>
+      <h2 id='abstract'>Abstract</h2>
+      <p>This page describes W3C RDF-star Working Group&#39;s test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.</p>
+      <h3>Contributing Tests</h3>
+      <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
+      <h3>Distribution</h3>
+      <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
+      <h3>Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+        COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+    </div>
+    <div>
+      <h2>
+        Test Descriptions
+      </h2>
+      <dl class='test-description'>
+        <dt id='turtle-star-1'>
+          <a class='testlink' href='#turtle-star-1'>
+            turtle-star-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-1' property='mf:name'>Turtle-star - subject quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-1' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-01.ttl' property='mf:action'>turtle-star-eval-01.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-01.nt' property='mf:result'>turtle-star-eval-01.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-2'>
+          <a class='testlink' href='#turtle-star-2'>
+            turtle-star-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-2' property='mf:name'>Turtle-star - object quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-2' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-02.ttl' property='mf:action'>turtle-star-eval-02.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-02.nt' property='mf:result'>turtle-star-eval-02.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bnode-1'>
+          <a class='testlink' href='#turtle-star-bnode-1'>
+            turtle-star-bnode-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-bnode-1' property='mf:name'>Turtle-star - blank node label</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-bnode-1' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-bnode-1.ttl' property='mf:action'>turtle-star-eval-bnode-1.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-bnode-1.nt' property='mf:result'>turtle-star-eval-bnode-1.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bnode-2'>
+          <a class='testlink' href='#turtle-star-bnode-2'>
+            turtle-star-bnode-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-bnode-2' property='mf:name'>Turtle-star - blank node labels</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-bnode-2' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-bnode-2.ttl' property='mf:action'>turtle-star-eval-bnode-2.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-bnode-2.nt' property='mf:result'>turtle-star-eval-bnode-2.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-annotation-1'>
+          <a class='testlink' href='#turtle-star-annotation-1'>
+            turtle-star-annotation-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-1' property='mf:name'>Turtle-star - Annotation form</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-1' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-annotation-1.ttl' property='mf:action'>turtle-star-eval-annotation-1.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-annotation-1.nt' property='mf:result'>turtle-star-eval-annotation-1.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-annotation-2'>
+          <a class='testlink' href='#turtle-star-annotation-2'>
+            turtle-star-annotation-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-2' property='mf:name'>Turtle-star - Annotation example</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-2' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-annotation-2.ttl' property='mf:action'>turtle-star-eval-annotation-2.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-annotation-2.nt' property='mf:result'>turtle-star-eval-annotation-2.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-annotation-3'>
+          <a class='testlink' href='#turtle-star-annotation-3'>
+            turtle-star-annotation-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-3' property='mf:name'>Turtle-star - Annotation - predicate and object lists</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-3' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-annotation-3.ttl' property='mf:action'>turtle-star-eval-annotation-3.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-annotation-3.nt' property='mf:result'>turtle-star-eval-annotation-3.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-annotation-4'>
+          <a class='testlink' href='#turtle-star-annotation-4'>
+            turtle-star-annotation-4:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-4' property='mf:name'>Turtle-star - Annotation - nested</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-4' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-annotation-4.ttl' property='mf:action'>turtle-star-eval-annotation-4.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-annotation-4.nt' property='mf:result'>turtle-star-eval-annotation-4.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-annotation-5'>
+          <a class='testlink' href='#turtle-star-annotation-5'>
+            turtle-star-annotation-5:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-5' property='mf:name'>Turtle-star - Annotation object list</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-5' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-annotation-5.ttl' property='mf:action'>turtle-star-eval-annotation-5.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-annotation-5.nt' property='mf:result'>turtle-star-eval-annotation-5.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-quoted-annotation-1'>
+          <a class='testlink' href='#turtle-star-quoted-annotation-1'>
+            turtle-star-quoted-annotation-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-1' property='mf:name'>Turtle-star - Annotation with quoting</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-1' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-quoted-annotation-1.ttl' property='mf:action'>turtle-star-eval-quoted-annotation-1.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-quoted-annotation-1.nt' property='mf:result'>turtle-star-eval-quoted-annotation-1.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-quoted-annotation-2'>
+          <a class='testlink' href='#turtle-star-quoted-annotation-2'>
+            turtle-star-quoted-annotation-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-2' property='mf:name'>Turtle-star - Annotation on triple with quoted subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-2' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-quoted-annotation-2.ttl' property='mf:action'>turtle-star-eval-quoted-annotation-2.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-quoted-annotation-2.nt' property='mf:result'>turtle-star-eval-quoted-annotation-2.nt</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-quoted-annotation-3'>
+          <a class='testlink' href='#turtle-star-quoted-annotation-3'>
+            turtle-star-quoted-annotation-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-3' property='mf:name'>Turtle-star - Annotation on triple with quoted object</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-3' typeof='rdft:TestTurtleEval'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleEval</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-eval-quoted-annotation-3.ttl' property='mf:action'>turtle-star-eval-quoted-annotation-3.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='turtle-star-eval-quoted-annotation-3.nt' property='mf:result'>turtle-star-eval-quoted-annotation-3.nt</a>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+    </div>
+    <footer>
+      <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    </footer>
+  </body>
+</html>

--- a/rdf/rdf12/rdf-turtle/eval/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/manifest.ttl
@@ -1,0 +1,113 @@
+## Distributed under both the "W3C Test Suite License" [1]
+## and the "W3C 3-clause BSD License".
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX test:   <http://www.w3.org/2001/sw/DataAccess/tests/>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+trs:manifest  rdf:type mf:Manifest ;
+   rdfs:label "RDF 1.2 Turtle Evaluation Tests"@en ;
+   skos:prefLabel "La suite des tests pour RDF 1.2 Turtle"@fr;
+   skos:prefLabel "Conjunto de pruebas para RDF 1.2 Turtle"@es;
+   dct:issued "2023-07-20"^^xsd:date ;
+   rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+   dct:modified "2023-07-20"^^xsd:date ;
+   dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+   dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+    mf:entries
+    (
+        trs:turtle-star-1
+        trs:turtle-star-2
+        trs:turtle-star-bnode-1
+        trs:turtle-star-bnode-2
+        trs:turtle-star-annotation-1
+        trs:turtle-star-annotation-2
+        trs:turtle-star-annotation-3
+        trs:turtle-star-annotation-4
+        trs:turtle-star-annotation-5
+        trs:turtle-star-quoted-annotation-1
+        trs:turtle-star-quoted-annotation-2
+        trs:turtle-star-quoted-annotation-3
+    ) .
+
+trs:turtle-star-1 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - subject quoted triple" ;
+   mf:action    <turtle-star-eval-01.ttl> ;
+   mf:result    <turtle-star-eval-01.nt> ;
+   .
+
+trs:turtle-star-2 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - object quoted triple" ;
+   mf:action    <turtle-star-eval-02.ttl> ;
+   mf:result    <turtle-star-eval-02.nt> ;
+   .
+
+trs:turtle-star-bnode-1 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - blank node label" ;
+   mf:action    <turtle-star-eval-bnode-1.ttl> ;
+   mf:result    <turtle-star-eval-bnode-1.nt> ;
+   .
+
+trs:turtle-star-bnode-2 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - blank node labels" ;
+   mf:action    <turtle-star-eval-bnode-2.ttl> ;
+   mf:result    <turtle-star-eval-bnode-2.nt> ;
+   .
+
+trs:turtle-star-annotation-1 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - Annotation form" ;
+   mf:action    <turtle-star-eval-annotation-1.ttl> ;
+   mf:result    <turtle-star-eval-annotation-1.nt> ;
+   .
+
+trs:turtle-star-annotation-2 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - Annotation example" ;
+   mf:action    <turtle-star-eval-annotation-2.ttl> ;
+   mf:result    <turtle-star-eval-annotation-2.nt> ;
+   .
+
+trs:turtle-star-annotation-3 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - Annotation - predicate and object lists" ;
+   mf:action    <turtle-star-eval-annotation-3.ttl> ;
+   mf:result    <turtle-star-eval-annotation-3.nt> ;
+   .
+
+trs:turtle-star-annotation-4 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - Annotation - nested" ;
+   mf:action    <turtle-star-eval-annotation-4.ttl> ;
+   mf:result    <turtle-star-eval-annotation-4.nt> ;
+   .
+
+trs:turtle-star-annotation-5 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - Annotation object list" ;
+   mf:action    <turtle-star-eval-annotation-5.ttl> ;
+   mf:result    <turtle-star-eval-annotation-5.nt> ;
+   .
+
+trs:turtle-star-quoted-annotation-1 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - Annotation with quoting" ;
+   mf:action    <turtle-star-eval-quoted-annotation-1.ttl> ;
+   mf:result    <turtle-star-eval-quoted-annotation-1.nt> ;
+   .
+   
+trs:turtle-star-quoted-annotation-2 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - Annotation on triple with quoted subject" ;
+   mf:action    <turtle-star-eval-quoted-annotation-2.ttl> ;
+   mf:result    <turtle-star-eval-quoted-annotation-2.nt> ;
+   .
+   
+trs:turtle-star-quoted-annotation-3 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle-star - Annotation on triple with quoted object" ;
+   mf:action    <turtle-star-eval-quoted-annotation-3.ttl> ;
+   mf:result    <turtle-star-eval-quoted-annotation-3.nt> ;
+   .
+

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-01.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-01.nt
@@ -1,0 +1,1 @@
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/q> <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-01.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-01.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+<<:s :p :o>> :q :z .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-02.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-02.nt
@@ -1,0 +1,1 @@
+<http://example/a> <http://example/q> << <http://example/s> <http://example/p> <http://example/o> >> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-02.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-02.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:a :q <<:s :p :o>> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-1.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-1.nt
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <http://example/o> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/r> <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-1.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-1.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p :o {| :r :z |} .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-2.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-2.nt
@@ -1,0 +1,7 @@
+<http://example/s> <http://example/p> <http://example/o> .
+_:b1 <http://example/graph> <http://host1/> .
+_:b1 <http://example/date> "2020-01-20"^^<http://www.w3.org/2001/XMLSchema#date> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/source> _:b1 .
+_:b2 <http://example/graph> <http://host2/> .
+_:b2 <http://example/date> "2020-12-31"^^<http://www.w3.org/2001/XMLSchema#date> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/source> _:b2 .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-2.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-2.ttl
@@ -1,0 +1,10 @@
+PREFIX :       <http://example/>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+:s :p :o {| :source [ :graph <http://host1/> ;
+                      :date "2020-01-20"^^xsd:date
+                    ] ;
+            :source [ :graph <http://host2/> ;
+                      :date "2020-12-31"^^xsd:date
+                    ]
+          |} .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-3.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-3.nt
@@ -1,0 +1,6 @@
+<http://example/s> <http://example/p> <http://example/o> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/a> <http://example/b> .
+<http://example/s> <http://example/p2> <http://example/o2> .
+<< <http://example/s> <http://example/p2> <http://example/o2> >> <http://example/a2> <http://example/b2> .
+<http://example/s> <http://example/p2> <http://example/o3> .
+<< <http://example/s> <http://example/p2> <http://example/o3> >> <http://example/a3> <http://example/b3> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-3.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-3.ttl
@@ -1,0 +1,5 @@
+PREFIX : <http://example/>
+
+:s :p :o {| :a :b |};
+    :p2 :o2 {| :a2 :b2 |},
+        :o3 {| :a3 :b3 |}.

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-4.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-4.nt
@@ -1,0 +1,3 @@
+<http://example/s> <http://example/p> <http://example/o> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/a> <http://example/b> .
+<< << <http://example/s> <http://example/p> <http://example/o> >> <http://example/a> <http://example/b> >> <http://example/a2> <http://example/b2> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-4.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-4.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p :o {| :a :b {| :a2 :b2 |} |}.

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-5.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-5.nt
@@ -1,0 +1,3 @@
+<http://example/s> <http://example/p> <http://example/o1> .
+<http://example/s> <http://example/p> <http://example/o2> .
+<< <http://example/s> <http://example/p> <http://example/o2> >> <http://example/a> <http://example/b> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-5.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-annotation-5.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:s :p :o1, :o2 {| :a :b |} .
+

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-bnode-1.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-bnode-1.nt
@@ -1,0 +1,2 @@
+_:b9 <http://example/p> <http://example/o> .
+<< _:b9 <http://example/p> <http://example/o> >> <http://example/q> <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-bnode-1.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-bnode-1.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+_:b :p :o .
+<<_:b :p :o>> :q :z .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-bnode-2.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-bnode-2.nt
@@ -1,0 +1,2 @@
+_:label1 <http://example/p1> _:label1 .
+<< _:label1 <http://example/p1> _:label1 >> <http://example/q> << _:label1 <http://example/p2> <http://example/o> >> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-bnode-2.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-bnode-2.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+_:a :p1 _:a .
+<<_:a :p1 _:a >> :q <<_:a :p2 :o>> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-1.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-1.nt
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <http://example/o> .
+<<<http://example/s> <http://example/p> <http://example/o>>> <http://example/r> <<<http://example/s1> <http://example/p1> <http://example/o1>>> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-1.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-1.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p :o {| :r <<:s1 :p1 :o1>> |} .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-2.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-2.nt
@@ -1,0 +1,2 @@
+<<<http://example/s1> <http://example/p1> <http://example/o1>>> <http://example/p> <http://example/o> .
+<<<<<http://example/s1> <http://example/p1> <http://example/o1>>> <http://example/p> <http://example/o>>> <http://example/r> <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-2.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-2.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+<<:s1 :p1 :o1>> :p :o {| :r :z |} .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-3.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-3.nt
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> <<<http://example/s2> <http://example/p2> <http://example/o2>>> .
+<<<http://example/s> <http://example/p> <<<http://example/s2> <http://example/p2> <http://example/o2>>>>> <http://example/r> <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-3.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle-star-eval-quoted-annotation-3.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p <<:s2 :p2 :o2>> {| :r :z |} .

--- a/rdf/rdf12/rdf-turtle/syntax/index.html
+++ b/rdf/rdf12/rdf-turtle/syntax/index.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang='en' prefix='mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+  <!-- This file is generated automatciallly from manifest.ttl, and should not be edited directly. -->
+  <head>
+    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+    <meta content='width=device-width, initial-scale=1.0' name='viewport'>
+    <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' type='text/css'>
+    <style>
+      body: {bacground-image: none;}
+      dl.editor>dd {
+        margin: 0 0 0 40px;
+      }
+      dl.test-detail {
+        padding: 0.5em;
+      }
+      dl.test-detail>dt {
+        float: left;
+        clear: left;
+        text-align: right;
+        font-weight: bold;
+        color: green;
+      }
+      dl.test-detail>dt:after {content: ": "}
+      dl.test-detail>dd {
+        margin: 0 0 0 110px;
+        padding: 0 0 0.5em 0;
+      }
+      dl.test-description>dt {margin-top: 2em;}
+      dd {margin-left: 0;}
+      dd code {display: inline;}
+      footer {text-align: center;}
+    </style>
+    <title>
+      RDF 1.2 Turtle Syntax Tests
+    </title>
+    <style>
+      em.rfc2119 {
+        text-transform: lowercase;
+        font-variant:   small-caps;
+        font-style:     normal;
+        color:          #900;
+      }
+      a.testlink {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.testlink:hover {
+        text-decoration: underline;
+      }
+      .warning {color: orange;}
+      .error {color: red;}
+    </style>
+  </head>
+  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#manifest' typeof='mf:Manifest'>
+    <p>
+      <a href='http://www.w3.org/'>
+        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
+      </a>
+    </p>
+    <h1 property='rdfs:label'>RDF 1.2 Turtle Syntax Tests</h1>
+    <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    <hr title='Separator for header'>
+    <div>
+      <h2 id='abstract'>Abstract</h2>
+      <p>This page describes W3C RDF-star Working Group&#39;s test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.</p>
+      <h3>Contributing Tests</h3>
+      <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
+      <h3>Distribution</h3>
+      <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
+      <h3>Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+        COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+    </div>
+    <div>
+      <h2>
+        Test Descriptions
+      </h2>
+      <dl class='test-description'>
+        <dt id='turtle-star-1'>
+          <a class='testlink' href='#turtle-star-1'>
+            turtle-star-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-1' property='mf:name'>Turtle-star - subject quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-1' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-basic-01.ttl' property='mf:action'>turtle-star-syntax-basic-01.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-2'>
+          <a class='testlink' href='#turtle-star-2'>
+            turtle-star-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-2' property='mf:name'>Turtle-star - object quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-2' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-basic-02.ttl' property='mf:action'>turtle-star-syntax-basic-02.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-inside-1'>
+          <a class='testlink' href='#turtle-star-inside-1'>
+            turtle-star-inside-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-inside-1' property='mf:name'>Turtle-star - quoted triple inside blankNodePropertyList</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-inside-1' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-inside-01.ttl' property='mf:action'>turtle-star-syntax-inside-01.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-inside-2'>
+          <a class='testlink' href='#turtle-star-inside-2'>
+            turtle-star-inside-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-inside-2' property='mf:name'>Turtle-star - quoted triple inside collection</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-inside-2' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-inside-02.ttl' property='mf:action'>turtle-star-syntax-inside-02.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-nested-1'>
+          <a class='testlink' href='#turtle-star-nested-1'>
+            turtle-star-nested-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-nested-1' property='mf:name'>Turtle-star - nested quoted triple, subject position</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-nested-1' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-nested-01.ttl' property='mf:action'>turtle-star-syntax-nested-01.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-nested-2'>
+          <a class='testlink' href='#turtle-star-nested-2'>
+            turtle-star-nested-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-nested-2' property='mf:name'>Turtle-star - nested quoted triple, object position</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-nested-2' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-nested-02.ttl' property='mf:action'>turtle-star-syntax-nested-02.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-compound-1'>
+          <a class='testlink' href='#turtle-star-compound-1'>
+            turtle-star-compound-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-compound-1' property='mf:name'>Turtle-star - compound forms</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-compound-1' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-compound.ttl' property='mf:action'>turtle-star-syntax-compound.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bnode-1'>
+          <a class='testlink' href='#turtle-star-bnode-1'>
+            turtle-star-bnode-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-1' property='mf:name'>Turtle-star - blank node subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-1' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bnode-01.ttl' property='mf:action'>turtle-star-syntax-bnode-01.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bnode-2'>
+          <a class='testlink' href='#turtle-star-bnode-2'>
+            turtle-star-bnode-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-2' property='mf:name'>Turtle-star - blank node object</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-2' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bnode-02.ttl' property='mf:action'>turtle-star-syntax-bnode-02.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bnode-3'>
+          <a class='testlink' href='#turtle-star-bnode-3'>
+            turtle-star-bnode-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-3' property='mf:name'>Turtle-star - blank node</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-3' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bnode-03.ttl' property='mf:action'>turtle-star-syntax-bnode-03.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bad-1'>
+          <a class='testlink' href='#turtle-star-bad-1'>
+            turtle-star-bad-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-1' property='mf:name'>Turtle-star - bad - quoted triple as predicate</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-1' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bad-01.ttl' property='mf:action'>turtle-star-syntax-bad-01.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bad-2'>
+          <a class='testlink' href='#turtle-star-bad-2'>
+            turtle-star-bad-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-2' property='mf:name'>Turtle-star - bad - quoted triple outside triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-2' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bad-02.ttl' property='mf:action'>turtle-star-syntax-bad-02.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bad-3'>
+          <a class='testlink' href='#turtle-star-bad-3'>
+            turtle-star-bad-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-3' property='mf:name'>Turtle-star - bad - collection list in quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-3' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bad-03.ttl' property='mf:action'>turtle-star-syntax-bad-03.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bad-4'>
+          <a class='testlink' href='#turtle-star-bad-4'>
+            turtle-star-bad-4:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-4' property='mf:name'>Turtle-star - bad - literal in subject position of quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-4' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bad-04.ttl' property='mf:action'>turtle-star-syntax-bad-04.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bad-5'>
+          <a class='testlink' href='#turtle-star-bad-5'>
+            turtle-star-bad-5:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-5' property='mf:name'>Turtle-star - bad - blank node  as predicate in quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-5' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bad-05.ttl' property='mf:action'>turtle-star-syntax-bad-05.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bad-6'>
+          <a class='testlink' href='#turtle-star-bad-6'>
+            turtle-star-bad-6:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-6' property='mf:name'>Turtle-star - bad - compound blank node expression</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-6' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bad-06.ttl' property='mf:action'>turtle-star-syntax-bad-06.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bad-7'>
+          <a class='testlink' href='#turtle-star-bad-7'>
+            turtle-star-bad-7:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-7' property='mf:name'>Turtle-star - bad - incomplete quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-7' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bad-07.ttl' property='mf:action'>turtle-star-syntax-bad-07.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bad-8'>
+          <a class='testlink' href='#turtle-star-bad-8'>
+            turtle-star-bad-8:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-8' property='mf:name'>Turtle-star - bad - over-long quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-8' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bad-08.ttl' property='mf:action'>turtle-star-syntax-bad-08.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-ann-1'>
+          <a class='testlink' href='#turtle-star-ann-1'>
+            turtle-star-ann-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-ann-1' property='mf:name'>Turtle-star - Annotation form</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-ann-1' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-annotation-1.ttl' property='mf:action'>turtle-star-annotation-1.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-ann-2'>
+          <a class='testlink' href='#turtle-star-ann-2'>
+            turtle-star-ann-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-ann-2' property='mf:name'>Turtle-star - Annotation example</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-ann-2' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-annotation-2.ttl' property='mf:action'>turtle-star-annotation-2.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bad-ann-1'>
+          <a class='testlink' href='#turtle-star-bad-ann-1'>
+            turtle-star-bad-ann-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-ann-1' property='mf:name'>Turtle-star - bad - empty annotation</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-ann-1' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bad-ann-1.ttl' property='mf:action'>turtle-star-syntax-bad-ann-1.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle-star-bad-ann-2'>
+          <a class='testlink' href='#turtle-star-bad-ann-2'>
+            turtle-star-bad-ann-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-ann-2' property='mf:name'>Turtle-star - bad - triple as annotation</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-ann-2' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle-star-syntax-bad-ann-2.ttl' property='mf:action'>turtle-star-syntax-bad-ann-2.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-1'>
+          <a class='testlink' href='#nt-ttl-star-1'>
+            nt-ttl-star-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-1' property='mf:name'>N-Triples-star as Turtle-star - subject quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-1' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-syntax-1.ttl' property='mf:action'>nt-ttl-star-syntax-1.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-2'>
+          <a class='testlink' href='#nt-ttl-star-2'>
+            nt-ttl-star-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-2' property='mf:name'>N-Triples-star as Turtle-star - object quoted triple</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-2' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-syntax-2.ttl' property='mf:action'>nt-ttl-star-syntax-2.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-3'>
+          <a class='testlink' href='#nt-ttl-star-3'>
+            nt-ttl-star-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-3' property='mf:name'>N-Triples-star as Turtle-star - subject and object quoted triples</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-3' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-syntax-3.ttl' property='mf:action'>nt-ttl-star-syntax-3.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-4'>
+          <a class='testlink' href='#nt-ttl-star-4'>
+            nt-ttl-star-4:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-4' property='mf:name'>N-Triples-star as Turtle-star - whitespace and terms</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-4' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-syntax-4.ttl' property='mf:action'>nt-ttl-star-syntax-4.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-5'>
+          <a class='testlink' href='#nt-ttl-star-5'>
+            nt-ttl-star-5:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-5' property='mf:name'>N-Triples-star as Turtle-star - Nested, no whitespace</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-5' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-syntax-5.ttl' property='mf:action'>nt-ttl-star-syntax-5.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-bnode-1'>
+          <a class='testlink' href='#nt-ttl-star-bnode-1'>
+            nt-ttl-star-bnode-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bnode-1' property='mf:name'>N-Triples-star as Turtle-star - Blank node subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bnode-1' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-bnode-1.ttl' property='mf:action'>nt-ttl-star-bnode-1.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-bnode-2'>
+          <a class='testlink' href='#nt-ttl-star-bnode-2'>
+            nt-ttl-star-bnode-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bnode-2' property='mf:name'>N-Triples-star as Turtle-star - Blank node object</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bnode-2' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-bnode-2.ttl' property='mf:action'>nt-ttl-star-bnode-2.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-nested-1'>
+          <a class='testlink' href='#nt-ttl-star-nested-1'>
+            nt-ttl-star-nested-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-nested-1' property='mf:name'>N-Triples-star as Turtle-star - Nested subject term</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-nested-1' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-nested-1.ttl' property='mf:action'>nt-ttl-star-nested-1.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-nested-2'>
+          <a class='testlink' href='#nt-ttl-star-nested-2'>
+            nt-ttl-star-nested-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-nested-2' property='mf:name'>N-Triples-star as Turtle-star - Nested object term</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-nested-2' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-nested-2.ttl' property='mf:action'>nt-ttl-star-nested-2.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-bad-1'>
+          <a class='testlink' href='#nt-ttl-star-bad-1'>
+            nt-ttl-star-bad-1:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-1' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple as predicate</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-1' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-bad-syntax-1.ttl' property='mf:action'>nt-ttl-star-bad-syntax-1.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-bad-2'>
+          <a class='testlink' href='#nt-ttl-star-bad-2'>
+            nt-ttl-star-bad-2:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-2' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple, literal subject</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-2' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-bad-syntax-2.ttl' property='mf:action'>nt-ttl-star-bad-syntax-2.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-bad-3'>
+          <a class='testlink' href='#nt-ttl-star-bad-3'>
+            nt-ttl-star-bad-3:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-3' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple, literal predicate</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-3' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-bad-syntax-3.ttl' property='mf:action'>nt-ttl-star-bad-syntax-3.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='nt-ttl-star-bad-4'>
+          <a class='testlink' href='#nt-ttl-star-bad-4'>
+            nt-ttl-star-bad-4:
+          </a>
+          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-4' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple, blank node predicate</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-4' typeof='rdft:TestTurtleNegativeSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtleNegativeSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='nt-ttl-star-bad-syntax-4.ttl' property='mf:action'>nt-ttl-star-bad-syntax-4.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+    </div>
+    <footer>
+      <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
+    </footer>
+  </body>
+</html>

--- a/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
@@ -1,0 +1,268 @@
+## Distributed under both the "W3C Test Suite License" [1]
+## and the "W3C 3-clause BSD License".
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#> 
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> 
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#> 
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#> 
+PREFIX dct:    <http://purl.org/dc/terms/> 
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#> 
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/> 
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+trs:manifest  rdf:type mf:Manifest ;
+   rdfs:label "RDF 1.2 Turtle Syntax Tests"@en ;
+   skos:prefLabel "La suite des tests pour la syntaxe RDF 1.2 Turtle"@fr ;
+   skos:prefLabel "Conjunto de pruebas para la sintaxis RDF 1.2 Turtle"@es ;
+   dct:issued "2023-07-20"^^xsd:date ; 
+   dct:modified "2023-07-20"^^xsd:date ; 
+   dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+   dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+    mf:entries
+    (
+        trs:turtle-star-1
+        trs:turtle-star-2
+
+        trs:turtle-star-inside-1
+        trs:turtle-star-inside-2
+
+        trs:turtle-star-nested-1
+        trs:turtle-star-nested-2
+
+        trs:turtle-star-compound-1
+
+        trs:turtle-star-bnode-1
+        trs:turtle-star-bnode-2
+        trs:turtle-star-bnode-3
+
+        trs:turtle-star-bad-1
+        trs:turtle-star-bad-2
+        trs:turtle-star-bad-3
+        trs:turtle-star-bad-4
+        trs:turtle-star-bad-5
+        trs:turtle-star-bad-6
+        trs:turtle-star-bad-7
+        trs:turtle-star-bad-8
+
+        trs:turtle-star-ann-1
+        trs:turtle-star-ann-2
+        
+        trs:turtle-star-bad-ann-1
+        trs:turtle-star-bad-ann-2
+
+## The same data as the N-Triples-star syntax tests,
+## except in file *.ttl and "TestTurtle"
+
+        trs:nt-ttl-star-1
+        trs:nt-ttl-star-2
+        trs:nt-ttl-star-3
+        trs:nt-ttl-star-4
+        trs:nt-ttl-star-5
+
+        trs:nt-ttl-star-bnode-1
+        trs:nt-ttl-star-bnode-2
+
+        trs:nt-ttl-star-nested-1
+        trs:nt-ttl-star-nested-2
+
+        trs:nt-ttl-star-bad-1
+        trs:nt-ttl-star-bad-2
+        trs:nt-ttl-star-bad-3
+        trs:nt-ttl-star-bad-4
+    ) .
+
+## Good Syntax
+
+trs:turtle-star-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle-star - subject quoted triple" ;
+   mf:action    <turtle-star-syntax-basic-01.ttl> ;
+   .
+
+trs:turtle-star-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle-star - object quoted triple" ;
+   mf:action    <turtle-star-syntax-basic-02.ttl> ;
+   .
+
+trs:turtle-star-inside-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle-star - quoted triple inside blankNodePropertyList" ;
+   mf:action    <turtle-star-syntax-inside-01.ttl> ;
+   .
+
+trs:turtle-star-inside-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle-star - quoted triple inside collection" ;
+   mf:action    <turtle-star-syntax-inside-02.ttl> ;
+   .
+
+trs:turtle-star-nested-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle-star - nested quoted triple, subject position" ;
+   mf:action    <turtle-star-syntax-nested-01.ttl> ;
+   .
+
+trs:turtle-star-nested-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle-star - nested quoted triple, object position" ;
+   mf:action     <turtle-star-syntax-nested-02.ttl> ;
+   .
+
+trs:turtle-star-compound-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle-star - compound forms" ;
+   mf:action    <turtle-star-syntax-compound.ttl> ;
+   .
+
+trs:turtle-star-bnode-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle-star - blank node subject" ;
+   mf:action    <turtle-star-syntax-bnode-01.ttl> ;
+   .
+
+trs:turtle-star-bnode-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle-star - blank node object" ;
+   mf:action    <turtle-star-syntax-bnode-02.ttl> ;
+   .
+
+trs:turtle-star-bnode-3 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle-star - blank node" ;
+   mf:action    <turtle-star-syntax-bnode-03.ttl> ;
+   .
+
+## Bad Syntax
+
+trs:turtle-star-bad-1 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "Turtle-star - bad - quoted triple as predicate" ;
+    mf:action    <turtle-star-syntax-bad-01.ttl> ;
+    .
+
+trs:turtle-star-bad-2 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "Turtle-star - bad - quoted triple outside triple" ;
+    mf:action    <turtle-star-syntax-bad-02.ttl> ;
+    .
+
+trs:turtle-star-bad-3 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "Turtle-star - bad - collection list in quoted triple" ;
+    mf:action    <turtle-star-syntax-bad-03.ttl> ;
+    .
+
+trs:turtle-star-bad-4 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "Turtle-star - bad - literal in subject position of quoted triple" ;
+    mf:action    <turtle-star-syntax-bad-04.ttl> ;
+    .
+
+trs:turtle-star-bad-5 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "Turtle-star - bad - blank node  as predicate in quoted triple";
+    mf:action    <turtle-star-syntax-bad-05.ttl> ;
+    .
+
+trs:turtle-star-bad-6 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "Turtle-star - bad - compound blank node expression";
+    mf:action    <turtle-star-syntax-bad-06.ttl> ;
+    .
+
+trs:turtle-star-bad-7 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "Turtle-star - bad - incomplete quoted triple";
+    mf:action    <turtle-star-syntax-bad-07.ttl> ;
+    .
+
+trs:turtle-star-bad-8 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "Turtle-star - bad - over-long quoted triple";
+    mf:action    <turtle-star-syntax-bad-08.ttl> ;
+    .
+
+## Annotation syntax
+
+trs:turtle-star-ann-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+    mf:name      "Turtle-star - Annotation form" ;
+    mf:action    <turtle-star-annotation-1.ttl> ;
+   .
+
+trs:turtle-star-ann-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+    mf:name      "Turtle-star - Annotation example" ;
+    mf:action    <turtle-star-annotation-2.ttl> ;
+    .
+
+## Bad annotation syntax
+
+trs:turtle-star-bad-ann-1 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "Turtle-star - bad - empty annotation" ;
+    mf:action    <turtle-star-syntax-bad-ann-1.ttl> ;
+   .
+
+trs:turtle-star-bad-ann-2 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "Turtle-star - bad - triple as annotation" ;
+    mf:action    <turtle-star-syntax-bad-ann-2.ttl> ;
+   .
+
+## --------------------------------------------------
+## Same data as the N-triples-star tests.
+## N-Triples is a subset of Turtle, and the same is true for the "star" feature.
+
+## Good Syntax
+
+trs:nt-ttl-star-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "N-Triples-star as Turtle-star - subject quoted triple" ;
+   mf:action    <nt-ttl-star-syntax-1.ttl> ;
+   .
+
+trs:nt-ttl-star-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "N-Triples-star as Turtle-star - object quoted triple" ;
+   mf:action    <nt-ttl-star-syntax-2.ttl> ;
+   .
+
+trs:nt-ttl-star-3 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "N-Triples-star as Turtle-star - subject and object quoted triples" ;
+   mf:action    <nt-ttl-star-syntax-3.ttl> ;
+   .
+
+trs:nt-ttl-star-4 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "N-Triples-star as Turtle-star - whitespace and terms" ;
+   mf:action    <nt-ttl-star-syntax-4.ttl> ;
+   .
+
+trs:nt-ttl-star-5 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "N-Triples-star as Turtle-star - Nested, no whitespace" ;
+   mf:action    <nt-ttl-star-syntax-5.ttl> ;
+   .
+
+# Blank nodes
+
+trs:nt-ttl-star-bnode-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "N-Triples-star as Turtle-star - Blank node subject" ;
+   mf:action    <nt-ttl-star-bnode-1.ttl> ;
+   .
+
+trs:nt-ttl-star-bnode-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "N-Triples-star as Turtle-star - Blank node object" ;
+   mf:action    <nt-ttl-star-bnode-2.ttl> ;
+   .
+   
+trs:nt-ttl-star-nested-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "N-Triples-star as Turtle-star - Nested subject term" ;
+   mf:action    <nt-ttl-star-nested-1.ttl> ;
+   .
+
+trs:nt-ttl-star-nested-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "N-Triples-star as Turtle-star - Nested object term" ;
+   mf:action    <nt-ttl-star-nested-2.ttl> ;
+   .
+
+## Bad syntax
+ 
+trs:nt-ttl-star-bad-1 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "N-Triples-star as Turtle-star - Bad - quoted triple as predicate" ;
+    mf:action    <nt-ttl-star-bad-syntax-1.ttl> ;
+    .
+    
+trs:nt-ttl-star-bad-2 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "N-Triples-star as Turtle-star - Bad - quoted triple, literal subject" ;
+    mf:action    <nt-ttl-star-bad-syntax-2.ttl> ;
+    .
+
+trs:nt-ttl-star-bad-3 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "N-Triples-star as Turtle-star - Bad - quoted triple, literal predicate" ;
+    mf:action    <nt-ttl-star-bad-syntax-3.ttl> ;
+    .
+
+trs:nt-ttl-star-bad-4 rdf:type rdft:TestTurtleNegativeSyntax ;
+    mf:name      "N-Triples-star as Turtle-star - Bad - quoted triple, blank node predicate" ;
+    mf:action    <nt-ttl-star-bad-syntax-4.ttl> ;
+    .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bad-syntax-1.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bad-syntax-1.ttl
@@ -1,0 +1,1 @@
+<http://example/a> << <http://example/s> <http://example/p>  <http://example/o> >>  <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bad-syntax-2.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bad-syntax-2.ttl
@@ -1,0 +1,1 @@
+<< "XYZ" <http://example/p> <http://example/o> >> <http://example/q> <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bad-syntax-3.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bad-syntax-3.ttl
@@ -1,0 +1,1 @@
+<< <http://example/s> "XYZ" <http://example/o> >> <http://example/q> <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bad-syntax-4.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bad-syntax-4.ttl
@@ -1,0 +1,1 @@
+<< <http://example/s> _:label <http://example/o> >> <http://example/q> <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bnode-1.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bnode-1.ttl
@@ -1,0 +1,2 @@
+_:b0 <http://example/p> <http://example/o> .
+<< _:b0 <http://example/p> <http://example/o> >> <http://example/q> "ABC" .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bnode-2.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-bnode-2.ttl
@@ -1,0 +1,2 @@
+<http://example/s> <http://example/p> _:b1 .
+<< <http://example/s> <http://example/p> _:b1 >> <http://example/q> "456"^^<http://www.w3.org/2001/XMLSchema#integer> .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-nested-1.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-nested-1.ttl
@@ -1,0 +1,3 @@
+<http://example/s> <http://example/p> <http://example/o> .
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/r> <http://example/z> .
+<< << <http://example/s> <http://example/p> <http://example/o> >> <http://example/r> <http://example/z> >> <http://example/q> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-nested-2.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-nested-2.ttl
@@ -1,0 +1,3 @@
+<http://example/s> <http://example/p> <http://example/o> .
+<http://example/a> <http://example/q> << <http://example/s> <http://example/p> <http://example/o> >> .
+<< <http://example/a> <http://example/q> << <http://example/s> <http://example/p> <http://example/o> >> >> <http://example/r> <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-syntax-1.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-syntax-1.ttl
@@ -1,0 +1,1 @@
+<< <http://example/s> <http://example/p> <http://example/o> >> <http://example/q> <http://example/z> .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-syntax-2.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-syntax-2.ttl
@@ -1,0 +1,1 @@
+<http://example/x> <http://example/p> << <http://example/s> <http://example/p> <http://example/o> >> .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-syntax-3.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-syntax-3.ttl
@@ -1,0 +1,1 @@
+<< <http://example/s1> <http://example/p1> <http://example/o1> >> <http://example/q> << <http://example/s2> <http://example/p2> <http://example/o2> >> .

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-syntax-4.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-syntax-4.ttl
@@ -1,0 +1,1 @@
+<<<http://example/s1><http://example/p1><http://example/o1>>><http://example/q><<<http://example/s2><http://example/p2><http://example/o2>>>.

--- a/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-syntax-5.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/nt-ttl-star-syntax-5.ttl
@@ -1,0 +1,1 @@
+<<<<<http://example/s1><http://example/p1><http://example/o1>>><http://example/q1><<<http://example/s2><http://example/p2><http://example/o2>>>>><http://example/q2><<<<<http://example/s3><http://example/p3><http://example/o3>>><http://example/q3><<<http://example/s4><http://example/p4><http://example/o4>>>>>.

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-annotation-1.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-annotation-1.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p :o {| :r :z |} .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-annotation-2.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-annotation-2.ttl
@@ -1,0 +1,10 @@
+PREFIX :       <http://example/>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+:s :p :o {| :source [ :graph <http://host1/> ;
+                      :date "2020-01-20"^^xsd:date
+                    ] ;
+            :source [ :graph <http://host2/> ;
+                      :date "2020-12-31"^^xsd:date
+                    ]
+          |} .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-01.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-01.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:s :p :o .
+:x <<:s :p :o>> 123 .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-02.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-02.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:s :p :o .
+<<:s :p :o>> .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-03.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-03.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:s :p ("abc") .
+<<:s :p ("abc") >> :q 123 .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-04.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-04.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:s :p :o .
+<<3 :p :o >> :q :z .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-05.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-05.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+<<:s [] :o>> :q 123 .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-06.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-06.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+
+<<:s :p [ :p1 :o1 ]  >> :q 123 .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-07.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-07.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p << :p :r >> .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-08.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-08.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p << :g :s :p :o >> .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-ann-1.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-ann-1.ttl
@@ -1,0 +1,6 @@
+PREFIX : <http://example.com/ns#>
+
+SELECT * {
+  :s :p :o {|  |} .
+}
+

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-ann-2.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bad-ann-2.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example.com/ns#>
+
+:a :b :c {| :s :p :o |} .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-basic-01.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-basic-01.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:s :p :o .
+<<:s :p :o>> :q 123 .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-basic-02.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-basic-02.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:s :p :o .
+:x :p <<:s :p :o>> .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bnode-01.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bnode-01.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+_:a :p :o .
+<<_:a :p :o >> :q 456 .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bnode-02.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bnode-02.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:s :p _:a .
+<<:s :p _:a >> :q 456 .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bnode-03.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-bnode-03.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+<<[] :p [] >> :q :z .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-compound.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-compound.ttl
@@ -1,0 +1,11 @@
+PREFIX : <http://example/>
+
+
+:x :r :z .
+:a :b :c .
+<<:a :b :c>> :r :z .
+<<:x :r :z >> :p <<:a :b :c>> .
+
+<< <<:x :r :z >> :p <<:a :b :c>> >>
+   :q
+<< <<:x :r :z >> :p <<:a :b :c>> >> .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-inside-01.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-inside-01.ttl
@@ -1,0 +1,4 @@
+PREFIX : <http://example/>
+
+:s :p :o .
+[ :q <<:s :p :o>> ] :b :c .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-inside-02.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-inside-02.ttl
@@ -1,0 +1,5 @@
+PREFIX : <http://example/>
+
+:s :p :o1 .
+:s :p :o2 .
+( <<:s :p :o1>> <<:s :p :o2>> )  :q 123 .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-nested-01.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-nested-01.ttl
@@ -1,0 +1,7 @@
+PREFIX : <http://example/>
+
+:s :p :o .
+
+<<:s :p :o >> :r :z .
+
+<< <<:s :p :o >> :r :z >> :q 1 .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-nested-02.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle-star-syntax-nested-02.ttl
@@ -1,0 +1,5 @@
+PREFIX : <http://example/>
+
+:s :p :o .
+:a :q <<:s :p :o >> .
+<< :a :q <<:s :p :o >>>> :r :z .

--- a/rdf/rdf12/template.haml
+++ b/rdf/rdf12/template.haml
@@ -30,7 +30,7 @@
       dd code {display: inline;}
       footer {text-align: center;}
     %title
-      = man['label']
+      = man['label'].is_a?(Hash) ? man['label']['@value'] : man['label']
     :css
       em.rfc2119 { 
         text-transform: lowercase;
@@ -52,7 +52,7 @@
     %p
       %a{href: "http://www.w3.org/"}
         %img{src: "http://www.w3.org/Icons/w3c_home", alt: "W3C", height: 48, width: 72}
-    %h1{property: "rdfs:label"}<= man['label']
+    %h1{property: "rdfs:label"}<= man['label'].is_a?(Hash) ? man['label']['@value'] : man['label']
     :markdown
       [Copyright](http://www.w3.org/Consortium/Legal/ipr-notice#Copyright) © 2004-2023 [World Wide Web Consortium](https://www.w3.org/). <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> [liability](https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer), [trademark](https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks) and [permissive document license](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document) rules apply.
     %hr{title: "Separator for header"}
@@ -94,9 +94,9 @@
           Test Descriptions
         %dl.test-description
           - man['entries'].each do |test|
-            %dt{id: test['@id'][1..-1]}
-              %a.testlink{href: "#{test['@id']}"}
-                = "#{test['@id'][1..-1]}:"
+            %dt{id: test['@id'].split('#').last}
+              %a.testlink{href: "##{test['@id'].split('#').last}"}
+                = "#{test['@id'].split('#').last}:"
               %span{about: test['@id'], property: "mf:name"}<~test['name']
             %dd{property: "mf:entry", inlist: true, resource: test['@id'], typeof: test['@type']}
               %div{property: "rdfs:comment"}

--- a/rdf/rdf12/template.haml
+++ b/rdf/rdf12/template.haml
@@ -65,7 +65,9 @@
             #{Array(man['comment']).join(' ').gsub(/\s+/m, ' ').strip.gsub(/(MUST|SHOULD|MAY)/, '<em class="rfc2119">\\1</em>')}
 
       :markdown
-        This page describes W3C RDF test suite, comprising tests for RDF 1.1 and RDF 1.2.
+        This page describes W3C RDF-star Working Group's test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.
 
         ### Contributing Tests
         The test manifests and entries are built automatically from [manifest.ttl](manifest.ttl) using a Rake task. Tests may be contributed via pull request to [https://github.com/w3c/rdf-tests](https://github.com/w3c/rdf-tests) with suitable changes to the [manifest.ttl](manifest.ttl) and referenced files.

--- a/rdf/template.haml
+++ b/rdf/template.haml
@@ -30,7 +30,7 @@
       dd code {display: inline;}
       footer {text-align: center;}
     %title
-      = man['label']
+      = man['label'].is_a?(Hash) ? man['label']['@value'] : man['label']
     :css
       em.rfc2119 { 
         text-transform: lowercase;
@@ -52,7 +52,7 @@
     %p
       %a{href: "http://www.w3.org/"}
         %img{src: "http://www.w3.org/Icons/w3c_home", alt: "W3C", height: 48, width: 72}
-    %h1{property: "rdfs:label"}<= man['label']
+    %h1{property: "rdfs:label"}<= man['label'].is_a?(Hash) ? man['label']['@value'] : man['label']
     :markdown
       [Copyright](http://www.w3.org/Consortium/Legal/ipr-notice#Copyright) © 2004-2023 [World Wide Web Consortium](https://www.w3.org/). <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> [liability](https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer), [trademark](https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks) and [permissive document license](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document) rules apply.
     %hr{title: "Separator for header"}


### PR DESCRIPTION
This adds the RDF-star tests from https://github.com/w3c/rdf-star/tree/main/tests with some minimal renaming.

Note the pattern of the tests manifests varies from RDF 1.1 with addition of `trs` prefix for manifest/test location and a separation between syntax and evaluation tests, that we may want to reconsider.