### PR TITLE
GROUP BY test for SPARQL 1.2 to confirm SAMETERM semantics

### DIFF
--- a/sparql/sparql12/grouping/group-data-1.ttl
+++ b/sparql/sparql12/grouping/group-data-1.ttl
@@ -1,0 +1,7 @@
+@prefix : <http://example/> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#>
+
+:s1 :p "1"^^xsd:integer .
+:s2 :p "1"^^xsd:integer .
+:s3 :p "001"^^xsd:integer . 
+:s4 :p "1"^^xsd:string .

--- a/sparql/sparql12/grouping/group01.rq
+++ b/sparql/sparql12/grouping/group01.rq
@@ -1,0 +1,8 @@
+PREFIX : <http://example/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?v (COUNT(*) AS ?cnt)
+{
+  ?s :p ?v .
+}
+GROUP BY ?v

--- a/sparql/sparql12/grouping/group01.srx
+++ b/sparql/sparql12/grouping/group01.srx
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="v"/>
+    <variable name="cnt"/>
+  </head>
+  <results>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+      <binding name="cnt">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">2</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">001</literal>
+      </binding>
+      <binding name="cnt">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#string">1</literal>
+      </binding>
+      <binding name="cnt">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+    </result>
+  </results>
+</sparql>

--- a/sparql/sparql12/grouping/manifest.ttl
+++ b/sparql/sparql12/grouping/manifest.ttl
@@ -1,0 +1,24 @@
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix :       <http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#> .
+@prefix rdfs:	<http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
+@prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
+
+<>  rdf:type mf:Manifest ;
+    rdfs:label "Grouping" ;
+    mf:entries
+    ( 
+    :group01
+    ) .
+
+
+:group01 rdf:type mf:QueryEvaluationTest ;
+    mf:name "Group-1";
+    rdfs:comment    "Grouping with literals" ;
+    dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <group01.rq> ;
+           qt:data   <group-data-1.ttl> ] ;
+    mf:result  <group01.srx>
+    .

--- a/sparql/sparql12/manifest.ttl
+++ b/sparql/sparql12/manifest.ttl
@@ -1,0 +1,36 @@
+## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
+
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+trs:manifest  rdf:type mf:Manifest ;
+  rdfs:label "SPARQL 1.2 tests"@en ;
+  skos:prefLabel "La suite des tests pour SPARQL 1.2"@fr;
+  skos:prefLabel "Conjunto de pruebas para SPARQL 1.2"@es;
+  dct:issued "2023-12-01"^^xsd:date ;
+  rdfs:seeAlso <https://w3c.github.io/rdf-tests/> ;
+  dct:modified "2023-12-01"^^xsd:date ;
+  dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
+  dct:creator [ foaf:homepage <https://w3c.github.io/rdf-star-wg/> ; foaf:name "W3C RDF-star Working Group" ] ;
+  rdfs:comment """
+    These test suites are a product of the [W3C RDF-star Working Group]() as
+    well as the RDF-star Interest Group within the W3C RDF-DEV Community Group,
+    and has been maintained by the
+    [RDF Test Curation Community Group](https://www.w3.org/community/rdf-tests/)
+    at [https://github.com/w3c/rdf-tests/tree/main/sparql/sparql12](https://github.com/w3c/rdf-tests/tree/main/sparql/sparql12/).
+
+    Conformance with SPARQL 1.2 specifications can be determined via
+    successfully running the tests for relevant specifications along
+    with the relevant SPARQL 1.1 tests.
+  """;
+  mf:include (
+    <grouping/manifest.ttl>
+  ) .


### PR DESCRIPTION
This test applies GROUP BY to literals to confirm that grouping is done based on SAMETERM semantics; as discussed in https://github.com/w3c/sparql-query/issues/131

