### PR TITLE
Add assumedTestBase to give machine readable base URI information.

### DIFF
--- a/ns/test-manifest.ttl
+++ b/ns/test-manifest.ttl
@@ -52,6 +52,11 @@
     rdfs:range   rdf:List ;
     .
 
+:assumedTestBase rdf:type rdf:Property ;
+    rdfs:comment "The assumed base URI for tests" ;
+    rdfs:domain	 :Manifest ;
+    .
+
 ## ---- Property declarations for each test ----
 
 :name rdf:type rdf:Property ;

--- a/rdf/rdf11/rdf-trig/manifest.ttl
+++ b/rdf/rdf11/rdf-trig/manifest.ttl
@@ -16,6 +16,7 @@
 
 <>  rdf:type mf:Manifest ;
     rdfs:label "TriG tests" ;
+    mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/> ;
     mf:entries
     (
     # TriG specific tests

--- a/rdf/rdf11/rdf-turtle/manifest.ttl
+++ b/rdf/rdf11/rdf-turtle/manifest.ttl
@@ -17,6 +17,7 @@
 
 <>  rdf:type mf:Manifest ;
     rdfs:label "Turtle tests" ;
+    mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/> ;
     mf:entries
     (
 

--- a/rdf/rdf11/rdf-xml/manifest.ttl
+++ b/rdf/rdf11/rdf-xml/manifest.ttl
@@ -14,6 +14,7 @@
 
 <> rdf:type mf:Manifest ;
   rdfs:label "RDF/XML Syntax tests" ;
+   mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-xml/> ;
   mf:entries (
     <#amp-in-url-test001>
     <#datatypes-test001>


### PR DESCRIPTION
This is a PR to branch `fix-default-base`.