### PR TITLE
Adds 'NoCanonicalizationOfNumerics' requirement to 'test-manifest' vocabulary

### DIFF
--- a/ns/test-manifest.ttl
+++ b/ns/test-manifest.ttl
@@ -171,6 +171,9 @@
     
 :LangTagAwareness	rdf:type :Requirement ;
     rdfs:comment "Tests that require langauge tag handling in FILTERs" .
+    
+:NoCanonicalizationOfNumerics	rdf:type :Requirement ;
+    rdfs:comment "Tests that require that literals with numeric datatypes are not canonicalized during loading" .
 
 ## ---- Notable features ----
 

--- a/sparql/sparql12/template.haml
+++ b/sparql/sparql12/template.haml
@@ -1,0 +1,195 @@
+!!! 5
+%html{lang: :en, prefix: "dawgt:   http://www.w3.org/2001/sw/DataAccess/tests/test-dawg# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# mfx:    http://jena.hpl.hp.com/2005/05/test-manifest-extra# qt:     http://www.w3.org/2001/sw/DataAccess/tests/test-query# sd:      http://www.w3.org/ns/sparql-service-description# ut:     http://www.w3.org/2009/sparql/tests/test-update#"}
+  %head
+    %meta{"http-equiv" => "Content-Type", content: "text/html;charset=utf-8"}
+    %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}
+    %link{rel: "stylesheet", type: "text/css", href: "https://www.w3.org/StyleSheets/TR/base"}
+    :css
+      body: {bacground-image: none;}
+      dl.editor>dd {
+        margin: 0 0 0 40px;
+      }
+      dl.test-detail {
+        padding: 0.5em;
+      }
+      dl.test-detail>dt {
+        float: left;
+        clear: left;
+        text-align: right;
+        font-weight: bold;
+        color: green;
+      }
+      dl.test-detail>dt:after {content: ": "}
+      dl.test-detail>dd {
+        margin: 0 0 0 110px;
+        padding: 0 0 0.5em 0;
+      }
+      dl.test-description>dt {margin-top: 2em;}
+      dd {margin-left: 0;}
+      dd code {display: inline;}
+      footer {text-align: center;}
+    %title
+      = man['label']
+    :css
+      em.rfc2119 { 
+        text-transform: lowercase;
+        font-variant:   small-caps;
+        font-style:     normal;
+        color:          #900;
+      }
+      a.testlink {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.testlink:hover {
+        text-decoration: underline;
+      }
+      .warning {color: orange;}
+      .error {color: red;}
+
+  %body{resource: man['@id'], typeof: man['@type']}
+    %p
+      %a{href: "http://www.w3.org/"}
+        %img{src: "http://www.w3.org/Icons/w3c_home", alt: "W3C", height: 48, width: 72}
+    %h1{property: "rdfs:label"}<= man['label']
+    :markdown
+      [Copyright](http://www.w3.org/Consortium/Legal/ipr-notice#Copyright) © 2010 [<acronym title="World Wide Web Consortium">W3C</acronym>](http://www.w3.org/)<sup>®</sup> ([<acronym title="Massachusetts Institute of Technology">MIT</acronym>](http://www.csail.mit.edu/), [<acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym>](http://www.ercim.org/), [Keio](http://www.keio.ac.jp/)), All Rights Reserved. W3C [liability](http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer), [trademark](http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks), and [document use](http://www.w3.org/Consortium/Legal/copyright-documents) rules apply.
+    %hr{title: "Separator for header"}
+
+    %div
+      %h2{id: "abstract"}="Abstract"
+      %p{property: "rdfs:comment"}
+        = Array(man['comment']).join(' ').gsub(/\s+/m, ' ').strip.gsub(/(MUST|SHOULD|MAY)/, '<em class="rfc2119">\\1</em>')
+      :markdown
+        This page describes SPARQL 1.2 test suite of the W3C RDF-star Working Group.
+
+        ### Contributing Tests
+        The test manifests and entries are built automatically from [manifest.ttl](manifest.ttl) using a Rake task. Tests may be contributed via pull request to [https://github.com/w3c/rdf-tests](https://github.com/w3c/rdf-tests) with suitable changes to the [manifest.ttl](manifest.ttl) and referenced files.
+
+        ### Distribution
+          Distributed under both the [W3C Test Suite License](http://www.w3.org/Consortium/Legal/2008/04-testsuite-license) and the [W3C 3-clause BSD License](http://www.w3.org/Consortium/Legal/2008/03-bsd-license). To contribute to a W3C Test Suite, see the [policies and contribution forms](http://www.w3.org/2004/10/27-testcases).
+
+        ### Disclaimer
+          UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+          COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.
+
+
+    - if man['include']
+      %div
+        %h2
+          Referenced Manifests
+        %ul
+          - Array(man['include']).map{|m| m.sub('manifest.ttl', '')}.sort.each do |uri|
+            %li
+              %a{property: 'mf:include', inlist: true, href: "#{uri}index.html"}=uri
+
+    - if man['entries']
+      %div
+        %h2
+          Test Descriptions
+        %dl.test-description
+          - man['entries'].each do |test|
+            %dt{id: test['@id']}
+              %a.testlink{href: "##{test['@id']}"}
+                = "#{test['@id']}:"
+              %span{about: test['@id'], property: "mf:name"}<~test['name']
+            %dd{property: "mf:entry", inlist: true, resource: test['@id'], typeof: test['@type']}
+              %div{property: "rdfs:comment"}
+                :markdown
+                  #{Array(test['comment']).join(' ').gsub(/\s+/m, ' ').strip.gsub(/(MUST|SHOULD|MAY)/, '<em class="rfc2119">\\1</em>')}
+                - if test['type'] =~ /Negative/
+                  %p.error
+                    Negative Test
+              %dl.test-detail
+                %dt="type"
+                %dd<~test['@type']
+                %dt="approval"
+                %dd{property: "mf:approval", resource: test['approval']}<~test['approval']
+                - # Syntax Tests
+                - if test['approvedBy']
+                  %dt="approvedBy"
+                  %dd
+                    %a{property: "dawgt:approvedBy", href: test['approvedBy']}<~test['approvedBy']
+
+                - # Evaluation Tests
+                - if test['action'].is_a?(String)
+                  %dt="action"
+                  %dd
+                    %a{property: "mf:action", href: test['action']}<~test['action']
+                - if test['action'].is_a?(Hash)
+                  %dt="action"
+                  %dd
+                    %dl.test-detail{property: "mf:action", resource: test['action']['@id']}
+                      - # Entailment
+                      - if test['action']['EntailmentProfile']
+                        %dt='EntailmentProfile'
+                        %dd
+                          - test['action']['EntailmentProfile'].each do |r|
+                            %span{property: "sd:EntailmentProfile", resource: r}<~r
+                      - if test['action']['http://www.w3.org/ns/sparql-service-description#EntailmentProfile']
+                        %dt='EntailmentProfile'
+                        %dd{property: "sd:EntailmentProfile", resource: test['action']['http://www.w3.org/ns/sparql-service-description#EntailmentProfile']['@id']}<~test['action']['http://www.w3.org/ns/sparql-service-description#EntailmentProfile']['@id']
+                      - if test['action']['entailmentRegime']
+                        %dt='entailmentRegime'
+                        %dd
+                          - test['action']['entailmentRegime'].each do |r|
+                            %span{property: "sd:entailmentRegime", resource: r}<~r
+                      - if test['action']['http://www.w3.org/ns/sparql-service-description#entailmentRegime']
+                        %dt='entailmentRegime'
+                        %dd{property: "sd:entailmentRegime", resource: test['action']['http://www.w3.org/ns/sparql-service-description#entailmentRegime']['@id']}<~test['action']['http://www.w3.org/ns/sparql-service-description#entailmentRegime']['@id']
+
+                      - if test['action']['query']
+                        %dt='query'
+                        %dd
+                          %a{property: "qt:query", href: test['action']['query']}<~test['action']['query']
+                      - if test['action']['data']
+                        %dt='data'
+                        %dd
+                          %a{property: "qt:data", href: test['action']['data']}<~test['action']['data']
+                      - if test['action']['ut:data']
+                        %dt='data'
+                        %dd
+                          %a{property: "ut:data", href: test['action']['ut:data']}<~test['action']['ut:data']
+                      - if test['action']['ut:graphData']
+                        %dt='graphData'
+                        %dd
+                          %table.test-detail
+                            - test['action']['ut:graphData'].each do |gd|
+                              %tr{property: 'ut:graphData', resource: gd['@id']}
+                                %td{property: "rdfs:label"}<~gd['label']
+                                %td
+                                  %a{property: "ut:graph", href: gd['ut:graph']}<~gd['ut:graph']
+                      - if test['action']['ut:request']
+                        %dt='request'
+                        %dd
+                          %a{property: "ut:request", href: test['action']['ut:request']}<~test['action']['ut:request']
+
+                - if test['result'].is_a?(String)
+                  %dt="result"
+                  %dd
+                    %a{property: "mf:result", href: test['result']}<~test['result']
+                - if test['result'].is_a?(Hash)
+                  %dt="result"
+                  %dd
+                    %dl.test-detail{property: "mf:result", resource: test['result']['@id']}
+                      - if test['result']['ut:result']
+                        %dt='result'
+                        %dd
+                          %code{property: "ut:result", resource: test['result']['ut:result']}<~test['result']['ut:result']
+                      - if test['result']['ut:data']
+                        %dt='data'
+                        %dd
+                          %a{property: "ut:data", href: test['result']['ut:data']}<~test['result']['ut:data']
+                      - if test['result']['ut:graphData']
+                        %dt='graphData'
+                        %dd
+                          %table.test-detail
+                            - test['result']['ut:graphData'].each do |gd|
+                              %tr{property: 'ut:graphData', resource: gd['@id']}
+                                %td{property: "rdfs:label"}<~gd['label']
+                                %td
+                                  %a{property: "ut:graph", href: gd['ut:graph']}<~gd['ut:graph']
+
+    %footer
+      :markdown
+        [Copyright ©](http://www.w3.org/Consortium/Legal/ipr-notice#Copyright) 2015 [W3C](http://www.w3.org/)® ([MIT](http://www.csail.mit.edu/), [ERCIM](http://www.ercim.org/), [Keio](http://www.keio.ac.jp/), [Beihang](http://ev.buaa.edu.cn/)). W3C® [liability](http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer), [trademark](http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks) and [document use](http://www.w3.org/Consortium/Legal/copyright-documents) rules apply.


### PR DESCRIPTION
This PR extends the test-manifest vocabulary with a 'NoCanonicalizationOfNumerics' requirement for tests, as suggested by @kasei in https://github.com/w3c/rdf-tests/pull/122#issuecomment-1834651276

Once (and if) this PR gets merged, then this requirement can be specified for the test added by PR #122