### PR TITLE
Make links from index to rollup manifests for syntaxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,12 +179,11 @@ em.rfc2119 {
     <ul>
       <li><a href="rdf/rdf12/">RDF 1.2</a>
         <ul>
-          <li><a href="rdf/rdf12/rdf-n-triples/syntax">N-Triples syntax tests</a></li>
+          <li><a href="rdf/rdf12/rdf-n-triples">N-Triples tests</a> (includes 1.1 tests)</li>
+          <!--li><a href="rdf/rdf12/rdf-n-quads">N-Quads tests</a> (includes 1.1 tests)</li-->
           <li><a href="rdf/rdf12/rdf-semantics">Semantics tests</a></li>
-          <li><a href="rdf/rdf12/rdf-turtle/syntax">Turtle syntax tests</a></li>
-          <li><a href="rdf/rdf12/rdf-turtle/eval">Turtle evaluation tests</a></li>
-          <li><a href="rdf/rdf12/rdf-trig/syntax">TriG syntax tests</a></li>
-          <li><a href="rdf/rdf12/rdf-trig/eval">TriG evaluation tests</a></li>
+          <li><a href="rdf/rdf12/rdf-turtle">Turtle tests</a> (includes 1.1 tests)</li>
+          <li><a href="rdf/rdf12/rdf-trig">TriG tests</a> (includes 1.1 tests)</li>
         </ul>
       </li>
       <li><a href="rdf/rdf11/">RDF 1.1 tests</a>
@@ -228,6 +227,6 @@ Note that naming conventions for tests often make conflicting overlaps inevitabl
 <li>Implementations can typically access a given test suite using the <a href="https://w3c.github.io/rdf-tests/" target="_blank" rel="external nofollow">HTML view</a>. For example, the Turtle test manifest can be accessed at  <a href="https://w3c.github.io/rdf-tests/turtle/manifest.ttl" rel="external nofollow">https://w3c.github.io/rdf-tests/turtle/manifest.ttl</a>. Accessing test suites though an alternative branch via HTTP requires the use of a different facility, such as <a href="https://raw.githubusercontent.com/w3c/rdf-tests/main/turtle/manifest.ttl" target="_blank" rel="external nofollow">https://raw.githubusercontent.com/w3c/rdf-tests/main/turtle/manifest.ttl</a>, where &#8220;main&#8221; is replaced by the appropriate branch name.</li>
 </ul>
 
-<p>The group is chaired by <a href="http://greggkellogg.net/foaf#me">Gregg Kellogg</a>. The W3C staff contact is xxx. If you are member of the Community Group, and you want to gain a “push” right to this repository, please contact <a href="mailto:gregg@greggkellogg.net">gregg@greggkellogg.net</a>, providing your github ID.</p>
+<p>The group is chaired by <a href="http://greggkellogg.net/foaf#me">Gregg Kellogg</a>. The W3C staff contact is <a href="https://www.w3.org/2011/rdf-wg/wiki/User:Pchampin">Pierre-Antoine Champin</a>. If you are member of the Community Group, and you want to gain a “push” right to this repository, please contact <a href="mailto:gregg@greggkellogg.net">gregg@greggkellogg.net</a>, providing your github ID.</p>
 </body>
 </html>

--- a/rdf/rdf12/index.html
+++ b/rdf/rdf12/index.html
@@ -82,25 +82,16 @@
       </h2>
       <ul>
         <li>
-          <a href='rdf-n-triples/c14n/index.html' inlist='true' property='mf:include'>rdf-n-triples/c14n/</a>
-        </li>
-        <li>
-          <a href='rdf-n-triples/syntax/index.html' inlist='true' property='mf:include'>rdf-n-triples/syntax/</a>
+          <a href='rdf-n-triples/index.html' inlist='true' property='mf:include'>rdf-n-triples/</a>
         </li>
         <li>
           <a href='rdf-semantics/index.html' inlist='true' property='mf:include'>rdf-semantics/</a>
         </li>
         <li>
-          <a href='rdf-turtle/syntax/index.html' inlist='true' property='mf:include'>rdf-turtle/syntax/</a>
+          <a href='rdf-turtle/index.html' inlist='true' property='mf:include'>rdf-turtle/</a>
         </li>
         <li>
-          <a href='rdf-turtle/eval/index.html' inlist='true' property='mf:include'>rdf-turtle/eval/</a>
-        </li>
-        <li>
-          <a href='rdf-trig/syntax/index.html' inlist='true' property='mf:include'>rdf-trig/syntax/</a>
-        </li>
-        <li>
-          <a href='rdf-trig/eval/index.html' inlist='true' property='mf:include'>rdf-trig/eval/</a>
+          <a href='rdf-trig/index.html' inlist='true' property='mf:include'>rdf-trig/</a>
         </li>
       </ul>
     </div>

--- a/rdf/rdf12/manifest.ttl
+++ b/rdf/rdf12/manifest.ttl
@@ -32,12 +32,9 @@ trs:manifest  rdf:type mf:Manifest ;
     along with the relevant RDF 1.1 tests.
   """;
   mf:include (
-    <rdf-n-triples/c14n/manifest.ttl>
-    <rdf-n-triples/syntax/manifest.ttl>
+    <rdf-n-triples/manifest.ttl>
     <rdf-semantics/manifest.ttl>
-    <rdf-turtle/syntax/manifest.ttl>
-    <rdf-turtle/eval/manifest.ttl>
-    <rdf-trig/syntax/manifest.ttl>
-    <rdf-trig/eval/manifest.ttl>
+    <rdf-turtle/manifest.ttl>
+    <rdf-trig/manifest.ttl>
   ) .
 

--- a/rdf/rdf12/rdf-n-triples/c14n/index.html
+++ b/rdf/rdf12/rdf-n-triples/c14n/index.html
@@ -235,9 +235,9 @@
           <a class='testlink' href='#dirlangtagged_string'>
             dirlangtagged_string:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#dirlangtagged_string' property='mf:name'>C14N literal with base direction ltr</span>
+          <span about='../c14n#dirlangtagged_string' property='mf:name'>C14N literal with base direction ltr</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/c14n#dirlangtagged_string' typeof='rdft:TestNTriplesPositiveC14N'>
+        <dd inlist='true' property='mf:entry' resource='../c14n#dirlangtagged_string' typeof='rdft:TestNTriplesPositiveC14N'>
           <div property='rdfs:comment'>
             <p>Tests canonicalization of triples including directional language-tagged string</p>
           </div>

--- a/rdf/rdf12/rdf-n-triples/syntax/index.html
+++ b/rdf/rdf12/rdf-n-triples/syntax/index.html
@@ -262,9 +262,9 @@
           <a class='testlink' href='#ntriples-base-1'>
             ntriples-base-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-base-1' property='mf:name'>N-Triples literal with base direction ltr</span>
+          <span about='../syntax#ntriples-base-1' property='mf:name'>N-Triples literal with base direction ltr</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-base-1' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-base-1' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -282,9 +282,9 @@
           <a class='testlink' href='#ntriples-base-2'>
             ntriples-base-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-base-2' property='mf:name'>N-Triples literal with base direction rtl</span>
+          <span about='../syntax#ntriples-base-2' property='mf:name'>N-Triples literal with base direction rtl</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-base-2' typeof='rdft:TestNTriplesPositiveSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-base-2' typeof='rdft:TestNTriplesPositiveSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -462,9 +462,9 @@
           <a class='testlink' href='#ntriples-base-bad-1'>
             ntriples-base-bad-1:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-base-bad-1' property='mf:name'>N-Triples literal- Bad - undefined base direction</span>
+          <span about='../syntax#ntriples-base-bad-1' property='mf:name'>N-Triples literal- Bad - undefined base direction</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-base-bad-1' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-base-bad-1' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>
@@ -482,9 +482,9 @@
           <a class='testlink' href='#ntriples-base-bad-2'>
             ntriples-base-bad-2:
           </a>
-          <span about='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-base-bad-2' property='mf:name'>N-Triples literal- Bad - upper case LTR</span>
+          <span about='../syntax#ntriples-base-bad-2' property='mf:name'>N-Triples literal- Bad - upper case LTR</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax#ntriples-base-bad-2' typeof='rdft:TestNTriplesNegativeSyntax'>
+        <dd inlist='true' property='mf:entry' resource='../syntax#ntriples-base-bad-2' typeof='rdft:TestNTriplesNegativeSyntax'>
           <div property='rdfs:comment'>
           </div>
           <dl class='test-detail'>

--- a/sparql/sparql10/syntax-sparql3/index.html
+++ b/sparql/sparql10/syntax-sparql3/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>


### PR DESCRIPTION
N-Triples, TriG, and Turtle, as well as links from the rdf/rdf12/manifest.ttl.

This includes a manifest.ttl in /sparql, /sparql10, /sparql11, /rdf/rdf11, and /rdf/rdf12 that includes all appropriate manifests under. RDF 1.1 tests include the RDF 1.0 tests, and each of /rdf/rdf12/n-triples, /trig, and /turtle have manifests that include the separate sub manifests.

cc/@jeswr

Fixes #92.