### PR TITLE
Update turtle/trig-subm-01 test results based on the assumedTestBase

### DIFF
--- a/rdf/rdf11/rdf-trig/trig-subm-01.nq
+++ b/rdf/rdf11/rdf-trig/trig-subm-01.nq
@@ -1,2 +1,2 @@
-_:genid1 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/trig-subm-01.trig#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/trig-subm-01.trig#y> .
-_:genid2 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/trig-subm-01.trig#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/trig-subm-01.trig#y> <http://example/graph> .
+_:genid1 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/#y> .
+_:genid2 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/#y> <http://example/graph> .

--- a/rdf/rdf11/rdf-turtle/turtle-subm-01.nt
+++ b/rdf/rdf11/rdf-turtle/turtle-subm-01.nt
@@ -1,1 +1,1 @@
-_:genid1 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/turtle-subm-01.ttl#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/turtle-subm-01.ttl#y> .
+_:genid1 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/#y> .


### PR DESCRIPTION
…not the location of the test input.

This is a consequence of adding `mf:assumedTestBase` to the test manifests and using that for resolving relative IRI references.