### PR TITLE
Reinterpret assumed test base

### DIFF
--- a/ns/test-manifest.ttl
+++ b/ns/test-manifest.ttl
@@ -53,7 +53,7 @@
     .
 
 :assumedTestBase rdf:type rdf:Property ;
-    rdfs:comment "The assumed base URI for tests" ;
+    rdfs:comment "The assumed base URI for test manifest. Relative IRIs in manifest are resolved relative to this IRI." ;
     rdfs:domain	 :Manifest ;
     .
 

--- a/rdf/rdf11/rdf-trig/trig-subm-01.nq
+++ b/rdf/rdf11/rdf-trig/trig-subm-01.nq
@@ -1,2 +1,2 @@
-_:genid1 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/#y> .
-_:genid2 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/#y> <http://example/graph> .
+_:genid1 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/trig-subm-01.trig#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/trig-subm-01.trig#y> .
+_:genid2 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/trig-subm-01.trig#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/trig-subm-01.trig#y> <http://example/graph> .

--- a/rdf/rdf11/rdf-turtle/turtle-subm-01.nt
+++ b/rdf/rdf11/rdf-turtle/turtle-subm-01.nt
@@ -1,1 +1,1 @@
-_:genid1 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/#y> .
+_:genid1 <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/turtle-subm-01.ttl#x> <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/turtle-subm-01.ttl#y> .

--- a/rdf/rdf11/rdf-xml/manifest.ttl
+++ b/rdf/rdf11/rdf-xml/manifest.ttl
@@ -14,7 +14,7 @@
 
 <> rdf:type mf:Manifest ;
   rdfs:label "RDF/XML Syntax tests" ;
-  # mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-xml/> ;
+  mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-xml/> ;
   mf:entries (
     <#amp-in-url-test001>
     <#datatypes-test001>


### PR DESCRIPTION
* Changes the definition of assumedTestBase and revises the trig/turtle-subm-01 test results to be compatible with running without assumedTestBase. Fixes #113
* Adds assumedTestBase to RDF/XML tests.

cc/ @jeswr
