### PR TITLE
Adds missing prefix definitions for bad syntax tests.

### DIFF
--- a/rdf/rdf11/rdf-trig/trig-syntax-bad-missing-ns-dot-end.trig
+++ b/rdf/rdf11/rdf-trig/trig-syntax-bad-missing-ns-dot-end.trig
@@ -1,1 +1,4 @@
+@prefix valid: <http://example.com/v#> .
+@prefix invalid.: <http://example.com/i#> .
+
 {valid:s valid:p invalid.:o .}

--- a/rdf/rdf11/rdf-trig/trig-syntax-bad-missing-ns-dot-end.trig
+++ b/rdf/rdf11/rdf-trig/trig-syntax-bad-missing-ns-dot-end.trig
@@ -1,4 +1,4 @@
-@prefix valid: <http://example.com/v#> .
-@prefix invalid.: <http://example.com/i#> .
+PREFIX valid: <http://example.com/v#>
+PREFIX invalid.: <http://example.com/i#>
 
 {valid:s valid:p invalid.:o .}

--- a/rdf/rdf11/rdf-trig/trig-syntax-bad-missing-ns-dot-start.trig
+++ b/rdf/rdf11/rdf-trig/trig-syntax-bad-missing-ns-dot-start.trig
@@ -1,1 +1,3 @@
+@prefix .undefined: <http://example.com/u#> .
+
 {.undefined:s .undefined:p .undefined:o .}

--- a/rdf/rdf11/rdf-trig/trig-syntax-bad-missing-ns-dot-start.trig
+++ b/rdf/rdf11/rdf-trig/trig-syntax-bad-missing-ns-dot-start.trig
@@ -1,3 +1,3 @@
-@prefix .undefined: <http://example.com/u#> .
+PREFIX .undefined: <http://example.com/u#>
 
 {.undefined:s .undefined:p .undefined:o .}

--- a/rdf/rdf11/rdf-turtle/turtle-syntax-bad-missing-ns-dot-end.ttl
+++ b/rdf/rdf11/rdf-turtle/turtle-syntax-bad-missing-ns-dot-end.ttl
@@ -1,1 +1,4 @@
+@prefix valid: <http://example.com/v#> .
+@prefix invalid.: <http://example.com/i#> .
+
 valid:s valid:p invalid.:o .

--- a/rdf/rdf11/rdf-turtle/turtle-syntax-bad-missing-ns-dot-end.ttl
+++ b/rdf/rdf11/rdf-turtle/turtle-syntax-bad-missing-ns-dot-end.ttl
@@ -1,4 +1,4 @@
-@prefix valid: <http://example.com/v#> .
-@prefix invalid.: <http://example.com/i#> .
+PREFIX valid: <http://example.com/v#>
+PREFIX invalid.: <http://example.com/i#>
 
 valid:s valid:p invalid.:o .

--- a/rdf/rdf11/rdf-turtle/turtle-syntax-bad-missing-ns-dot-start.ttl
+++ b/rdf/rdf11/rdf-turtle/turtle-syntax-bad-missing-ns-dot-start.ttl
@@ -1,1 +1,3 @@
+@prefix .undefined: <http://example.com/u#> .
+
 .undefined:s .undefined:p .undefined:o .

--- a/rdf/rdf11/rdf-turtle/turtle-syntax-bad-missing-ns-dot-start.ttl
+++ b/rdf/rdf11/rdf-turtle/turtle-syntax-bad-missing-ns-dot-start.ttl
@@ -1,3 +1,3 @@
-@prefix .undefined: <http://example.com/u#> .
+PREFIX .undefined: <http://example.com/u#>
 
 .undefined:s .undefined:p .undefined:o .


### PR DESCRIPTION
This has been around since 2015.

Fixes #9.