### PR TITLE
Creates manifests and READMEs for each RDF 1.2 spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ task index: MANIFESTS.
 
 MANIFESTS.each do |ttl|
   html = ttl.sub(/manifest(.*)\.ttl$/, 'index\1.html')
+  base = 'https://w3c.github.io/rdf-tests/' + ttl.sub('manifest.ttl', '')
 
   # Find frame closest to file
   frame_path, template_path = nil, nil
@@ -35,8 +36,8 @@ MANIFESTS.each do |ttl|
 
       ttl_path, ttl_file = File.dirname(ttl), File.basename(ttl)
       Dir.chdir(ttl_path) do
-        RDF::Reader.open(ttl_file, base_uri: '') do |reader|
-          out = JSON::LD::Writer.buffer(frame: JSON.parse(frame), simple_compact_iris: true) do |writer|
+        RDF::Reader.open(ttl_file, base_uri: base) do |reader|
+          out = JSON::LD::Writer.buffer(frame: JSON.parse(frame), base_uri: base, simple_compact_iris: true) do |writer|
             writer << reader
           end
 

--- a/rdf/rdf11/rdf-mt/index.html
+++ b/rdf/rdf11/rdf-mt/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/rdf/rdf11/rdf-n-quads/index.html
+++ b/rdf/rdf11/rdf-n-quads/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/rdf/rdf11/rdf-n-triples/index.html
+++ b/rdf/rdf11/rdf-n-triples/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/rdf/rdf11/rdf-n-triples/manifest.ttl
+++ b/rdf/rdf11/rdf-n-triples/manifest.ttl
@@ -1,8 +1,8 @@
 # N-Triples Syntax tests
 
 @prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
 
 @prefix rdft:   <http://www.w3.org/ns/rdftest#> .

--- a/rdf/rdf11/rdf-trig/index.html
+++ b/rdf/rdf11/rdf-trig/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/rdf/rdf11/rdf-turtle/README
+++ b/rdf/rdf11/rdf-turtle/README
@@ -20,7 +20,7 @@ tests have a name (mf:name) and an input (mf:action). The Evaluation
 tests have an expected result (mf:result).
 
 • An implementation passes an Evaluation test if it parses the input
-  into a graph, parses the expecte result into another graph, and
+  into a graph, parses the expected result into another graph, and
   those two graphs are isomorphic (see
   <http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism>).
 

--- a/rdf/rdf11/rdf-turtle/index.html
+++ b/rdf/rdf11/rdf-turtle/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/rdf/rdf11/rdf-xml/index.html
+++ b/rdf/rdf11/rdf-xml/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/rdf/rdf12/index.html
+++ b/rdf/rdf12/index.html
@@ -82,16 +82,25 @@
       </h2>
       <ul>
         <li>
-          <a href='rdf-n-triples/index.html' inlist='true' property='mf:include'>rdf-n-triples/</a>
+          <a href='rdf-n-triples/c14n/index.html' inlist='true' property='mf:include'>rdf-n-triples/c14n/</a>
+        </li>
+        <li>
+          <a href='rdf-n-triples/syntax/index.html' inlist='true' property='mf:include'>rdf-n-triples/syntax/</a>
         </li>
         <li>
           <a href='rdf-semantics/index.html' inlist='true' property='mf:include'>rdf-semantics/</a>
         </li>
         <li>
-          <a href='rdf-turtle/index.html' inlist='true' property='mf:include'>rdf-turtle/</a>
+          <a href='rdf-turtle/syntax/index.html' inlist='true' property='mf:include'>rdf-turtle/syntax/</a>
         </li>
         <li>
-          <a href='rdf-trig/index.html' inlist='true' property='mf:include'>rdf-trig/</a>
+          <a href='rdf-turtle/eval/index.html' inlist='true' property='mf:include'>rdf-turtle/eval/</a>
+        </li>
+        <li>
+          <a href='rdf-trig/syntax/index.html' inlist='true' property='mf:include'>rdf-trig/syntax/</a>
+        </li>
+        <li>
+          <a href='rdf-trig/eval/index.html' inlist='true' property='mf:include'>rdf-trig/eval/</a>
         </li>
       </ul>
     </div>

--- a/rdf/rdf12/index.html
+++ b/rdf/rdf12/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12#manifest' typeof='mf:Manifest'>
+  <body resource='../rdf12#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -82,25 +82,16 @@
       </h2>
       <ul>
         <li>
-          <a href='rdf-n-triples/c14n/index.html' inlist='true' property='mf:include'>rdf-n-triples/c14n/</a>
-        </li>
-        <li>
-          <a href='rdf-n-triples/syntax/index.html' inlist='true' property='mf:include'>rdf-n-triples/syntax/</a>
+          <a href='rdf-n-triples/index.html' inlist='true' property='mf:include'>rdf-n-triples/</a>
         </li>
         <li>
           <a href='rdf-semantics/index.html' inlist='true' property='mf:include'>rdf-semantics/</a>
         </li>
         <li>
-          <a href='rdf-turtle/syntax/index.html' inlist='true' property='mf:include'>rdf-turtle/syntax/</a>
+          <a href='rdf-turtle/index.html' inlist='true' property='mf:include'>rdf-turtle/</a>
         </li>
         <li>
-          <a href='rdf-turtle/eval/index.html' inlist='true' property='mf:include'>rdf-turtle/eval/</a>
-        </li>
-        <li>
-          <a href='rdf-trig/syntax/index.html' inlist='true' property='mf:include'>rdf-trig/syntax/</a>
-        </li>
-        <li>
-          <a href='rdf-trig/eval/index.html' inlist='true' property='mf:include'>rdf-trig/eval/</a>
+          <a href='rdf-trig/index.html' inlist='true' property='mf:include'>rdf-trig/</a>
         </li>
       </ul>
     </div>

--- a/rdf/rdf12/rdf-n-triples/c14n/index.html
+++ b/rdf/rdf12/rdf-n-triples/c14n/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#manifest' typeof='mf:Manifest'>
+  <body resource='../c14n#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -85,9 +85,9 @@
           <a class='testlink' href='#comment_following_triple'>
             comment_following_triple:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#comment_following_triple' property='mf:name'>C14N comment_following_triple</span>
+          <span about='../c14n#comment_following_triple' property='mf:name'>C14N comment_following_triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#comment_following_triple' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#comment_following_triple' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of triples including comments</p>
           </div>
@@ -110,9 +110,9 @@
           <a class='testlink' href='#extra_whitespace-01'>
             extra_whitespace-01:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#extra_whitespace-01' property='mf:name'>C14N extra_whitespace-01</span>
+          <span about='../c14n#extra_whitespace-01' property='mf:name'>C14N extra_whitespace-01</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#extra_whitespace-01' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#extra_whitespace-01' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of triples with extra whitespace</p>
           </div>
@@ -135,9 +135,9 @@
           <a class='testlink' href='#extra_whitespace-02'>
             extra_whitespace-02:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#extra_whitespace-02' property='mf:name'>C14N extra_whitespace-02</span>
+          <span about='../c14n#extra_whitespace-02' property='mf:name'>C14N extra_whitespace-02</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#extra_whitespace-02' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#extra_whitespace-02' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of triples with extra whitespace</p>
           </div>
@@ -160,9 +160,9 @@
           <a class='testlink' href='#extra_whitespace-03'>
             extra_whitespace-03:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#extra_whitespace-03' property='mf:name'>C14N extra_whitespace-03</span>
+          <span about='../c14n#extra_whitespace-03' property='mf:name'>C14N extra_whitespace-03</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#extra_whitespace-03' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#extra_whitespace-03' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of triples with extra whitespace</p>
           </div>
@@ -185,9 +185,9 @@
           <a class='testlink' href='#extra_whitespace-04'>
             extra_whitespace-04:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#extra_whitespace-04' property='mf:name'>C14N extra_whitespace-04</span>
+          <span about='../c14n#extra_whitespace-04' property='mf:name'>C14N extra_whitespace-04</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#extra_whitespace-04' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#extra_whitespace-04' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of triples with extra whitespace</p>
           </div>
@@ -210,9 +210,9 @@
           <a class='testlink' href='#langtagged_string'>
             langtagged_string:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#langtagged_string' property='mf:name'>C14N langtagged_string</span>
+          <span about='../c14n#langtagged_string' property='mf:name'>C14N langtagged_string</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#langtagged_string' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#langtagged_string' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of triples including language-tagged string</p>
           </div>
@@ -235,9 +235,9 @@
           <a class='testlink' href='#literal_all_controls'>
             literal_all_controls:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_all_controls' property='mf:name'>C14N literal_all_controls</span>
+          <span about='../c14n#literal_all_controls' property='mf:name'>C14N literal_all_controls</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_all_controls' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_all_controls' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with control characters</p>
           </div>
@@ -260,9 +260,9 @@
           <a class='testlink' href='#literal_all_punctuation'>
             literal_all_punctuation:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_all_punctuation' property='mf:name'>C14N literal_all_punctuation</span>
+          <span about='../c14n#literal_all_punctuation' property='mf:name'>C14N literal_all_punctuation</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_all_punctuation' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_all_punctuation' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with punctuation characters</p>
           </div>
@@ -285,9 +285,9 @@
           <a class='testlink' href='#literal_ascii_boundaries'>
             literal_ascii_boundaries:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_ascii_boundaries' property='mf:name'>C14N literal_ascii_boundaries</span>
+          <span about='../c14n#literal_ascii_boundaries' property='mf:name'>C14N literal_ascii_boundaries</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_ascii_boundaries' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_ascii_boundaries' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literal_ascii_boundaries '\x00\x26\x28…'</p>
           </div>
@@ -310,9 +310,9 @@
           <a class='testlink' href='#literal_with_2_dquotes'>
             literal_with_2_dquotes:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_2_dquotes' property='mf:name'>C14N literal_with_2_dquotes</span>
+          <span about='../c14n#literal_with_2_dquotes' property='mf:name'>C14N literal_with_2_dquotes</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_2_dquotes' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_2_dquotes' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literal with 2 dquotes """a""b"""</p>
           </div>
@@ -335,9 +335,9 @@
           <a class='testlink' href='#literal_with_2_squotes'>
             literal_with_2_squotes:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_2_squotes' property='mf:name'>C14N literal_with_2_squotes</span>
+          <span about='../c14n#literal_with_2_squotes' property='mf:name'>C14N literal_with_2_squotes</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_2_squotes' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_2_squotes' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literal with 2 squotes "x''y"</p>
           </div>
@@ -360,9 +360,9 @@
           <a class='testlink' href='#literal_with_BACKSPACE'>
             literal_with_BACKSPACE:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_BACKSPACE' property='mf:name'>C14N literal_with_BACKSPACE</span>
+          <span about='../c14n#literal_with_BACKSPACE' property='mf:name'>C14N literal_with_BACKSPACE</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_BACKSPACE' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_BACKSPACE' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with backspace</p>
           </div>
@@ -385,9 +385,9 @@
           <a class='testlink' href='#literal_with_CARRIAGE_RETURN'>
             literal_with_CARRIAGE_RETURN:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_CARRIAGE_RETURN' property='mf:name'>C14N literal_with_CARRIAGE_RETURN</span>
+          <span about='../c14n#literal_with_CARRIAGE_RETURN' property='mf:name'>C14N literal_with_CARRIAGE_RETURN</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_CARRIAGE_RETURN' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_CARRIAGE_RETURN' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with carriage return</p>
           </div>
@@ -410,9 +410,9 @@
           <a class='testlink' href='#literal_with_CHARACTER_TABULATION'>
             literal_with_CHARACTER_TABULATION:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_CHARACTER_TABULATION' property='mf:name'>C14N literal_with_CHARACTER_TABULATION</span>
+          <span about='../c14n#literal_with_CHARACTER_TABULATION' property='mf:name'>C14N literal_with_CHARACTER_TABULATION</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_CHARACTER_TABULATION' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_CHARACTER_TABULATION' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with character tabulation</p>
           </div>
@@ -435,9 +435,9 @@
           <a class='testlink' href='#literal_with_dquote'>
             literal_with_dquote:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_dquote' property='mf:name'>C14N literal_with_dquote</span>
+          <span about='../c14n#literal_with_dquote' property='mf:name'>C14N literal_with_dquote</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_dquote' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_dquote' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with double quote</p>
           </div>
@@ -460,9 +460,9 @@
           <a class='testlink' href='#literal_with_FORM_FEED'>
             literal_with_FORM_FEED:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_FORM_FEED' property='mf:name'>C14N literal_with_FORM_FEED</span>
+          <span about='../c14n#literal_with_FORM_FEED' property='mf:name'>C14N literal_with_FORM_FEED</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_FORM_FEED' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_FORM_FEED' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with form feed</p>
           </div>
@@ -485,9 +485,9 @@
           <a class='testlink' href='#literal_with_LINE_FEED'>
             literal_with_LINE_FEED:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_LINE_FEED' property='mf:name'>C14N literal_with_LINE_FEED</span>
+          <span about='../c14n#literal_with_LINE_FEED' property='mf:name'>C14N literal_with_LINE_FEED</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_LINE_FEED' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_LINE_FEED' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with line feed</p>
           </div>
@@ -510,9 +510,9 @@
           <a class='testlink' href='#literal_with_numeric_escape4'>
             literal_with_numeric_escape4:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_numeric_escape4' property='mf:name'>C14N literal_with_numeric_escape4</span>
+          <span about='../c14n#literal_with_numeric_escape4' property='mf:name'>C14N literal_with_numeric_escape4</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_numeric_escape4' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_numeric_escape4' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with numeric escapes</p>
           </div>
@@ -535,9 +535,9 @@
           <a class='testlink' href='#literal_with_numeric_escape8'>
             literal_with_numeric_escape8:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_numeric_escape8' property='mf:name'>C14N literal_with_numeric_escape8</span>
+          <span about='../c14n#literal_with_numeric_escape8' property='mf:name'>C14N literal_with_numeric_escape8</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_numeric_escape8' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_numeric_escape8' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with numeric escapes</p>
           </div>
@@ -560,9 +560,9 @@
           <a class='testlink' href='#literal_with_REVERSE_SOLIDUS'>
             literal_with_REVERSE_SOLIDUS:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_REVERSE_SOLIDUS' property='mf:name'>C14N literal_with_REVERSE_SOLIDUS</span>
+          <span about='../c14n#literal_with_REVERSE_SOLIDUS' property='mf:name'>C14N literal_with_REVERSE_SOLIDUS</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_REVERSE_SOLIDUS' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_REVERSE_SOLIDUS' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with reverse solidus</p>
           </div>
@@ -585,9 +585,9 @@
           <a class='testlink' href='#literal_with_REVERSE_SOLIDUS2'>
             literal_with_REVERSE_SOLIDUS2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_REVERSE_SOLIDUS2' property='mf:name'>C14N literal_with_REVERSE_SOLIDUS2</span>
+          <span about='../c14n#literal_with_REVERSE_SOLIDUS2' property='mf:name'>C14N literal_with_REVERSE_SOLIDUS2</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_REVERSE_SOLIDUS2' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_REVERSE_SOLIDUS2' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with reverse solidus</p>
           </div>
@@ -610,9 +610,9 @@
           <a class='testlink' href='#literal_with_squote'>
             literal_with_squote:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_squote' property='mf:name'>C14N literal_with_squote</span>
+          <span about='../c14n#literal_with_squote' property='mf:name'>C14N literal_with_squote</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_squote' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_squote' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with single quotes</p>
           </div>
@@ -635,9 +635,9 @@
           <a class='testlink' href='#literal_with_string_dt'>
             literal_with_string_dt:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_string_dt' property='mf:name'>C14N literal_with_string_dt</span>
+          <span about='../c14n#literal_with_string_dt' property='mf:name'>C14N literal_with_string_dt</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_string_dt' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_string_dt' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literal with explicit xsd:string</p>
           </div>
@@ -660,9 +660,9 @@
           <a class='testlink' href='#literal_with_UTF8_boundaries'>
             literal_with_UTF8_boundaries:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_UTF8_boundaries' property='mf:name'>C14N literal_with_UTF8_boundaries</span>
+          <span about='../c14n#literal_with_UTF8_boundaries' property='mf:name'>C14N literal_with_UTF8_boundaries</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#literal_with_UTF8_boundaries' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#literal_with_UTF8_boundaries' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of literals with UTF8 boundaries</p>
           </div>
@@ -685,9 +685,9 @@
           <a class='testlink' href='#minimal_whitespace-01'>
             minimal_whitespace-01:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#minimal_whitespace-01' property='mf:name'>C14N minimal_whitespace-01</span>
+          <span about='../c14n#minimal_whitespace-01' property='mf:name'>C14N minimal_whitespace-01</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#minimal_whitespace-01' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#minimal_whitespace-01' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of triples without optional whitespace</p>
           </div>
@@ -710,9 +710,9 @@
           <a class='testlink' href='#minimal_whitespace-02'>
             minimal_whitespace-02:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#minimal_whitespace-02' property='mf:name'>C14N minimal_whitespace-02</span>
+          <span about='../c14n#minimal_whitespace-02' property='mf:name'>C14N minimal_whitespace-02</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#minimal_whitespace-02' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#minimal_whitespace-02' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of triples without optional whitespace</p>
           </div>
@@ -735,9 +735,9 @@
           <a class='testlink' href='#nt-syntax-uri-01'>
             nt-syntax-uri-01:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-uri-01' property='mf:name'>C14N nt-syntax-uri-01</span>
+          <span about='../c14n#nt-syntax-uri-01' property='mf:name'>C14N nt-syntax-uri-01</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-uri-01' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#nt-syntax-uri-01' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of IRIs</p>
           </div>
@@ -760,9 +760,9 @@
           <a class='testlink' href='#nt-syntax-uri-02'>
             nt-syntax-uri-02:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-uri-02' property='mf:name'>C14N nt-syntax-uri-02</span>
+          <span about='../c14n#nt-syntax-uri-02' property='mf:name'>C14N nt-syntax-uri-02</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-uri-02' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#nt-syntax-uri-02' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of IRIs</p>
           </div>
@@ -785,9 +785,9 @@
           <a class='testlink' href='#nt-syntax-uri-03'>
             nt-syntax-uri-03:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-uri-03' property='mf:name'>C14N nt-syntax-uri-03</span>
+          <span about='../c14n#nt-syntax-uri-03' property='mf:name'>C14N nt-syntax-uri-03</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-uri-03' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#nt-syntax-uri-03' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of IRIs</p>
           </div>
@@ -810,9 +810,9 @@
           <a class='testlink' href='#nt-syntax-uri-04'>
             nt-syntax-uri-04:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-uri-04' property='mf:name'>C14N nt-syntax-uri-04</span>
+          <span about='../c14n#nt-syntax-uri-04' property='mf:name'>C14N nt-syntax-uri-04</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-uri-04' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#nt-syntax-uri-04' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of IRIs</p>
           </div>
@@ -835,9 +835,9 @@
           <a class='testlink' href='#nt-syntax-str-esc-01'>
             nt-syntax-str-esc-01:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-str-esc-01' property='mf:name'>C14N nt-syntax-str-esc-01</span>
+          <span about='../c14n#nt-syntax-str-esc-01' property='mf:name'>C14N nt-syntax-str-esc-01</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-str-esc-01' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#nt-syntax-str-esc-01' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of string escapes</p>
           </div>
@@ -860,9 +860,9 @@
           <a class='testlink' href='#nt-syntax-str-esc-02'>
             nt-syntax-str-esc-02:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-str-esc-02' property='mf:name'>C14N nt-syntax-str-esc-02</span>
+          <span about='../c14n#nt-syntax-str-esc-02' property='mf:name'>C14N nt-syntax-str-esc-02</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-str-esc-02' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#nt-syntax-str-esc-02' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of string escapes</p>
           </div>
@@ -885,9 +885,9 @@
           <a class='testlink' href='#nt-syntax-str-esc-03'>
             nt-syntax-str-esc-03:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-str-esc-03' property='mf:name'>C14N nt-syntax-str-esc-03</span>
+          <span about='../c14n#nt-syntax-str-esc-03' property='mf:name'>C14N nt-syntax-str-esc-03</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#nt-syntax-str-esc-03' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#nt-syntax-str-esc-03' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of string escapes</p>
           </div>

--- a/rdf/rdf12/rdf-n-triples/c14n/manifest.ttl
+++ b/rdf/rdf12/rdf-n-triples/c14n/manifest.ttl
@@ -15,6 +15,7 @@ PREFIX rdft: <http://www.w3.org/ns/rdftest#>
 :manifest  a mf:Manifest ;
   rdfs:label "RDF-star N-Triples Canonicalization Test Suite"@en;
   rdfs:comment "Tests the generation of canonical N-Triples."@en;
+  mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n/> ;
   rdfs:seeAlso <README.md>;
   mf:entries (
     :comment_following_triple

--- a/rdf/rdf12/rdf-n-triples/index.html
+++ b/rdf/rdf12/rdf-n-triples/index.html
@@ -31,7 +31,7 @@
       footer {text-align: center;}
     </style>
     <title>
-      RDF 1.1 tests
+      RDF 1.2 N-Triples tests
     </title>
     <style>
       em.rfc2119 {
@@ -51,21 +51,23 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='./' typeof='mf:Manifest'>
+  <body resource='../rdf-n-triples#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
       </a>
     </p>
-    <h1 property='rdfs:label'>RDF 1.1 tests</h1>
+    <h1 property='rdfs:label'>RDF 1.2 N-Triples tests</h1>
     <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
     <hr title='Separator for header'>
     <div>
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
-        <p>These test suites are a product previous RDF working groups, and has been maintained by the <a href="https://www.w3.org/community/rdf-tests/">RDF Test Curation Community Group</a>. Community maintained at <a href="https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/">https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11</a>. Conformance with RDF 1.1 specifications can be determined via successfully running the tests for relevant specifications.</p>
+        <p>These test suites are a product of the <a href="">W3C RDF-star Working Group</a> as well as the RDF-star Interest Group within the W3C RDF-DEV Community Group, and has been maintained by the <a href="https://www.w3.org/community/rdf-tests/">RDF Test Curation Community Group</a> at <a href="https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/">https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11</a>. Conformance with RDF 1.2 specifications can be determined via successfully running the tests for relevant specifications along with the relevant RDF 1.1 tests.</p>
       </p>
-      <p>This page describes W3C RDF 1.1 Working Group's test suite.</p>
+      <p>This page describes W3C RDF-star Working Group's test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -80,22 +82,13 @@
       </h2>
       <ul>
         <li>
-          <a href='rdf-n-triples/index.html' inlist='true' property='mf:include'>rdf-n-triples/</a>
+          <a href='c14n/index.html' inlist='true' property='mf:include'>c14n/</a>
         </li>
         <li>
-          <a href='rdf-n-quads/index.html' inlist='true' property='mf:include'>rdf-n-quads/</a>
+          <a href='syntax/index.html' inlist='true' property='mf:include'>syntax/</a>
         </li>
         <li>
-          <a href='rdf-mt/index.html' inlist='true' property='mf:include'>rdf-mt/</a>
-        </li>
-        <li>
-          <a href='rdf-turtle/index.html' inlist='true' property='mf:include'>rdf-turtle/</a>
-        </li>
-        <li>
-          <a href='rdf-trig/index.html' inlist='true' property='mf:include'>rdf-trig/</a>
-        </li>
-        <li>
-          <a href='rdf-xml/index.html' inlist='true' property='mf:include'>rdf-xml/</a>
+          <a href='../../rdf11/rdf-n-triples/index.html' inlist='true' property='mf:include'>../../rdf11/rdf-n-triples/</a>
         </li>
       </ul>
     </div>

--- a/rdf/rdf12/rdf-n-triples/manifest.ttl
+++ b/rdf/rdf12/rdf-n-triples/manifest.ttl
@@ -1,0 +1,37 @@
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+trs:manifest  rdf:type mf:Manifest ;
+  rdfs:label "RDF 1.2 N-Triples tests"@en ;
+  skos:prefLabel "La suite des tests pour RDF 1.2 N-Triples"@fr;
+  skos:prefLabel "Conjunto de pruebas para RDF 1.2 N-Triples"@es;
+  dct:issued "2023-10-28"^^xsd:date ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+  mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/> ;
+  dct:modified "2023-10-28"^^xsd:date ;
+  dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+  rdfs:comment """
+    These test suites are a product of the [W3C RDF-star Working Group]() as well as the
+    RDF-star Interest Group within the W3C RDF-DEV Community Group,
+    and has been maintained by the
+    [RDF Test Curation Community Group](https://www.w3.org/community/rdf-tests/)
+    at [https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/).
+
+    Conformance with RDF 1.2 specifications can be determined via successfully running the
+    tests for relevant specifications
+    along with the relevant RDF 1.1 tests.
+  """;
+  mf:include (
+    <c14n/manifest.ttl>
+    <syntax/manifest.ttl>
+    <../../rdf11/rdf-n-triples/manifest.ttl>
+  ) .
+

--- a/rdf/rdf12/rdf-n-triples/syntax/index.html
+++ b/rdf/rdf12/rdf-n-triples/syntax/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#manifest' typeof='mf:Manifest'>
+  <body resource='../syntax#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -82,9 +82,9 @@
           <a class='testlink' href='#ntriples-star-1'>
             ntriples-star-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-1' property='mf:name'>N-Triples-star - subject quoted triple</span>
+          <span about='../syntax#ntriples-star-1' property='mf:name'>N-Triples-star - subject quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-1' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-1' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -102,9 +102,9 @@
           <a class='testlink' href='#ntriples-star-2'>
             ntriples-star-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-2' property='mf:name'>N-Triples-star - object quoted triple</span>
+          <span about='../syntax#ntriples-star-2' property='mf:name'>N-Triples-star - object quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-2' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-2' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -122,9 +122,9 @@
           <a class='testlink' href='#ntriples-star-3'>
             ntriples-star-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-3' property='mf:name'>N-Triples-star - subject and object quoted triples</span>
+          <span about='../syntax#ntriples-star-3' property='mf:name'>N-Triples-star - subject and object quoted triples</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-3' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-3' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -142,9 +142,9 @@
           <a class='testlink' href='#ntriples-star-4'>
             ntriples-star-4:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-4' property='mf:name'>N-Triples-star - whitespace and terms</span>
+          <span about='../syntax#ntriples-star-4' property='mf:name'>N-Triples-star - whitespace and terms</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-4' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-4' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -162,9 +162,9 @@
           <a class='testlink' href='#ntriples-star-5'>
             ntriples-star-5:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-5' property='mf:name'>N-Triples-star - Nested, no whitespace</span>
+          <span about='../syntax#ntriples-star-5' property='mf:name'>N-Triples-star - Nested, no whitespace</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-5' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-5' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -182,9 +182,9 @@
           <a class='testlink' href='#ntriples-star-bnode-1'>
             ntriples-star-bnode-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-1' property='mf:name'>N-Triples-star - Blank node subject</span>
+          <span about='../syntax#ntriples-star-bnode-1' property='mf:name'>N-Triples-star - Blank node subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-1' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-bnode-1' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -202,9 +202,9 @@
           <a class='testlink' href='#ntriples-star-bnode-2'>
             ntriples-star-bnode-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-2' property='mf:name'>N-Triples-star - Blank node object</span>
+          <span about='../syntax#ntriples-star-bnode-2' property='mf:name'>N-Triples-star - Blank node object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-2' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-bnode-2' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -222,9 +222,9 @@
           <a class='testlink' href='#ntriples-star-nested-1'>
             ntriples-star-nested-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-1' property='mf:name'>N-Triples-star - Nested subject term</span>
+          <span about='../syntax#ntriples-star-nested-1' property='mf:name'>N-Triples-star - Nested subject term</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-1' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-nested-1' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -242,9 +242,9 @@
           <a class='testlink' href='#ntriples-star-nested-2'>
             ntriples-star-nested-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-2' property='mf:name'>N-Triples-star - Nested object term</span>
+          <span about='../syntax#ntriples-star-nested-2' property='mf:name'>N-Triples-star - Nested object term</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-2' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-nested-2' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -262,9 +262,9 @@
           <a class='testlink' href='#ntriples-star-bad-1'>
             ntriples-star-bad-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-1' property='mf:name'>N-Triples-star - Bad - quoted triple as predicate</span>
+          <span about='../syntax#ntriples-star-bad-1' property='mf:name'>N-Triples-star - Bad - quoted triple as predicate</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-1' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-bad-1' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -282,9 +282,9 @@
           <a class='testlink' href='#ntriples-star-bad-2'>
             ntriples-star-bad-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-2' property='mf:name'>N-Triples-star - Bad - quoted triple, literal subject</span>
+          <span about='../syntax#ntriples-star-bad-2' property='mf:name'>N-Triples-star - Bad - quoted triple, literal subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-2' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-bad-2' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -302,9 +302,9 @@
           <a class='testlink' href='#ntriples-star-bad-3'>
             ntriples-star-bad-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-3' property='mf:name'>N-Triples-star - Bad - quoted triple, literal predicate</span>
+          <span about='../syntax#ntriples-star-bad-3' property='mf:name'>N-Triples-star - Bad - quoted triple, literal predicate</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-3' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-bad-3' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -322,9 +322,9 @@
           <a class='testlink' href='#ntriples-star-bad-4'>
             ntriples-star-bad-4:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-4' property='mf:name'>N-Triples-star - Bad - quoted triple, blank node predicate</span>
+          <span about='../syntax#ntriples-star-bad-4' property='mf:name'>N-Triples-star - Bad - quoted triple, blank node predicate</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bad-4' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-bad-4' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -342,9 +342,9 @@
           <a class='testlink' href='#ntriples-star-bnode-bad-annotated-syntax-1'>
             ntriples-star-bnode-bad-annotated-syntax-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-bad-annotated-syntax-1' property='mf:name'>N-Triples-star - Bad - annotated triple, blank node subject</span>
+          <span about='../syntax#ntriples-star-bnode-bad-annotated-syntax-1' property='mf:name'>N-Triples-star - Bad - annotated triple, blank node subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-bad-annotated-syntax-1' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-bnode-bad-annotated-syntax-1' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -362,9 +362,9 @@
           <a class='testlink' href='#ntriples-star-bnode-bad-annotated-syntax-2'>
             ntriples-star-bnode-bad-annotated-syntax-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-bad-annotated-syntax-2' property='mf:name'>N-Triples-star - Bad - annotated triple, blank node object</span>
+          <span about='../syntax#ntriples-star-bnode-bad-annotated-syntax-2' property='mf:name'>N-Triples-star - Bad - annotated triple, blank node object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-bnode-bad-annotated-syntax-2' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-bnode-bad-annotated-syntax-2' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -382,9 +382,9 @@
           <a class='testlink' href='#ntriples-star-nested-bad-annotated-syntax-1'>
             ntriples-star-nested-bad-annotated-syntax-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-bad-annotated-syntax-1' property='mf:name'>N-Triples-star - Bad - annotated triple, nested subject term</span>
+          <span about='../syntax#ntriples-star-nested-bad-annotated-syntax-1' property='mf:name'>N-Triples-star - Bad - annotated triple, nested subject term</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-bad-annotated-syntax-1' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-nested-bad-annotated-syntax-1' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -402,9 +402,9 @@
           <a class='testlink' href='#ntriples-star-nested-bad-annotated-syntax-2'>
             ntriples-star-nested-bad-annotated-syntax-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-bad-annotated-syntax-2' property='mf:name'>N-Triples-star - Bad - annotated triple, nested object term</span>
+          <span about='../syntax#ntriples-star-nested-bad-annotated-syntax-2' property='mf:name'>N-Triples-star - Bad - annotated triple, nested object term</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-star-nested-bad-annotated-syntax-2' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-star-nested-bad-annotated-syntax-2' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>

--- a/rdf/rdf12/rdf-n-triples/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-n-triples/syntax/manifest.ttl
@@ -17,6 +17,7 @@ trs:manifest  rdf:type mf:Manifest ;
    rdfs:label "N-Triples 1.2 Syntax Tests"@en ;
    skos:prefLabel "La suite des tests pour N-Triples 1.2"@fr;
    skos:prefLabel "Conjunto de pruebas para N-Triples 1.2r"@es;
+   mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax/> ;
    dct:issued "2023-07-20"^^xsd:date ;
    dct:modified "2023-07-20"^^xsd:date ;
    dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;

--- a/rdf/rdf12/rdf-semantics/index.html
+++ b/rdf/rdf12/rdf-semantics/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#manifest' typeof='mf:Manifest'>
+  <body resource='../rdf-semantics#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -82,9 +82,9 @@
           <a class='testlink' href='#all-identical-quoted-triples-are-the-same'>
             all-identical-quoted-triples-are-the-same:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#all-identical-quoted-triples-are-the-same' property='mf:name'>all-identical-quoted-triples-are-the-same</span>
+          <span about='../rdf-semantics#all-identical-quoted-triples-are-the-same' property='mf:name'>all-identical-quoted-triples-are-the-same</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#all-identical-quoted-triples-are-the-same' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#all-identical-quoted-triples-are-the-same' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Multiple occurences of the same quoted triples are undistinguishable in the abstract model.</p>
           </div>
@@ -107,9 +107,9 @@
           <a class='testlink' href='#quoted-triples-no-spurious'>
             quoted-triples-no-spurious:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#quoted-triples-no-spurious' property='mf:name'>quoted-triples-no-spurious</span>
+          <span about='../rdf-semantics#quoted-triples-no-spurious' property='mf:name'>quoted-triples-no-spurious</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#quoted-triples-no-spurious' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#quoted-triples-no-spurious' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>This test ensures that other entailments are not spurious.</p>
           </div>
@@ -132,9 +132,9 @@
           <a class='testlink' href='#bnodes-in-quoted-subject'>
             bnodes-in-quoted-subject:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject' property='mf:name'>bnodes-in-quoted-subject</span>
+          <span about='../rdf-semantics#bnodes-in-quoted-subject' property='mf:name'>bnodes-in-quoted-subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-quoted-subject' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Terms inside quoted triples can be replaced by fresh bnodes.</p>
           </div>
@@ -157,9 +157,9 @@
           <a class='testlink' href='#bnodes-in-quoted-object'>
             bnodes-in-quoted-object:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-object' property='mf:name'>bnodes-in-quoted-object</span>
+          <span about='../rdf-semantics#bnodes-in-quoted-object' property='mf:name'>bnodes-in-quoted-object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-object' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-quoted-object' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Terms inside quoted triples can be replaced by fresh bnodes.</p>
           </div>
@@ -182,9 +182,9 @@
           <a class='testlink' href='#bnodes-in-quoted-subject-and-object'>
             bnodes-in-quoted-subject-and-object:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject-and-object' property='mf:name'>bnodes-in-quoted-subject-and-object</span>
+          <span about='../rdf-semantics#bnodes-in-quoted-subject-and-object' property='mf:name'>bnodes-in-quoted-subject-and-object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject-and-object' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-quoted-subject-and-object' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Terms inside quoted triples can be replaced by fresh bnodes.</p>
           </div>
@@ -207,9 +207,9 @@
           <a class='testlink' href='#bnodes-in-quoted-subject-and-object-fail'>
             bnodes-in-quoted-subject-and-object-fail:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject-and-object-fail' property='mf:name'>bnodes-in-quoted-subject-and-object-fail</span>
+          <span about='../rdf-semantics#bnodes-in-quoted-subject-and-object-fail' property='mf:name'>bnodes-in-quoted-subject-and-object-fail</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#bnodes-in-quoted-subject-and-object-fail' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-quoted-subject-and-object-fail' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>The same bnode can not match different quoted terms.</p>
           </div>
@@ -232,9 +232,9 @@
           <a class='testlink' href='#same-bnode-same-quoted-term'>
             same-bnode-same-quoted-term:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#same-bnode-same-quoted-term' property='mf:name'>same-bnode-same-quoted-term</span>
+          <span about='../rdf-semantics#same-bnode-same-quoted-term' property='mf:name'>same-bnode-same-quoted-term</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#same-bnode-same-quoted-term' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#same-bnode-same-quoted-term' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Identical quoted term can be replaced by the same fresh bnode multiple times.</p>
           </div>
@@ -257,9 +257,9 @@
           <a class='testlink' href='#different-bnodes-same-quoted-term'>
             different-bnodes-same-quoted-term:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#different-bnodes-same-quoted-term' property='mf:name'>different-bnodes-same-quoted-term</span>
+          <span about='../rdf-semantics#different-bnodes-same-quoted-term' property='mf:name'>different-bnodes-same-quoted-term</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#different-bnodes-same-quoted-term' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#different-bnodes-same-quoted-term' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Different bnodes can match identical quoted terms.</p>
           </div>
@@ -282,9 +282,9 @@
           <a class='testlink' href='#constrained-bnodes-in-quoted-subject'>
             constrained-bnodes-in-quoted-subject:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-subject' property='mf:name'>constrained-bnodes-in-quoted-subject</span>
+          <span about='../rdf-semantics#constrained-bnodes-in-quoted-subject' property='mf:name'>constrained-bnodes-in-quoted-subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-subject' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-in-quoted-subject' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Terms inside and outside quoted triples can be replaced by fresh bnodes</p>
           </div>
@@ -307,9 +307,9 @@
           <a class='testlink' href='#constrained-bnodes-in-quoted-object'>
             constrained-bnodes-in-quoted-object:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-object' property='mf:name'>constrained-bnodes-in-quoted-object</span>
+          <span about='../rdf-semantics#constrained-bnodes-in-quoted-object' property='mf:name'>constrained-bnodes-in-quoted-object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-object' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-in-quoted-object' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Terms inside and outside quoted triples can be replaced by fresh bnodes.</p>
           </div>
@@ -332,9 +332,9 @@
           <a class='testlink' href='#constrained-bnodes-in-quoted-fail'>
             constrained-bnodes-in-quoted-fail:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-fail' property='mf:name'>constrained-bnodes-in-quoted-fail</span>
+          <span about='../rdf-semantics#constrained-bnodes-in-quoted-fail' property='mf:name'>constrained-bnodes-in-quoted-fail</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-in-quoted-fail' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-in-quoted-fail' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Quoted bnode identifiers share the same scope as non-quoted ones. A bnode that occurs both inside quoted triples and inside asserted triples must satisfy all occurrences at the same time.</p>
           </div>
@@ -357,9 +357,9 @@
           <a class='testlink' href='#constrained-bnodes-on-literal'>
             constrained-bnodes-on-literal:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-on-literal' property='mf:name'>constrained-bnodes-on-literal</span>
+          <span about='../rdf-semantics#constrained-bnodes-on-literal' property='mf:name'>constrained-bnodes-on-literal</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#constrained-bnodes-on-literal' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-on-literal' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Literals inside and outside quoted triples can be replaced by fresh bnodes.</p>
           </div>
@@ -382,9 +382,9 @@
           <a class='testlink' href='#malformed-literal-control'>
             malformed-literal-control:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-control' property='mf:name'>malformed-literal-control</span>
+          <span about='../rdf-semantics#malformed-literal-control' property='mf:name'>malformed-literal-control</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-control' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#malformed-literal-control' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Checks that xsd:integer is indeed recognized, to ensure that malformed-literal-* tests do not pass spuriously.</p>
           </div>
@@ -403,9 +403,9 @@
           <a class='testlink' href='#malformed-literal'>
             malformed-literal:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal' property='mf:name'>malformed-literal</span>
+          <span about='../rdf-semantics#malformed-literal' property='mf:name'>malformed-literal</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#malformed-literal' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Malformed literals are allowed when quoted.</p>
           </div>
@@ -424,9 +424,9 @@
           <a class='testlink' href='#malformed-literal-accepted'>
             malformed-literal-accepted:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-accepted' property='mf:name'>malformed-literal-accepted</span>
+          <span about='../rdf-semantics#malformed-literal-accepted' property='mf:name'>malformed-literal-accepted</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-accepted' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#malformed-literal-accepted' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Malformed literals are allowed when quoted.</p>
           </div>
@@ -449,9 +449,9 @@
           <a class='testlink' href='#malformed-literal-no-spurious'>
             malformed-literal-no-spurious:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-no-spurious' property='mf:name'>malformed-literal-no-spurious</span>
+          <span about='../rdf-semantics#malformed-literal-no-spurious' property='mf:name'>malformed-literal-no-spurious</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-no-spurious' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#malformed-literal-no-spurious' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Quoted malformed literals do not lead to spurious entailment.</p>
           </div>
@@ -474,9 +474,9 @@
           <a class='testlink' href='#malformed-literal-bnode-neg'>
             malformed-literal-bnode-neg:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-bnode-neg' property='mf:name'>malformed-literal-bnode</span>
+          <span about='../rdf-semantics#malformed-literal-bnode-neg' property='mf:name'>malformed-literal-bnode</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#malformed-literal-bnode-neg' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#malformed-literal-bnode-neg' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Malformed literals can not be replaced by blank nodes.</p>
           </div>
@@ -499,9 +499,9 @@
           <a class='testlink' href='#opaque-literal-control'>
             opaque-literal-control:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-literal-control' property='mf:name'>opaque-literal-control</span>
+          <span about='../rdf-semantics#opaque-literal-control' property='mf:name'>opaque-literal-control</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-literal-control' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#opaque-literal-control' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Checks that xsd:integer is indeed recognized, to ensure that opaque-literal does not pass spuriously.</p>
           </div>
@@ -524,9 +524,9 @@
           <a class='testlink' href='#opaque-literal'>
             opaque-literal:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-literal' property='mf:name'>opaque-literal</span>
+          <span about='../rdf-semantics#opaque-literal' property='mf:name'>opaque-literal</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-literal' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#opaque-literal' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Quoted literals are opaque, even when their datatype is recognized.</p>
           </div>
@@ -549,9 +549,9 @@
           <a class='testlink' href='#opaque-language-string-control'>
             opaque-language-string-control:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-language-string-control' property='mf:name'>opaque-language-string-control</span>
+          <span about='../rdf-semantics#opaque-language-string-control' property='mf:name'>opaque-language-string-control</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-language-string-control' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#opaque-language-string-control' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Checks that language strings are indeed recognized, to ensure that opaque-language-string does not pass spuriously.</p>
           </div>
@@ -574,9 +574,9 @@
           <a class='testlink' href='#opaque-language-string'>
             opaque-language-string:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-language-string' property='mf:name'>opaque-language-string</span>
+          <span about='../rdf-semantics#opaque-language-string' property='mf:name'>opaque-language-string</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-language-string' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#opaque-language-string' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Quoted literals (including language strings) are opaque, even when their datatype is recognized.</p>
           </div>
@@ -599,9 +599,9 @@
           <a class='testlink' href='#opaque-iri-control'>
             opaque-iri-control:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-iri-control' property='mf:name'>opaque-iri-control</span>
+          <span about='../rdf-semantics#opaque-iri-control' property='mf:name'>opaque-iri-control</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-iri-control' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#opaque-iri-control' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Check that owl:sameAs works as expected, to ensure that opaque-iri does not pass spuriously.</p>
           </div>
@@ -624,9 +624,9 @@
           <a class='testlink' href='#opaque-iri'>
             opaque-iri:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-iri' property='mf:name'>opaque-iri</span>
+          <span about='../rdf-semantics#opaque-iri' property='mf:name'>opaque-iri</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#opaque-iri' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#opaque-iri' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Quoted IRIs are opaque.</p>
           </div>
@@ -649,9 +649,9 @@
           <a class='testlink' href='#quoted-not-asserted'>
             quoted-not-asserted:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#quoted-not-asserted' property='mf:name'>quoted-not-asserted</span>
+          <span about='../rdf-semantics#quoted-not-asserted' property='mf:name'>quoted-not-asserted</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#quoted-not-asserted' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#quoted-not-asserted' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Quoted triples are not asserted.</p>
           </div>
@@ -674,9 +674,9 @@
           <a class='testlink' href='#annotated-asserted'>
             annotated-asserted:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotated-asserted' property='mf:name'>annotated-asserted</span>
+          <span about='../rdf-semantics#annotated-asserted' property='mf:name'>annotated-asserted</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotated-asserted' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#annotated-asserted' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Annotated triples are asserted.</p>
           </div>
@@ -699,9 +699,9 @@
           <a class='testlink' href='#annotation'>
             annotation:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotation' property='mf:name'>annotation</span>
+          <span about='../rdf-semantics#annotation' property='mf:name'>annotation</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotation' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#annotation' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Annotation are about the annotated triple.</p>
           </div>
@@ -724,9 +724,9 @@
           <a class='testlink' href='#annotation-unfolded'>
             annotation-unfolded:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotation-unfolded' property='mf:name'>annotation-unfolded</span>
+          <span about='../rdf-semantics#annotation-unfolded' property='mf:name'>annotation-unfolded</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics#annotation-unfolded' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#annotation-unfolded' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
             <p>Annotation is the same as separate assertions.</p>
           </div>

--- a/rdf/rdf12/rdf-semantics/manifest.ttl
+++ b/rdf/rdf12/rdf-semantics/manifest.ttl
@@ -19,6 +19,7 @@ trs:manifest a mf:Manifest;
   rdfs:label "RDF 1.2 Semantics tests"@en ;
   skos:prefLabel "La suite des tests pour la sémantique de RDF 1.2"@fr;
   skos:prefLabel "Conjunto de pruebas para la semántica de RDF 1.2"@es;
+  mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-semantics/> ;
   dct:issued "2023-07-20"^^xsd:date ;
   dct:modified "2023-07-20"^^xsd:date ;
   dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;

--- a/rdf/rdf12/rdf-trig/README.md
+++ b/rdf/rdf12/rdf-trig/README.md
@@ -1,0 +1,23 @@
+This README is for the W3C RDF-star Working Group's TrigG test suite.
+This test suite contains three kinds of tests:
+
+*  Positive evaluation (`rdft:TestTrigEval`) — a pair of an input TriG file and referenced N-Quads file..
+*  Positive evaluation (`rdft:TestTrigNegativeEval`) — a pair of an input TriG file and referenced N-Quads file..
+*  Positive syntax (`rdft:TestTriGPositiveSyntax`) — an input TriG file with no syntax errors.
+*  Negative syntax (`rdft:TestTriGNegativeSyntax`) — an input TriG file with at least one syntax error.
+
+The `manifest.ttl` files in this directory lists tests in the RDF-star WG's TriG test suite.
+All tests have a name (`mf:name`) and an input (`mf:action`).
+
+• An implementation passes an Evaluation test if it parses the input
+  into a dataset, parses the expected result into another dataset, and
+  those two dataset are isomorphic (see
+  <https://www.w3.org/TR/rdf12-concepts/#dfn-dataset-isomorphism>).
+• An implementation passes an Negative Evaluation test if it parses the input
+  into a dataset, parses the expected result into another dataset, and
+  those two dataset are _not_ isomorphic (see
+  <https://www.w3.org/TR/rdf12-concepts/#dfn-dataset-isomorphism>).
+* An implementation passes a positive syntax test if it parses the input.
+* An implementation passes a negative syntax test if it fails to parse the input.
+
+The home of the test suite is <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/>.

--- a/rdf/rdf12/rdf-trig/eval/index.html
+++ b/rdf/rdf12/rdf-trig/eval/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#manifest' typeof='mf:Manifest'>
+  <body resource='../eval#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -82,9 +82,9 @@
           <a class='testlink' href='#trig-star-1'>
             trig-star-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-1' property='mf:name'>TriG-star - subject quoted triple</span>
+          <span about='../eval#trig-star-1' property='mf:name'>TriG-star - subject quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-1' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-1' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -106,9 +106,9 @@
           <a class='testlink' href='#trig-star-2'>
             trig-star-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-2' property='mf:name'>TriG-star - object quoted triple</span>
+          <span about='../eval#trig-star-2' property='mf:name'>TriG-star - object quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-2' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-2' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -130,9 +130,9 @@
           <a class='testlink' href='#trig-star-bnode-1'>
             trig-star-bnode-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-bnode-1' property='mf:name'>TriG-star - blank node label</span>
+          <span about='../eval#trig-star-bnode-1' property='mf:name'>TriG-star - blank node label</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-bnode-1' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-bnode-1' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -154,9 +154,9 @@
           <a class='testlink' href='#trig-star-bnode-2'>
             trig-star-bnode-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-bnode-2' property='mf:name'>TriG-star - blank node labels</span>
+          <span about='../eval#trig-star-bnode-2' property='mf:name'>TriG-star - blank node labels</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-bnode-2' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-bnode-2' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -178,9 +178,9 @@
           <a class='testlink' href='#trig-star-annotation-1'>
             trig-star-annotation-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-1' property='mf:name'>TriG-star - Annotation form</span>
+          <span about='../eval#trig-star-annotation-1' property='mf:name'>TriG-star - Annotation form</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-1' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-annotation-1' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -202,9 +202,9 @@
           <a class='testlink' href='#trig-star-annotation-2'>
             trig-star-annotation-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-2' property='mf:name'>TriG-star - Annotation example</span>
+          <span about='../eval#trig-star-annotation-2' property='mf:name'>TriG-star - Annotation example</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-2' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-annotation-2' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -226,9 +226,9 @@
           <a class='testlink' href='#trig-star-annotation-3'>
             trig-star-annotation-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-3' property='mf:name'>TriG-star - Annotation - predicate and object lists</span>
+          <span about='../eval#trig-star-annotation-3' property='mf:name'>TriG-star - Annotation - predicate and object lists</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-3' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-annotation-3' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -250,9 +250,9 @@
           <a class='testlink' href='#trig-star-annotation-4'>
             trig-star-annotation-4:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-4' property='mf:name'>TriG-star - Annotation - nested</span>
+          <span about='../eval#trig-star-annotation-4' property='mf:name'>TriG-star - Annotation - nested</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-4' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-annotation-4' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -274,9 +274,9 @@
           <a class='testlink' href='#trig-star-annotation-5'>
             trig-star-annotation-5:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-5' property='mf:name'>TriG-star - Annotation object list</span>
+          <span about='../eval#trig-star-annotation-5' property='mf:name'>TriG-star - Annotation object list</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-annotation-5' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-annotation-5' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -298,9 +298,9 @@
           <a class='testlink' href='#trig-star-quoted-annotation-1'>
             trig-star-quoted-annotation-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-1' property='mf:name'>TriG-star - Annotation with quoting</span>
+          <span about='../eval#trig-star-quoted-annotation-1' property='mf:name'>TriG-star - Annotation with quoting</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-1' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-quoted-annotation-1' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -322,9 +322,9 @@
           <a class='testlink' href='#trig-star-quoted-annotation-2'>
             trig-star-quoted-annotation-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-2' property='mf:name'>TriG-star - Annotation on triple with quoted subject</span>
+          <span about='../eval#trig-star-quoted-annotation-2' property='mf:name'>TriG-star - Annotation on triple with quoted subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-2' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-quoted-annotation-2' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -346,9 +346,9 @@
           <a class='testlink' href='#trig-star-quoted-annotation-3'>
             trig-star-quoted-annotation-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-3' property='mf:name'>TriG-star - Annotation on triple with quoted object</span>
+          <span about='../eval#trig-star-quoted-annotation-3' property='mf:name'>TriG-star - Annotation on triple with quoted object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval#trig-star-quoted-annotation-3' typeof='rdft:TestTrigEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#trig-star-quoted-annotation-3' typeof='rdft:TestTrigEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>

--- a/rdf/rdf12/rdf-trig/eval/manifest.ttl
+++ b/rdf/rdf12/rdf-trig/eval/manifest.ttl
@@ -18,6 +18,7 @@ trs:manifest  rdf:type mf:Manifest ;
    rdfs:label "RDF 1.2 TriG Evaluation Tests"@en ;
    skos:prefLabel "La suite des tests pour évaluation de RDF 1.2 TriG"@fr;
    skos:prefLabel "Conjunto de pruebas para evaluar RDF 1.2 TriG"@es;
+   mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/eval/> ;
    dct:issued "2023-07-20"^^xsd:date ;
    rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
    dct:modified "2023-07-20"^^xsd:date ;

--- a/rdf/rdf12/rdf-trig/index.html
+++ b/rdf/rdf12/rdf-trig/index.html
@@ -31,7 +31,7 @@
       footer {text-align: center;}
     </style>
     <title>
-      RDF 1.1 tests
+      RDF 1.2 TriG tests
     </title>
     <style>
       em.rfc2119 {
@@ -51,21 +51,23 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='./' typeof='mf:Manifest'>
+  <body resource='../rdf-trig#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
       </a>
     </p>
-    <h1 property='rdfs:label'>RDF 1.1 tests</h1>
+    <h1 property='rdfs:label'>RDF 1.2 TriG tests</h1>
     <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
     <hr title='Separator for header'>
     <div>
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
-        <p>These test suites are a product previous RDF working groups, and has been maintained by the <a href="https://www.w3.org/community/rdf-tests/">RDF Test Curation Community Group</a>. Community maintained at <a href="https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/">https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11</a>. Conformance with RDF 1.1 specifications can be determined via successfully running the tests for relevant specifications.</p>
+        <p>These test suites are a product of the <a href="">W3C RDF-star Working Group</a> as well as the RDF-star Interest Group within the W3C RDF-DEV Community Group, and has been maintained by the <a href="https://www.w3.org/community/rdf-tests/">RDF Test Curation Community Group</a> at <a href="https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/">https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11</a>. Conformance with RDF 1.2 specifications can be determined via successfully running the tests for relevant specifications along with the relevant RDF 1.1 tests.</p>
       </p>
-      <p>This page describes W3C RDF 1.1 Working Group's test suite.</p>
+      <p>This page describes W3C RDF-star Working Group's test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -80,22 +82,13 @@
       </h2>
       <ul>
         <li>
-          <a href='rdf-n-triples/index.html' inlist='true' property='mf:include'>rdf-n-triples/</a>
+          <a href='eval/index.html' inlist='true' property='mf:include'>eval/</a>
         </li>
         <li>
-          <a href='rdf-n-quads/index.html' inlist='true' property='mf:include'>rdf-n-quads/</a>
+          <a href='syntax/index.html' inlist='true' property='mf:include'>syntax/</a>
         </li>
         <li>
-          <a href='rdf-mt/index.html' inlist='true' property='mf:include'>rdf-mt/</a>
-        </li>
-        <li>
-          <a href='rdf-turtle/index.html' inlist='true' property='mf:include'>rdf-turtle/</a>
-        </li>
-        <li>
-          <a href='rdf-trig/index.html' inlist='true' property='mf:include'>rdf-trig/</a>
-        </li>
-        <li>
-          <a href='rdf-xml/index.html' inlist='true' property='mf:include'>rdf-xml/</a>
+          <a href='../../rdf11/rdf-trig/index.html' inlist='true' property='mf:include'>../../rdf11/rdf-trig/</a>
         </li>
       </ul>
     </div>

--- a/rdf/rdf12/rdf-trig/manifest.ttl
+++ b/rdf/rdf12/rdf-trig/manifest.ttl
@@ -1,0 +1,37 @@
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+trs:manifest  rdf:type mf:Manifest ;
+  rdfs:label "RDF 1.2 TriG tests"@en ;
+  skos:prefLabel "La suite des tests pour RDF 1.2 TriG"@fr;
+  skos:prefLabel "Conjunto de pruebas para RDF 1.2 TriG"@es;
+  mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/> ;
+  dct:issued "2023-10-28"^^xsd:date ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+  dct:modified "2023-10-28"^^xsd:date ;
+  dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+  rdfs:comment """
+    These test suites are a product of the [W3C RDF-star Working Group]() as well as the
+    RDF-star Interest Group within the W3C RDF-DEV Community Group,
+    and has been maintained by the
+    [RDF Test Curation Community Group](https://www.w3.org/community/rdf-tests/)
+    at [https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/).
+
+    Conformance with RDF 1.2 specifications can be determined via successfully running the
+    tests for relevant specifications
+    along with the relevant RDF 1.1 tests.
+  """;
+  mf:include (
+    <eval/manifest.ttl>
+    <syntax/manifest.ttl>
+    <../../rdf11/rdf-trig/manifest.ttl>
+  ) .
+

--- a/rdf/rdf12/rdf-trig/syntax/index.html
+++ b/rdf/rdf12/rdf-trig/syntax/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#manifest' typeof='mf:Manifest'>
+  <body resource='../syntax#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -82,9 +82,9 @@
           <a class='testlink' href='#trig-star-1'>
             trig-star-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-1' property='mf:name'>TriG-star - subject quoted triple</span>
+          <span about='../syntax#trig-star-1' property='mf:name'>TriG-star - subject quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-1' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-1' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -102,9 +102,9 @@
           <a class='testlink' href='#trig-star-2'>
             trig-star-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-2' property='mf:name'>TriG-star - object quoted triple</span>
+          <span about='../syntax#trig-star-2' property='mf:name'>TriG-star - object quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-2' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-2' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -122,9 +122,9 @@
           <a class='testlink' href='#trig-star-inside-1'>
             trig-star-inside-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-inside-1' property='mf:name'>TriG-star - quoted triple inside blankNodePropertyList</span>
+          <span about='../syntax#trig-star-inside-1' property='mf:name'>TriG-star - quoted triple inside blankNodePropertyList</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-inside-1' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-inside-1' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -142,9 +142,9 @@
           <a class='testlink' href='#trig-star-inside-2'>
             trig-star-inside-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-inside-2' property='mf:name'>TriG-star - quoted triple inside collection</span>
+          <span about='../syntax#trig-star-inside-2' property='mf:name'>TriG-star - quoted triple inside collection</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-inside-2' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-inside-2' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -162,9 +162,9 @@
           <a class='testlink' href='#trig-star-nested-1'>
             trig-star-nested-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-nested-1' property='mf:name'>TriG-star - nested quoted triple, subject position</span>
+          <span about='../syntax#trig-star-nested-1' property='mf:name'>TriG-star - nested quoted triple, subject position</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-nested-1' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-nested-1' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -182,9 +182,9 @@
           <a class='testlink' href='#trig-star-nested-2'>
             trig-star-nested-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-nested-2' property='mf:name'>TriG-star - nested quoted triple, object position</span>
+          <span about='../syntax#trig-star-nested-2' property='mf:name'>TriG-star - nested quoted triple, object position</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-nested-2' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-nested-2' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -202,9 +202,9 @@
           <a class='testlink' href='#trig-star-compound-1'>
             trig-star-compound-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-compound-1' property='mf:name'>TriG-star - compound forms</span>
+          <span about='../syntax#trig-star-compound-1' property='mf:name'>TriG-star - compound forms</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-compound-1' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-compound-1' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -222,9 +222,9 @@
           <a class='testlink' href='#trig-star-bnode-1'>
             trig-star-bnode-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-1' property='mf:name'>TriG-star - blank node subject</span>
+          <span about='../syntax#trig-star-bnode-1' property='mf:name'>TriG-star - blank node subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-1' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bnode-1' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -242,9 +242,9 @@
           <a class='testlink' href='#trig-star-bnode-2'>
             trig-star-bnode-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-2' property='mf:name'>TriG-star - blank node object</span>
+          <span about='../syntax#trig-star-bnode-2' property='mf:name'>TriG-star - blank node object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-2' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bnode-2' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -262,9 +262,9 @@
           <a class='testlink' href='#trig-star-bnode-3'>
             trig-star-bnode-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-3' property='mf:name'>TriG-star - blank node</span>
+          <span about='../syntax#trig-star-bnode-3' property='mf:name'>TriG-star - blank node</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bnode-3' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bnode-3' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -282,9 +282,9 @@
           <a class='testlink' href='#trig-star-bad-1'>
             trig-star-bad-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-1' property='mf:name'>TriG-star - bad - quoted triple as predicate</span>
+          <span about='../syntax#trig-star-bad-1' property='mf:name'>TriG-star - bad - quoted triple as predicate</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-1' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bad-1' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -302,9 +302,9 @@
           <a class='testlink' href='#trig-star-bad-2'>
             trig-star-bad-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-2' property='mf:name'>TriG-star - bad - quoted triple outside triple</span>
+          <span about='../syntax#trig-star-bad-2' property='mf:name'>TriG-star - bad - quoted triple outside triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-2' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bad-2' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -322,9 +322,9 @@
           <a class='testlink' href='#trig-star-bad-3'>
             trig-star-bad-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-3' property='mf:name'>TriG-star - bad - collection list in quoted triple</span>
+          <span about='../syntax#trig-star-bad-3' property='mf:name'>TriG-star - bad - collection list in quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-3' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bad-3' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -342,9 +342,9 @@
           <a class='testlink' href='#trig-star-bad-4'>
             trig-star-bad-4:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-4' property='mf:name'>TriG-star - bad - literal in subject position of quoted triple</span>
+          <span about='../syntax#trig-star-bad-4' property='mf:name'>TriG-star - bad - literal in subject position of quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-4' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bad-4' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -362,9 +362,9 @@
           <a class='testlink' href='#trig-star-bad-5'>
             trig-star-bad-5:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-5' property='mf:name'>TriG-star - bad - blank node  as predicate in quoted triple</span>
+          <span about='../syntax#trig-star-bad-5' property='mf:name'>TriG-star - bad - blank node  as predicate in quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-5' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bad-5' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -382,9 +382,9 @@
           <a class='testlink' href='#trig-star-bad-6'>
             trig-star-bad-6:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-6' property='mf:name'>TriG-star - bad - compound blank node expression</span>
+          <span about='../syntax#trig-star-bad-6' property='mf:name'>TriG-star - bad - compound blank node expression</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-6' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bad-6' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -402,9 +402,9 @@
           <a class='testlink' href='#trig-star-bad-7'>
             trig-star-bad-7:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-7' property='mf:name'>TriG-star - bad - incomplete quoted triple</span>
+          <span about='../syntax#trig-star-bad-7' property='mf:name'>TriG-star - bad - incomplete quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-7' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bad-7' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -422,9 +422,9 @@
           <a class='testlink' href='#trig-star-bad-8'>
             trig-star-bad-8:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-8' property='mf:name'>TriG-star - bad - over-long quoted triple</span>
+          <span about='../syntax#trig-star-bad-8' property='mf:name'>TriG-star - bad - over-long quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-8' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bad-8' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -442,9 +442,9 @@
           <a class='testlink' href='#trig-star-ann-1'>
             trig-star-ann-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-ann-1' property='mf:name'>TriG-star - Annotation form</span>
+          <span about='../syntax#trig-star-ann-1' property='mf:name'>TriG-star - Annotation form</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-ann-1' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-ann-1' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -462,9 +462,9 @@
           <a class='testlink' href='#trig-star-ann-2'>
             trig-star-ann-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-ann-2' property='mf:name'>TriG-star - Annotation example</span>
+          <span about='../syntax#trig-star-ann-2' property='mf:name'>TriG-star - Annotation example</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-ann-2' typeof='rdft:TestTrigPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-ann-2' typeof='rdft:TestTrigPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -482,9 +482,9 @@
           <a class='testlink' href='#trig-star-bad-ann-1'>
             trig-star-bad-ann-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-ann-1' property='mf:name'>TriG-star - bad - empty annotation</span>
+          <span about='../syntax#trig-star-bad-ann-1' property='mf:name'>TriG-star - bad - empty annotation</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-ann-1' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bad-ann-1' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -502,9 +502,9 @@
           <a class='testlink' href='#trig-star-bad-ann-2'>
             trig-star-bad-ann-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-ann-2' property='mf:name'>TriG-star - bad - triple as annotation</span>
+          <span about='../syntax#trig-star-bad-ann-2' property='mf:name'>TriG-star - bad - triple as annotation</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax#trig-star-bad-ann-2' typeof='rdft:TestTrigNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#trig-star-bad-ann-2' typeof='rdft:TestTrigNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>

--- a/rdf/rdf12/rdf-trig/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-trig/syntax/manifest.ttl
@@ -17,6 +17,7 @@ trs:manifest  rdf:type mf:Manifest ;
     rdfs:label "RDF 1.2 TriG Syntax Tests"@en ;
     skos:prefLabel "La suite des tests pour la syntaxe de RDF 1.2 TriG"@fr ;
     skos:prefLabel "Conjunto de pruebas para la sintaxis de RDF 1.2 TriG"@es ;
+    mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax/> ;
     dct:issued "2023-07-20"^^xsd:date ;
     rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
     dct:modified "2023-07-20"^^xsd:date ;

--- a/rdf/rdf12/rdf-turtle/README.md
+++ b/rdf/rdf12/rdf-turtle/README.md
@@ -1,0 +1,23 @@
+This README is for the W3C RDF-star Working Group's Turtle test suite.
+This test suite contains three kinds of tests:
+
+*  Positive evaluation (`rdft:TestTurtleEval`) — a pair of an input Turtle file and referenced N-Quads file..
+*  Positive evaluation (`rdft:TestTurtleNegativeEval`) — a pair of an input Turtle file and referenced N-Quads file..
+*  Positive syntax (`rdft:TestTurtlePositiveSyntax`) — an input Turtle file with no syntax errors.
+*  Negative syntax (`rdft:TestTurtleNegatitveSyntax`) — an input Turtle file with at least one syntax error.
+
+The `manifest.ttl` files in this directory lists tests in the RDF-star WG's Turtle test suite.
+All tests have a name (`mf:name`) and an input (`mf:action`).
+
+• An implementation passes an Evaluation test if it parses the input
+  into a graph, parses the expected result into another graph, and
+  those two graphs are isomorphic (see
+  <http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism>).
+• An implementation passes a Negative Evaluation test if it parses the input
+  into a graph, parses the expected result into another graph, and
+  those two graphs are _not_ isomorphic (see
+  <http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism>).
+* An implementation passes a positive syntax test if it parses the input.
+* An implementation passes a negative syntax test if it fails to parse the input.
+
+The home of the test suite is <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/>.

--- a/rdf/rdf12/rdf-turtle/eval/index.html
+++ b/rdf/rdf12/rdf-turtle/eval/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#manifest' typeof='mf:Manifest'>
+  <body resource='../eval#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -82,9 +82,9 @@
           <a class='testlink' href='#turtle-star-1'>
             turtle-star-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-1' property='mf:name'>Turtle-star - subject quoted triple</span>
+          <span about='../eval#turtle-star-1' property='mf:name'>Turtle-star - subject quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-1' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-1' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -106,9 +106,9 @@
           <a class='testlink' href='#turtle-star-2'>
             turtle-star-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-2' property='mf:name'>Turtle-star - object quoted triple</span>
+          <span about='../eval#turtle-star-2' property='mf:name'>Turtle-star - object quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-2' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-2' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -130,9 +130,9 @@
           <a class='testlink' href='#turtle-star-bnode-1'>
             turtle-star-bnode-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-bnode-1' property='mf:name'>Turtle-star - blank node label</span>
+          <span about='../eval#turtle-star-bnode-1' property='mf:name'>Turtle-star - blank node label</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-bnode-1' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-bnode-1' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -154,9 +154,9 @@
           <a class='testlink' href='#turtle-star-bnode-2'>
             turtle-star-bnode-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-bnode-2' property='mf:name'>Turtle-star - blank node labels</span>
+          <span about='../eval#turtle-star-bnode-2' property='mf:name'>Turtle-star - blank node labels</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-bnode-2' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-bnode-2' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -178,9 +178,9 @@
           <a class='testlink' href='#turtle-star-annotation-1'>
             turtle-star-annotation-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-1' property='mf:name'>Turtle-star - Annotation form</span>
+          <span about='../eval#turtle-star-annotation-1' property='mf:name'>Turtle-star - Annotation form</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-1' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-annotation-1' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -202,9 +202,9 @@
           <a class='testlink' href='#turtle-star-annotation-2'>
             turtle-star-annotation-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-2' property='mf:name'>Turtle-star - Annotation example</span>
+          <span about='../eval#turtle-star-annotation-2' property='mf:name'>Turtle-star - Annotation example</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-2' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-annotation-2' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -226,9 +226,9 @@
           <a class='testlink' href='#turtle-star-annotation-3'>
             turtle-star-annotation-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-3' property='mf:name'>Turtle-star - Annotation - predicate and object lists</span>
+          <span about='../eval#turtle-star-annotation-3' property='mf:name'>Turtle-star - Annotation - predicate and object lists</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-3' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-annotation-3' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -250,9 +250,9 @@
           <a class='testlink' href='#turtle-star-annotation-4'>
             turtle-star-annotation-4:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-4' property='mf:name'>Turtle-star - Annotation - nested</span>
+          <span about='../eval#turtle-star-annotation-4' property='mf:name'>Turtle-star - Annotation - nested</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-4' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-annotation-4' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -274,9 +274,9 @@
           <a class='testlink' href='#turtle-star-annotation-5'>
             turtle-star-annotation-5:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-5' property='mf:name'>Turtle-star - Annotation object list</span>
+          <span about='../eval#turtle-star-annotation-5' property='mf:name'>Turtle-star - Annotation object list</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-annotation-5' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-annotation-5' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -298,9 +298,9 @@
           <a class='testlink' href='#turtle-star-quoted-annotation-1'>
             turtle-star-quoted-annotation-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-1' property='mf:name'>Turtle-star - Annotation with quoting</span>
+          <span about='../eval#turtle-star-quoted-annotation-1' property='mf:name'>Turtle-star - Annotation with quoting</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-1' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-quoted-annotation-1' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -322,9 +322,9 @@
           <a class='testlink' href='#turtle-star-quoted-annotation-2'>
             turtle-star-quoted-annotation-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-2' property='mf:name'>Turtle-star - Annotation on triple with quoted subject</span>
+          <span about='../eval#turtle-star-quoted-annotation-2' property='mf:name'>Turtle-star - Annotation on triple with quoted subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-2' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-quoted-annotation-2' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -346,9 +346,9 @@
           <a class='testlink' href='#turtle-star-quoted-annotation-3'>
             turtle-star-quoted-annotation-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-3' property='mf:name'>Turtle-star - Annotation on triple with quoted object</span>
+          <span about='../eval#turtle-star-quoted-annotation-3' property='mf:name'>Turtle-star - Annotation on triple with quoted object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval#turtle-star-quoted-annotation-3' typeof='rdft:TestTurtleEval'>
+        <dd inlist='true' property='mf:entry' resource='../eval#turtle-star-quoted-annotation-3' typeof='rdft:TestTurtleEval'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>

--- a/rdf/rdf12/rdf-turtle/eval/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/manifest.ttl
@@ -18,6 +18,7 @@ trs:manifest  rdf:type mf:Manifest ;
    rdfs:label "RDF 1.2 Turtle Evaluation Tests"@en ;
    skos:prefLabel "La suite des tests pour RDF 1.2 Turtle"@fr;
    skos:prefLabel "Conjunto de pruebas para RDF 1.2 Turtle"@es;
+   mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/eval/> ;
    dct:issued "2023-07-20"^^xsd:date ;
    rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
    dct:modified "2023-07-20"^^xsd:date ;

--- a/rdf/rdf12/rdf-turtle/index.html
+++ b/rdf/rdf12/rdf-turtle/index.html
@@ -31,7 +31,7 @@
       footer {text-align: center;}
     </style>
     <title>
-      RDF 1.1 tests
+      RDF 1.2 Turtle tests
     </title>
     <style>
       em.rfc2119 {
@@ -51,21 +51,23 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='./' typeof='mf:Manifest'>
+  <body resource='../rdf-turtle#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
       </a>
     </p>
-    <h1 property='rdfs:label'>RDF 1.1 tests</h1>
+    <h1 property='rdfs:label'>RDF 1.2 Turtle tests</h1>
     <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2004-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
     <hr title='Separator for header'>
     <div>
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
-        <p>These test suites are a product previous RDF working groups, and has been maintained by the <a href="https://www.w3.org/community/rdf-tests/">RDF Test Curation Community Group</a>. Community maintained at <a href="https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/">https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11</a>. Conformance with RDF 1.1 specifications can be determined via successfully running the tests for relevant specifications.</p>
+        <p>These test suites are a product of the <a href="">W3C RDF-star Working Group</a> as well as the RDF-star Interest Group within the W3C RDF-DEV Community Group, and has been maintained by the <a href="https://www.w3.org/community/rdf-tests/">RDF Test Curation Community Group</a> at <a href="https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/">https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11</a>. Conformance with RDF 1.2 specifications can be determined via successfully running the tests for relevant specifications along with the relevant RDF 1.1 tests.</p>
       </p>
-      <p>This page describes W3C RDF 1.1 Working Group's test suite.</p>
+      <p>This page describes W3C RDF-star Working Group's test suite for RDF 1.2.
+        Conformance for RDF 1.2 requires conforming with tests in this test suite
+        along with the relevant RDF 1.2 tests.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -80,22 +82,13 @@
       </h2>
       <ul>
         <li>
-          <a href='rdf-n-triples/index.html' inlist='true' property='mf:include'>rdf-n-triples/</a>
+          <a href='eval/index.html' inlist='true' property='mf:include'>eval/</a>
         </li>
         <li>
-          <a href='rdf-n-quads/index.html' inlist='true' property='mf:include'>rdf-n-quads/</a>
+          <a href='syntax/index.html' inlist='true' property='mf:include'>syntax/</a>
         </li>
         <li>
-          <a href='rdf-mt/index.html' inlist='true' property='mf:include'>rdf-mt/</a>
-        </li>
-        <li>
-          <a href='rdf-turtle/index.html' inlist='true' property='mf:include'>rdf-turtle/</a>
-        </li>
-        <li>
-          <a href='rdf-trig/index.html' inlist='true' property='mf:include'>rdf-trig/</a>
-        </li>
-        <li>
-          <a href='rdf-xml/index.html' inlist='true' property='mf:include'>rdf-xml/</a>
+          <a href='../../rdf11/rdf-turtle/index.html' inlist='true' property='mf:include'>../../rdf11/rdf-turtle/</a>
         </li>
       </ul>
     </div>

--- a/rdf/rdf12/rdf-turtle/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/manifest.ttl
@@ -1,0 +1,37 @@
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+trs:manifest  rdf:type mf:Manifest ;
+  rdfs:label "RDF 1.2 Turtle tests"@en ;
+  skos:prefLabel "La suite des tests pour RDF 1.2 Turtle"@fr;
+  skos:prefLabel "Conjunto de pruebas para RDF 1.2 Turtle"@es;
+  mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/> ;
+  dct:issued "2023-10-28"^^xsd:date ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+  dct:modified "2023-10-28"^^xsd:date ;
+  dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+  rdfs:comment """
+    These test suites are a product of the [W3C RDF-star Working Group]() as well as the
+    RDF-star Interest Group within the W3C RDF-DEV Community Group,
+    and has been maintained by the
+    [RDF Test Curation Community Group](https://www.w3.org/community/rdf-tests/)
+    at [https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11](https://github.com/w3c/rdf-tests/tree/main/rdf/rdf11/).
+
+    Conformance with RDF 1.2 specifications can be determined via successfully running the
+    tests for relevant specifications
+    along with the relevant RDF 1.1 tests.
+  """;
+  mf:include (
+    <eval/manifest.ttl>
+    <syntax/manifest.ttl>
+    <../../rdf11/rdf-turtle/manifest.ttl>
+  ) .
+

--- a/rdf/rdf12/rdf-turtle/syntax/index.html
+++ b/rdf/rdf12/rdf-turtle/syntax/index.html
@@ -51,7 +51,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#manifest' typeof='mf:Manifest'>
+  <body resource='../syntax#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -82,9 +82,9 @@
           <a class='testlink' href='#turtle-star-1'>
             turtle-star-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-1' property='mf:name'>Turtle-star - subject quoted triple</span>
+          <span about='../syntax#turtle-star-1' property='mf:name'>Turtle-star - subject quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-1' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-1' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -102,9 +102,9 @@
           <a class='testlink' href='#turtle-star-2'>
             turtle-star-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-2' property='mf:name'>Turtle-star - object quoted triple</span>
+          <span about='../syntax#turtle-star-2' property='mf:name'>Turtle-star - object quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-2' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-2' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -122,9 +122,9 @@
           <a class='testlink' href='#turtle-star-inside-1'>
             turtle-star-inside-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-inside-1' property='mf:name'>Turtle-star - quoted triple inside blankNodePropertyList</span>
+          <span about='../syntax#turtle-star-inside-1' property='mf:name'>Turtle-star - quoted triple inside blankNodePropertyList</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-inside-1' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-inside-1' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -142,9 +142,9 @@
           <a class='testlink' href='#turtle-star-inside-2'>
             turtle-star-inside-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-inside-2' property='mf:name'>Turtle-star - quoted triple inside collection</span>
+          <span about='../syntax#turtle-star-inside-2' property='mf:name'>Turtle-star - quoted triple inside collection</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-inside-2' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-inside-2' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -162,9 +162,9 @@
           <a class='testlink' href='#turtle-star-nested-1'>
             turtle-star-nested-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-nested-1' property='mf:name'>Turtle-star - nested quoted triple, subject position</span>
+          <span about='../syntax#turtle-star-nested-1' property='mf:name'>Turtle-star - nested quoted triple, subject position</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-nested-1' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-nested-1' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -182,9 +182,9 @@
           <a class='testlink' href='#turtle-star-nested-2'>
             turtle-star-nested-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-nested-2' property='mf:name'>Turtle-star - nested quoted triple, object position</span>
+          <span about='../syntax#turtle-star-nested-2' property='mf:name'>Turtle-star - nested quoted triple, object position</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-nested-2' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-nested-2' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -202,9 +202,9 @@
           <a class='testlink' href='#turtle-star-compound-1'>
             turtle-star-compound-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-compound-1' property='mf:name'>Turtle-star - compound forms</span>
+          <span about='../syntax#turtle-star-compound-1' property='mf:name'>Turtle-star - compound forms</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-compound-1' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-compound-1' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -222,9 +222,9 @@
           <a class='testlink' href='#turtle-star-bnode-1'>
             turtle-star-bnode-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-1' property='mf:name'>Turtle-star - blank node subject</span>
+          <span about='../syntax#turtle-star-bnode-1' property='mf:name'>Turtle-star - blank node subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-1' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bnode-1' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -242,9 +242,9 @@
           <a class='testlink' href='#turtle-star-bnode-2'>
             turtle-star-bnode-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-2' property='mf:name'>Turtle-star - blank node object</span>
+          <span about='../syntax#turtle-star-bnode-2' property='mf:name'>Turtle-star - blank node object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-2' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bnode-2' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -262,9 +262,9 @@
           <a class='testlink' href='#turtle-star-bnode-3'>
             turtle-star-bnode-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-3' property='mf:name'>Turtle-star - blank node</span>
+          <span about='../syntax#turtle-star-bnode-3' property='mf:name'>Turtle-star - blank node</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bnode-3' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bnode-3' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -282,9 +282,9 @@
           <a class='testlink' href='#turtle-star-bad-1'>
             turtle-star-bad-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-1' property='mf:name'>Turtle-star - bad - quoted triple as predicate</span>
+          <span about='../syntax#turtle-star-bad-1' property='mf:name'>Turtle-star - bad - quoted triple as predicate</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-1' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bad-1' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -302,9 +302,9 @@
           <a class='testlink' href='#turtle-star-bad-2'>
             turtle-star-bad-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-2' property='mf:name'>Turtle-star - bad - quoted triple outside triple</span>
+          <span about='../syntax#turtle-star-bad-2' property='mf:name'>Turtle-star - bad - quoted triple outside triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-2' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bad-2' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -322,9 +322,9 @@
           <a class='testlink' href='#turtle-star-bad-3'>
             turtle-star-bad-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-3' property='mf:name'>Turtle-star - bad - collection list in quoted triple</span>
+          <span about='../syntax#turtle-star-bad-3' property='mf:name'>Turtle-star - bad - collection list in quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-3' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bad-3' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -342,9 +342,9 @@
           <a class='testlink' href='#turtle-star-bad-4'>
             turtle-star-bad-4:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-4' property='mf:name'>Turtle-star - bad - literal in subject position of quoted triple</span>
+          <span about='../syntax#turtle-star-bad-4' property='mf:name'>Turtle-star - bad - literal in subject position of quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-4' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bad-4' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -362,9 +362,9 @@
           <a class='testlink' href='#turtle-star-bad-5'>
             turtle-star-bad-5:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-5' property='mf:name'>Turtle-star - bad - blank node  as predicate in quoted triple</span>
+          <span about='../syntax#turtle-star-bad-5' property='mf:name'>Turtle-star - bad - blank node  as predicate in quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-5' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bad-5' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -382,9 +382,9 @@
           <a class='testlink' href='#turtle-star-bad-6'>
             turtle-star-bad-6:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-6' property='mf:name'>Turtle-star - bad - compound blank node expression</span>
+          <span about='../syntax#turtle-star-bad-6' property='mf:name'>Turtle-star - bad - compound blank node expression</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-6' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bad-6' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -402,9 +402,9 @@
           <a class='testlink' href='#turtle-star-bad-7'>
             turtle-star-bad-7:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-7' property='mf:name'>Turtle-star - bad - incomplete quoted triple</span>
+          <span about='../syntax#turtle-star-bad-7' property='mf:name'>Turtle-star - bad - incomplete quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-7' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bad-7' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -422,9 +422,9 @@
           <a class='testlink' href='#turtle-star-bad-8'>
             turtle-star-bad-8:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-8' property='mf:name'>Turtle-star - bad - over-long quoted triple</span>
+          <span about='../syntax#turtle-star-bad-8' property='mf:name'>Turtle-star - bad - over-long quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-8' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bad-8' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -442,9 +442,9 @@
           <a class='testlink' href='#turtle-star-ann-1'>
             turtle-star-ann-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-ann-1' property='mf:name'>Turtle-star - Annotation form</span>
+          <span about='../syntax#turtle-star-ann-1' property='mf:name'>Turtle-star - Annotation form</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-ann-1' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-ann-1' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -462,9 +462,9 @@
           <a class='testlink' href='#turtle-star-ann-2'>
             turtle-star-ann-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-ann-2' property='mf:name'>Turtle-star - Annotation example</span>
+          <span about='../syntax#turtle-star-ann-2' property='mf:name'>Turtle-star - Annotation example</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-ann-2' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-ann-2' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -482,9 +482,9 @@
           <a class='testlink' href='#turtle-star-bad-ann-1'>
             turtle-star-bad-ann-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-ann-1' property='mf:name'>Turtle-star - bad - empty annotation</span>
+          <span about='../syntax#turtle-star-bad-ann-1' property='mf:name'>Turtle-star - bad - empty annotation</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-ann-1' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bad-ann-1' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -502,9 +502,9 @@
           <a class='testlink' href='#turtle-star-bad-ann-2'>
             turtle-star-bad-ann-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-ann-2' property='mf:name'>Turtle-star - bad - triple as annotation</span>
+          <span about='../syntax#turtle-star-bad-ann-2' property='mf:name'>Turtle-star - bad - triple as annotation</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#turtle-star-bad-ann-2' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle-star-bad-ann-2' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -522,9 +522,9 @@
           <a class='testlink' href='#nt-ttl-star-1'>
             nt-ttl-star-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-1' property='mf:name'>N-Triples-star as Turtle-star - subject quoted triple</span>
+          <span about='../syntax#nt-ttl-star-1' property='mf:name'>N-Triples-star as Turtle-star - subject quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-1' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-1' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -542,9 +542,9 @@
           <a class='testlink' href='#nt-ttl-star-2'>
             nt-ttl-star-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-2' property='mf:name'>N-Triples-star as Turtle-star - object quoted triple</span>
+          <span about='../syntax#nt-ttl-star-2' property='mf:name'>N-Triples-star as Turtle-star - object quoted triple</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-2' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-2' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -562,9 +562,9 @@
           <a class='testlink' href='#nt-ttl-star-3'>
             nt-ttl-star-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-3' property='mf:name'>N-Triples-star as Turtle-star - subject and object quoted triples</span>
+          <span about='../syntax#nt-ttl-star-3' property='mf:name'>N-Triples-star as Turtle-star - subject and object quoted triples</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-3' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-3' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -582,9 +582,9 @@
           <a class='testlink' href='#nt-ttl-star-4'>
             nt-ttl-star-4:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-4' property='mf:name'>N-Triples-star as Turtle-star - whitespace and terms</span>
+          <span about='../syntax#nt-ttl-star-4' property='mf:name'>N-Triples-star as Turtle-star - whitespace and terms</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-4' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-4' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -602,9 +602,9 @@
           <a class='testlink' href='#nt-ttl-star-5'>
             nt-ttl-star-5:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-5' property='mf:name'>N-Triples-star as Turtle-star - Nested, no whitespace</span>
+          <span about='../syntax#nt-ttl-star-5' property='mf:name'>N-Triples-star as Turtle-star - Nested, no whitespace</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-5' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-5' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -622,9 +622,9 @@
           <a class='testlink' href='#nt-ttl-star-bnode-1'>
             nt-ttl-star-bnode-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bnode-1' property='mf:name'>N-Triples-star as Turtle-star - Blank node subject</span>
+          <span about='../syntax#nt-ttl-star-bnode-1' property='mf:name'>N-Triples-star as Turtle-star - Blank node subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bnode-1' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-bnode-1' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -642,9 +642,9 @@
           <a class='testlink' href='#nt-ttl-star-bnode-2'>
             nt-ttl-star-bnode-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bnode-2' property='mf:name'>N-Triples-star as Turtle-star - Blank node object</span>
+          <span about='../syntax#nt-ttl-star-bnode-2' property='mf:name'>N-Triples-star as Turtle-star - Blank node object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bnode-2' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-bnode-2' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -662,9 +662,9 @@
           <a class='testlink' href='#nt-ttl-star-nested-1'>
             nt-ttl-star-nested-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-nested-1' property='mf:name'>N-Triples-star as Turtle-star - Nested subject term</span>
+          <span about='../syntax#nt-ttl-star-nested-1' property='mf:name'>N-Triples-star as Turtle-star - Nested subject term</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-nested-1' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-nested-1' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -682,9 +682,9 @@
           <a class='testlink' href='#nt-ttl-star-nested-2'>
             nt-ttl-star-nested-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-nested-2' property='mf:name'>N-Triples-star as Turtle-star - Nested object term</span>
+          <span about='../syntax#nt-ttl-star-nested-2' property='mf:name'>N-Triples-star as Turtle-star - Nested object term</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-nested-2' typeof='rdft:TestTurtlePositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-nested-2' typeof='rdft:TestTurtlePositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -702,9 +702,9 @@
           <a class='testlink' href='#nt-ttl-star-bad-1'>
             nt-ttl-star-bad-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-1' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple as predicate</span>
+          <span about='../syntax#nt-ttl-star-bad-1' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple as predicate</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-1' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-bad-1' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -722,9 +722,9 @@
           <a class='testlink' href='#nt-ttl-star-bad-2'>
             nt-ttl-star-bad-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-2' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple, literal subject</span>
+          <span about='../syntax#nt-ttl-star-bad-2' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple, literal subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-2' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-bad-2' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -742,9 +742,9 @@
           <a class='testlink' href='#nt-ttl-star-bad-3'>
             nt-ttl-star-bad-3:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-3' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple, literal predicate</span>
+          <span about='../syntax#nt-ttl-star-bad-3' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple, literal predicate</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-3' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-bad-3' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -762,9 +762,9 @@
           <a class='testlink' href='#nt-ttl-star-bad-4'>
             nt-ttl-star-bad-4:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-4' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple, blank node predicate</span>
+          <span about='../syntax#nt-ttl-star-bad-4' property='mf:name'>N-Triples-star as Turtle-star - Bad - quoted triple, blank node predicate</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#nt-ttl-star-bad-4' typeof='rdft:TestTurtleNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#nt-ttl-star-bad-4' typeof='rdft:TestTurtleNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>

--- a/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
@@ -17,6 +17,7 @@ trs:manifest  rdf:type mf:Manifest ;
    rdfs:label "RDF 1.2 Turtle Syntax Tests"@en ;
    skos:prefLabel "La suite des tests pour la syntaxe RDF 1.2 Turtle"@fr ;
    skos:prefLabel "Conjunto de pruebas para la sintaxis RDF 1.2 Turtle"@es ;
+   mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax/> ;
    dct:issued "2023-07-20"^^xsd:date ; 
    dct:modified "2023-07-20"^^xsd:date ; 
    dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;

--- a/sparql/sparql10/algebra/index.html
+++ b/sparql/sparql10/algebra/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/ask/index.html
+++ b/sparql/sparql10/ask/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/basic/index.html
+++ b/sparql/sparql10/basic/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/boolean-effective-value/index.html
+++ b/sparql/sparql10/boolean-effective-value/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/bound/index.html
+++ b/sparql/sparql10/bound/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/cast/index.html
+++ b/sparql/sparql10/cast/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/dataset/index.html
+++ b/sparql/sparql10/dataset/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/distinct/index.html
+++ b/sparql/sparql10/distinct/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/expr-builtin/index.html
+++ b/sparql/sparql10/expr-builtin/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/expr-equals/index.html
+++ b/sparql/sparql10/expr-equals/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/expr-ops/index.html
+++ b/sparql/sparql10/expr-ops/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/graph/index.html
+++ b/sparql/sparql10/graph/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/i18n/index.html
+++ b/sparql/sparql10/i18n/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/index-evaluation.html
+++ b/sparql/sparql10/index-evaluation.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='manifest-evaluation.ttl' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/index-syntax.html
+++ b/sparql/sparql10/index-syntax.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='manifest-syntax.ttl' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/index.html
+++ b/sparql/sparql10/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/open-world/index.html
+++ b/sparql/sparql10/open-world/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/optional-filter/index.html
+++ b/sparql/sparql10/optional-filter/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/optional/index.html
+++ b/sparql/sparql10/optional/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/reduced/index.html
+++ b/sparql/sparql10/reduced/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/regex/index.html
+++ b/sparql/sparql10/regex/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/solution-seq/index.html
+++ b/sparql/sparql10/solution-seq/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/sort/index.html
+++ b/sparql/sparql10/sort/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/syntax-sparql1/index.html
+++ b/sparql/sparql10/syntax-sparql1/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql10/syntax-sparql2/index.html
+++ b/sparql/sparql10/syntax-sparql2/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/add/index.html
+++ b/sparql/sparql11/add/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/aggregates/index.html
+++ b/sparql/sparql11/aggregates/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/basic-update/index.html
+++ b/sparql/sparql11/basic-update/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/bind/index.html
+++ b/sparql/sparql11/bind/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/bindings/index.html
+++ b/sparql/sparql11/bindings/index.html
@@ -49,7 +49,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/cast/index.html
+++ b/sparql/sparql11/cast/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/clear/index.html
+++ b/sparql/sparql11/clear/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/construct/index.html
+++ b/sparql/sparql11/construct/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/copy/index.html
+++ b/sparql/sparql11/copy/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/csv-tsv-res/index.html
+++ b/sparql/sparql11/csv-tsv-res/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/delete-data/index.html
+++ b/sparql/sparql11/delete-data/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/delete-insert/index.html
+++ b/sparql/sparql11/delete-insert/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/delete-where/index.html
+++ b/sparql/sparql11/delete-where/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/delete/index.html
+++ b/sparql/sparql11/delete/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/drop/index.html
+++ b/sparql/sparql11/drop/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/entailment/index.html
+++ b/sparql/sparql11/entailment/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/exists/index.html
+++ b/sparql/sparql11/exists/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/functions/index.html
+++ b/sparql/sparql11/functions/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/grouping/index.html
+++ b/sparql/sparql11/grouping/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/index-all.html
+++ b/sparql/sparql11/index-all.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='manifest-all.ttl' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/index-sparql11-fed.html
+++ b/sparql/sparql11/index-sparql11-fed.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='manifest-sparql11-fed.ttl' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/index-sparql11-query.html
+++ b/sparql/sparql11/index-sparql11-query.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='manifest-sparql11-query.ttl' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/index-sparql11-results.html
+++ b/sparql/sparql11/index-sparql11-results.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='manifest-sparql11-results.ttl' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/index-sparql11-update.html
+++ b/sparql/sparql11/index-sparql11-update.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='manifest-sparql11-update.ttl' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/json-res/index.html
+++ b/sparql/sparql11/json-res/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/move/index.html
+++ b/sparql/sparql11/move/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/negation/index.html
+++ b/sparql/sparql11/negation/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/project-expression/index.html
+++ b/sparql/sparql11/project-expression/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/property-path/index.html
+++ b/sparql/sparql11/property-path/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/service-description/index.html
+++ b/sparql/sparql11/service-description/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/service/index.html
+++ b/sparql/sparql11/service/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/subquery/index.html
+++ b/sparql/sparql11/subquery/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/syntax-fed/index.html
+++ b/sparql/sparql11/syntax-fed/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>

--- a/sparql/sparql11/syntax-query/index.html
+++ b/sparql/sparql11/syntax-query/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>


### PR DESCRIPTION
referencing the RDF 1.1 manifests as well.

Specs can now be updated to reference, e.g., https://w3c.github.io/rdf-tests/rdf12/rdf-n-triples/, which will include all related RDF 1.2 manifests as well as the original RDF 1.1 manifest.