### PR TITLE
SPARQL indexes

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@ em.rfc2119 {
   </li>
 	<li><a href="sparql">SPARQL tests</a>
     <ul>
-      <li>SPARQL 1.2</li>
+      <li><a href="sparql/sparql12">SPARQL 1.2 tests</a></li>
       <li><a href="sparql/sparql11">SPARQL 1.1 tests</a>
         (<a href="sparql/reports/">SPARQL 1.1 implementation report</a>)
       </li>

--- a/sparql/sparql10/algebra/index.html
+++ b/sparql/sparql10/algebra/index.html
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-1:
+        <dt id='nested-opt-1'>
+          <a class='testlink' href='#nested-opt-1'>
+            nested-opt-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-1' property='mf:name'>Nested Optionals - 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-1' property='mf:name'>Nested Optionals - 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-1' typeof='mf:QueryEvaluationTest'>
@@ -103,10 +104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-2:
+        <dt id='nested-opt-2'>
+          <a class='testlink' href='#nested-opt-2'>
+            nested-opt-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-2' property='mf:name'>Nested Optionals - 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-2' property='mf:name'>Nested Optionals - 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-2' typeof='mf:QueryEvaluationTest'>
@@ -129,10 +131,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-1:
+        <dt id='opt-filter-1'>
+          <a class='testlink' href='#opt-filter-1'>
+            opt-filter-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-1' property='mf:name'>Optional-filter - 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-1' property='mf:name'>Optional-filter - 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-1' typeof='mf:QueryEvaluationTest'>
@@ -155,10 +158,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-2:
+        <dt id='opt-filter-2'>
+          <a class='testlink' href='#opt-filter-2'>
+            opt-filter-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-2' property='mf:name'>Optional-filter - 2 filters</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-2' property='mf:name'>Optional-filter - 2 filters</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-2' typeof='mf:QueryEvaluationTest'>
@@ -181,10 +185,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-3:
+        <dt id='opt-filter-3'>
+          <a class='testlink' href='#opt-filter-3'>
+            opt-filter-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-3' property='mf:name'>Optional-filter - scope of variable</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-3' property='mf:name'>Optional-filter - scope of variable</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#opt-filter-3' typeof='mf:QueryEvaluationTest'>
@@ -207,10 +212,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-1:
+        <dt id='filter-place-1'>
+          <a class='testlink' href='#filter-place-1'>
+            filter-place-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-1' property='mf:name'>Filter-placement - 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-1' property='mf:name'>Filter-placement - 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-1' typeof='mf:QueryEvaluationTest'>
@@ -233,10 +239,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-2:
+        <dt id='filter-place-2'>
+          <a class='testlink' href='#filter-place-2'>
+            filter-place-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-2' property='mf:name'>Filter-placement - 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-2' property='mf:name'>Filter-placement - 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-2' typeof='mf:QueryEvaluationTest'>
@@ -259,10 +266,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-3:
+        <dt id='filter-place-3'>
+          <a class='testlink' href='#filter-place-3'>
+            filter-place-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-3' property='mf:name'>Filter-placement - 3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-3' property='mf:name'>Filter-placement - 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-place-3' typeof='mf:QueryEvaluationTest'>
@@ -285,10 +293,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-1:
+        <dt id='filter-nested-1'>
+          <a class='testlink' href='#filter-nested-1'>
+            filter-nested-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-1' property='mf:name'>Filter-nested - 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-1' property='mf:name'>Filter-nested - 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-1' typeof='mf:QueryEvaluationTest'>
@@ -311,10 +320,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-2:
+        <dt id='filter-nested-2'>
+          <a class='testlink' href='#filter-nested-2'>
+            filter-nested-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-2' property='mf:name'>Filter-nested - 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-2' property='mf:name'>Filter-nested - 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-nested-2' typeof='mf:QueryEvaluationTest'>
@@ -337,10 +347,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-scope-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-scope-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-scope-1:
+        <dt id='filter-scope-1'>
+          <a class='testlink' href='#filter-scope-1'>
+            filter-scope-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-scope-1' property='mf:name'>Filter-scope - 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-scope-1' property='mf:name'>Filter-scope - 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#filter-scope-1' typeof='mf:QueryEvaluationTest'>
@@ -363,10 +374,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-scope-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-scope-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-scope-1:
+        <dt id='join-scope-1'>
+          <a class='testlink' href='#join-scope-1'>
+            join-scope-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-scope-1' property='mf:name'>Join scope - 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-scope-1' property='mf:name'>Join scope - 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-scope-1' typeof='mf:QueryEvaluationTest'>
@@ -389,10 +401,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-1:
+        <dt id='join-combo-1'>
+          <a class='testlink' href='#join-combo-1'>
+            join-combo-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-1' property='mf:name'>Join operator with OPTs, BGPs, and UNIONs</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-1' property='mf:name'>Join operator with OPTs, BGPs, and UNIONs</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-1' typeof='mf:QueryEvaluationTest'>
@@ -415,10 +428,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-2:
+        <dt id='join-combo-2'>
+          <a class='testlink' href='#join-combo-2'>
+            join-combo-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-2' property='mf:name'>Join operator with Graph and Union</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-2' property='mf:name'>Join operator with Graph and Union</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-2' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/ask/index.html
+++ b/sparql/sparql10/ask/index.html
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-1:
+        <dt id='ask-1'>
+          <a class='testlink' href='#ask-1'>
+            ask-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-1' property='mf:name'>ASK-1 (SPARQL XML results)</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-1' property='mf:name'>ASK-1 (SPARQL XML results)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-1' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-4:
+        <dt id='ask-4'>
+          <a class='testlink' href='#ask-4'>
+            ask-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-4' property='mf:name'>ASK-4 (SPARQL XML results)</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-4' property='mf:name'>ASK-4 (SPARQL XML results)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-4' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-7'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-7'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-7:
+        <dt id='ask-7'>
+          <a class='testlink' href='#ask-7'>
+            ask-7:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-7' property='mf:name'>ASK-7 (SPARQL XML results)</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-7' property='mf:name'>ASK-7 (SPARQL XML results)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-7' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-8'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-8'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-8:
+        <dt id='ask-8'>
+          <a class='testlink' href='#ask-8'>
+            ask-8:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-8' property='mf:name'>ASK-8 (SPARQL XML results)</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-8' property='mf:name'>ASK-8 (SPARQL XML results)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/ask/manifest#ask-8' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/basic/index.html
+++ b/sparql/sparql10/basic/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-1:
+        <dt id='base-prefix-1'>
+          <a class='testlink' href='#base-prefix-1'>
+            base-prefix-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-1' property='mf:name'>Basic - Prefix/Base 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-1' property='mf:name'>Basic - Prefix/Base 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-1' typeof='mf:QueryEvaluationTest'>
@@ -103,10 +104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-2:
+        <dt id='base-prefix-2'>
+          <a class='testlink' href='#base-prefix-2'>
+            base-prefix-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-2' property='mf:name'>Basic - Prefix/Base 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-2' property='mf:name'>Basic - Prefix/Base 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-2' typeof='mf:QueryEvaluationTest'>
@@ -128,10 +130,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-3:
+        <dt id='base-prefix-3'>
+          <a class='testlink' href='#base-prefix-3'>
+            base-prefix-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-3' property='mf:name'>Basic - Prefix/Base 3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-3' property='mf:name'>Basic - Prefix/Base 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-3' typeof='mf:QueryEvaluationTest'>
@@ -153,10 +156,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-4:
+        <dt id='base-prefix-4'>
+          <a class='testlink' href='#base-prefix-4'>
+            base-prefix-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-4' property='mf:name'>Basic - Prefix/Base 4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-4' property='mf:name'>Basic - Prefix/Base 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-4' typeof='mf:QueryEvaluationTest'>
@@ -178,10 +182,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-5'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-5'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-5:
+        <dt id='base-prefix-5'>
+          <a class='testlink' href='#base-prefix-5'>
+            base-prefix-5:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-5' property='mf:name'>Basic - Prefix/Base 5</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-5' property='mf:name'>Basic - Prefix/Base 5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#base-prefix-5' typeof='mf:QueryEvaluationTest'>
@@ -203,10 +208,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-1:
+        <dt id='list-1'>
+          <a class='testlink' href='#list-1'>
+            list-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-1' property='mf:name'>Basic - List 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-1' property='mf:name'>Basic - List 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-1' typeof='mf:QueryEvaluationTest'>
@@ -228,10 +234,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-2:
+        <dt id='list-2'>
+          <a class='testlink' href='#list-2'>
+            list-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-2' property='mf:name'>Basic - List 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-2' property='mf:name'>Basic - List 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-2' typeof='mf:QueryEvaluationTest'>
@@ -253,10 +260,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-3:
+        <dt id='list-3'>
+          <a class='testlink' href='#list-3'>
+            list-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-3' property='mf:name'>Basic - List 3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-3' property='mf:name'>Basic - List 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-3' typeof='mf:QueryEvaluationTest'>
@@ -278,10 +286,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-4:
+        <dt id='list-4'>
+          <a class='testlink' href='#list-4'>
+            list-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-4' property='mf:name'>Basic - List 4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-4' property='mf:name'>Basic - List 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-4' typeof='mf:QueryEvaluationTest'>
@@ -303,10 +312,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-1:
+        <dt id='quotes-1'>
+          <a class='testlink' href='#quotes-1'>
+            quotes-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-1' property='mf:name'>Basic - Quotes 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-1' property='mf:name'>Basic - Quotes 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-1' typeof='mf:QueryEvaluationTest'>
@@ -328,10 +338,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-2:
+        <dt id='quotes-2'>
+          <a class='testlink' href='#quotes-2'>
+            quotes-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-2' property='mf:name'>Basic - Quotes 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-2' property='mf:name'>Basic - Quotes 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-2' typeof='mf:QueryEvaluationTest'>
@@ -353,10 +364,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-3:
+        <dt id='quotes-3'>
+          <a class='testlink' href='#quotes-3'>
+            quotes-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-3' property='mf:name'>Basic - Quotes 3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-3' property='mf:name'>Basic - Quotes 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-3' typeof='mf:QueryEvaluationTest'>
@@ -378,10 +390,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-4:
+        <dt id='quotes-4'>
+          <a class='testlink' href='#quotes-4'>
+            quotes-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-4' property='mf:name'>Basic - Quotes 4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-4' property='mf:name'>Basic - Quotes 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#quotes-4' typeof='mf:QueryEvaluationTest'>
@@ -403,10 +416,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-1:
+        <dt id='term-1'>
+          <a class='testlink' href='#term-1'>
+            term-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-1' property='mf:name'>Basic - Term 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-1' property='mf:name'>Basic - Term 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-1' typeof='mf:QueryEvaluationTest'>
@@ -428,10 +442,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-2:
+        <dt id='term-2'>
+          <a class='testlink' href='#term-2'>
+            term-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-2' property='mf:name'>Basic - Term 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-2' property='mf:name'>Basic - Term 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-2' typeof='mf:QueryEvaluationTest'>
@@ -453,10 +468,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-3:
+        <dt id='term-3'>
+          <a class='testlink' href='#term-3'>
+            term-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-3' property='mf:name'>Basic - Term 3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-3' property='mf:name'>Basic - Term 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-3' typeof='mf:QueryEvaluationTest'>
@@ -478,10 +494,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-4:
+        <dt id='term-4'>
+          <a class='testlink' href='#term-4'>
+            term-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-4' property='mf:name'>Basic - Term 4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-4' property='mf:name'>Basic - Term 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-4' typeof='mf:QueryEvaluationTest'>
@@ -503,10 +520,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-5'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-5'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-5:
+        <dt id='term-5'>
+          <a class='testlink' href='#term-5'>
+            term-5:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-5' property='mf:name'>Basic - Term 5</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-5' property='mf:name'>Basic - Term 5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-5' typeof='mf:QueryEvaluationTest'>
@@ -528,10 +546,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-6'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-6'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-6:
+        <dt id='term-6'>
+          <a class='testlink' href='#term-6'>
+            term-6:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-6' property='mf:name'>Basic - Term 6</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-6' property='mf:name'>Basic - Term 6</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-6' typeof='mf:QueryEvaluationTest'>
@@ -553,10 +572,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-7'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-7'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-7:
+        <dt id='term-7'>
+          <a class='testlink' href='#term-7'>
+            term-7:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-7' property='mf:name'>Basic - Term 7</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-7' property='mf:name'>Basic - Term 7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-7' typeof='mf:QueryEvaluationTest'>
@@ -578,10 +598,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-8'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-8'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-8:
+        <dt id='term-8'>
+          <a class='testlink' href='#term-8'>
+            term-8:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-8' property='mf:name'>Basic - Term 8</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-8' property='mf:name'>Basic - Term 8</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-8' typeof='mf:QueryEvaluationTest'>
@@ -603,10 +624,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-9'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-9'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-9:
+        <dt id='term-9'>
+          <a class='testlink' href='#term-9'>
+            term-9:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-9' property='mf:name'>Basic - Term 9</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-9' property='mf:name'>Basic - Term 9</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#term-9' typeof='mf:QueryEvaluationTest'>
@@ -628,10 +650,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-1:
+        <dt id='var-1'>
+          <a class='testlink' href='#var-1'>
+            var-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-1' property='mf:name'>Basic - Var 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-1' property='mf:name'>Basic - Var 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-1' typeof='mf:QueryEvaluationTest'>
@@ -653,10 +676,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-2:
+        <dt id='var-2'>
+          <a class='testlink' href='#var-2'>
+            var-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-2' property='mf:name'>Basic - Var 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-2' property='mf:name'>Basic - Var 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#var-2' typeof='mf:QueryEvaluationTest'>
@@ -678,10 +702,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#bgp-no-match'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#bgp-no-match'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#bgp-no-match:
+        <dt id='bgp-no-match'>
+          <a class='testlink' href='#bgp-no-match'>
+            bgp-no-match:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#bgp-no-match' property='mf:name'>Non-matching triple pattern</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#bgp-no-match' property='mf:name'>Non-matching triple pattern</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#bgp-no-match' typeof='mf:QueryEvaluationTest'>
@@ -704,10 +729,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#spoo-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#spoo-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#spoo-1:
+        <dt id='spoo-1'>
+          <a class='testlink' href='#spoo-1'>
+            spoo-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#spoo-1' property='mf:name'>Basic graph pattern - spoo</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#spoo-1' property='mf:name'>Basic graph pattern - spoo</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#spoo-1' typeof='mf:QueryEvaluationTest'>
@@ -730,10 +756,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#prefix-name-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#prefix-name-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#prefix-name-1:
+        <dt id='prefix-name-1'>
+          <a class='testlink' href='#prefix-name-1'>
+            prefix-name-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#prefix-name-1' property='mf:name'>Prefix name 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#prefix-name-1' property='mf:name'>Prefix name 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#prefix-name-1' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/bnode-coreference/index.html
+++ b/sparql/sparql10/bnode-coreference/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bnode-coreference/manifest#dawg-bnode-coref-001'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bnode-coreference/manifest#dawg-bnode-coref-001'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bnode-coreference/manifest#dawg-bnode-coref-001:
+        <dt id='dawg-bnode-coref-001'>
+          <a class='testlink' href='#dawg-bnode-coref-001'>
+            dawg-bnode-coref-001:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bnode-coreference/manifest#dawg-bnode-coref-001' property='mf:name'>dawg-bnode-coreference</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bnode-coreference/manifest#dawg-bnode-coref-001' property='mf:name'>dawg-bnode-coreference</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bnode-coreference/manifest#dawg-bnode-coref-001' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/boolean-effective-value/index.html
+++ b/sparql/sparql10/boolean-effective-value/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-boolean-literal'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-boolean-literal'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-boolean-literal:
+        <dt id='dawg-boolean-literal'>
+          <a class='testlink' href='#dawg-boolean-literal'>
+            dawg-boolean-literal:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-boolean-literal' property='mf:name'>Test literal &#39;true&#39;</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-boolean-literal' property='mf:name'>Test literal &#39;true&#39;</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-boolean-literal' typeof='mf:QueryEvaluationTest'>
@@ -103,10 +104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-1:
+        <dt id='dawg-bev-1'>
+          <a class='testlink' href='#dawg-bev-1'>
+            dawg-bev-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-1' property='mf:name'>Test &#39;boolean effective value&#39; - true</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-1' property='mf:name'>Test &#39;boolean effective value&#39; - true</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-1' typeof='mf:QueryEvaluationTest'>
@@ -129,10 +131,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-2:
+        <dt id='dawg-bev-2'>
+          <a class='testlink' href='#dawg-bev-2'>
+            dawg-bev-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-2' property='mf:name'>Test &#39;boolean effective value&#39; - false</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-2' property='mf:name'>Test &#39;boolean effective value&#39; - false</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-2' typeof='mf:QueryEvaluationTest'>
@@ -155,10 +158,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-3:
+        <dt id='dawg-bev-3'>
+          <a class='testlink' href='#dawg-bev-3'>
+            dawg-bev-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-3' property='mf:name'>Test &#39;boolean effective value&#39; - &amp;&amp;</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-3' property='mf:name'>Test &#39;boolean effective value&#39; - &amp;&amp;</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-3' typeof='mf:QueryEvaluationTest'>
@@ -181,10 +185,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-4:
+        <dt id='dawg-bev-4'>
+          <a class='testlink' href='#dawg-bev-4'>
+            dawg-bev-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-4' property='mf:name'>Test &#39;boolean effective value&#39; - ||</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-4' property='mf:name'>Test &#39;boolean effective value&#39; - ||</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-4' typeof='mf:QueryEvaluationTest'>
@@ -215,10 +220,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-5'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-5'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-5:
+        <dt id='dawg-bev-5'>
+          <a class='testlink' href='#dawg-bev-5'>
+            dawg-bev-5:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-5' property='mf:name'>Test &#39;boolean effective value&#39; - optional</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-5' property='mf:name'>Test &#39;boolean effective value&#39; - optional</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-5' typeof='mf:QueryEvaluationTest'>
@@ -241,10 +247,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-6'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-6'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-6:
+        <dt id='dawg-bev-6'>
+          <a class='testlink' href='#dawg-bev-6'>
+            dawg-bev-6:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-6' property='mf:name'>Test &#39;boolean effective value&#39; - unknown types</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-6' property='mf:name'>Test &#39;boolean effective value&#39; - unknown types</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/boolean-effective-value/manifest#dawg-bev-6' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/bound/index.html
+++ b/sparql/sparql10/bound/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bound/manifest#dawg-bound-query-001'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bound/manifest#dawg-bound-query-001'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bound/manifest#dawg-bound-query-001:
+        <dt id='dawg-bound-query-001'>
+          <a class='testlink' href='#dawg-bound-query-001'>
+            dawg-bound-query-001:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bound/manifest#dawg-bound-query-001' property='mf:name'>dawg-bound-query-001</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bound/manifest#dawg-bound-query-001' property='mf:name'>dawg-bound-query-001</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/bound/manifest#dawg-bound-query-001' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/cast/index.html
+++ b/sparql/sparql10/cast/index.html
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-str'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-str'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-str:
+        <dt id='cast-str'>
+          <a class='testlink' href='#cast-str'>
+            cast-str:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-str' property='mf:name'>Cast to xsd:string</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-str' property='mf:name'>Cast to xsd:string</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-str' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-flt'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-flt'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-flt:
+        <dt id='cast-flt'>
+          <a class='testlink' href='#cast-flt'>
+            cast-flt:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-flt' property='mf:name'>Cast to xsd:float</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-flt' property='mf:name'>Cast to xsd:float</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-flt' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dbl'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dbl'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dbl:
+        <dt id='cast-dbl'>
+          <a class='testlink' href='#cast-dbl'>
+            cast-dbl:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dbl' property='mf:name'>Cast to xsd:double</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dbl' property='mf:name'>Cast to xsd:double</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dbl' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dec'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dec'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dec:
+        <dt id='cast-dec'>
+          <a class='testlink' href='#cast-dec'>
+            cast-dec:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dec' property='mf:name'>Cast to xsd:decimal</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dec' property='mf:name'>Cast to xsd:decimal</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dec' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-int'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-int'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-int:
+        <dt id='cast-int'>
+          <a class='testlink' href='#cast-int'>
+            cast-int:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-int' property='mf:name'>Cast to xsd:integer</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-int' property='mf:name'>Cast to xsd:integer</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-int' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dT'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dT'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dT:
+        <dt id='cast-dT'>
+          <a class='testlink' href='#cast-dT'>
+            cast-dT:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dT' property='mf:name'>Cast to xsd:dateTime</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dT' property='mf:name'>Cast to xsd:dateTime</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-dT' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-bool'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-bool'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-bool:
+        <dt id='cast-bool'>
+          <a class='testlink' href='#cast-bool'>
+            cast-bool:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-bool' property='mf:name'>Cast to xsd:boolean</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-bool' property='mf:name'>Cast to xsd:boolean</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/cast/manifest#cast-bool' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/construct/index.html
+++ b/sparql/sparql10/construct/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-1:
+        <dt id='construct-1'>
+          <a class='testlink' href='#construct-1'>
+            construct-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-1' property='mf:name'>dawg-construct-identity</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-1' property='mf:name'>dawg-construct-identity</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-1' typeof='mf:QueryEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-2:
+        <dt id='construct-2'>
+          <a class='testlink' href='#construct-2'>
+            construct-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-2' property='mf:name'>dawg-construct-subgraph</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-2' property='mf:name'>dawg-construct-subgraph</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-2' typeof='mf:QueryEvaluationTest'>
@@ -130,10 +132,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-3:
+        <dt id='construct-3'>
+          <a class='testlink' href='#construct-3'>
+            construct-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-3' property='mf:name'>dawg-construct-reification-1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-3' property='mf:name'>dawg-construct-reification-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-3' typeof='mf:QueryEvaluationTest'>
@@ -156,10 +159,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-4:
+        <dt id='construct-4'>
+          <a class='testlink' href='#construct-4'>
+            construct-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-4' property='mf:name'>dawg-construct-reification-2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-4' property='mf:name'>dawg-construct-reification-2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-4' typeof='mf:QueryEvaluationTest'>
@@ -182,10 +186,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-5'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-5'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-5:
+        <dt id='construct-5'>
+          <a class='testlink' href='#construct-5'>
+            construct-5:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-5' property='mf:name'>dawg-construct-optional</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-5' property='mf:name'>dawg-construct-optional</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/construct/manifest#construct-5' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/dataset/index.html
+++ b/sparql/sparql10/dataset/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-01:
+        <dt id='dawg-dataset-01'>
+          <a class='testlink' href='#dawg-dataset-01'>
+            dawg-dataset-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-01' property='mf:name'>dataset-01</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-01' property='mf:name'>dataset-01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-01' typeof='mf:QueryEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-02:
+        <dt id='dawg-dataset-02'>
+          <a class='testlink' href='#dawg-dataset-02'>
+            dawg-dataset-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-02' property='mf:name'>dataset-02</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-02' property='mf:name'>dataset-02</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-02' typeof='mf:QueryEvaluationTest'>
@@ -130,10 +132,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-03:
+        <dt id='dawg-dataset-03'>
+          <a class='testlink' href='#dawg-dataset-03'>
+            dawg-dataset-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-03' property='mf:name'>dataset-03</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-03' property='mf:name'>dataset-03</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-03' typeof='mf:QueryEvaluationTest'>
@@ -156,10 +159,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-04:
+        <dt id='dawg-dataset-04'>
+          <a class='testlink' href='#dawg-dataset-04'>
+            dawg-dataset-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-04' property='mf:name'>dataset-04</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-04' property='mf:name'>dataset-04</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-04' typeof='mf:QueryEvaluationTest'>
@@ -182,10 +186,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-05:
+        <dt id='dawg-dataset-05'>
+          <a class='testlink' href='#dawg-dataset-05'>
+            dawg-dataset-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-05' property='mf:name'>dataset-05</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-05' property='mf:name'>dataset-05</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-05' typeof='mf:QueryEvaluationTest'>
@@ -208,10 +213,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-06:
+        <dt id='dawg-dataset-06'>
+          <a class='testlink' href='#dawg-dataset-06'>
+            dawg-dataset-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-06' property='mf:name'>dataset-06</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-06' property='mf:name'>dataset-06</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-06' typeof='mf:QueryEvaluationTest'>
@@ -234,10 +240,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-07:
+        <dt id='dawg-dataset-07'>
+          <a class='testlink' href='#dawg-dataset-07'>
+            dawg-dataset-07:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-07' property='mf:name'>dataset-07</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-07' property='mf:name'>dataset-07</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-07' typeof='mf:QueryEvaluationTest'>
@@ -260,10 +267,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-08'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-08'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-08:
+        <dt id='dawg-dataset-08'>
+          <a class='testlink' href='#dawg-dataset-08'>
+            dawg-dataset-08:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-08' property='mf:name'>dataset-08</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-08' property='mf:name'>dataset-08</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-08' typeof='mf:QueryEvaluationTest'>
@@ -286,10 +294,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-11'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-11'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-11:
+        <dt id='dawg-dataset-11'>
+          <a class='testlink' href='#dawg-dataset-11'>
+            dawg-dataset-11:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-11' property='mf:name'>dataset-11</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-11' property='mf:name'>dataset-11</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-11' typeof='mf:QueryEvaluationTest'>
@@ -312,10 +321,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-09b'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-09b'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-09b:
+        <dt id='dawg-dataset-09b'>
+          <a class='testlink' href='#dawg-dataset-09b'>
+            dawg-dataset-09b:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-09b' property='mf:name'>dataset-09b</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-09b' property='mf:name'>dataset-09b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-09b' typeof='mf:QueryEvaluationTest'>
@@ -338,10 +348,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-10b'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-10b'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-10b:
+        <dt id='dawg-dataset-10b'>
+          <a class='testlink' href='#dawg-dataset-10b'>
+            dawg-dataset-10b:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-10b' property='mf:name'>dataset-10b</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-10b' property='mf:name'>dataset-10b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-10b' typeof='mf:QueryEvaluationTest'>
@@ -364,10 +375,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-12b'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-12b'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-12b:
+        <dt id='dawg-dataset-12b'>
+          <a class='testlink' href='#dawg-dataset-12b'>
+            dawg-dataset-12b:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-12b' property='mf:name'>dataset-12b</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-12b' property='mf:name'>dataset-12b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/dataset/manifest#dawg-dataset-12b' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/distinct/index.html
+++ b/sparql/sparql10/distinct/index.html
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-1:
+        <dt id='no-distinct-1'>
+          <a class='testlink' href='#no-distinct-1'>
+            no-distinct-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-1' property='mf:name'>Numbers: No distinct</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-1' property='mf:name'>Numbers: No distinct</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-1' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-1:
+        <dt id='distinct-1'>
+          <a class='testlink' href='#distinct-1'>
+            distinct-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-1' property='mf:name'>Numbers: Distinct</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-1' property='mf:name'>Numbers: Distinct</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-1' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-2:
+        <dt id='no-distinct-2'>
+          <a class='testlink' href='#no-distinct-2'>
+            no-distinct-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-2' property='mf:name'>Strings: No distinct</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-2' property='mf:name'>Strings: No distinct</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-2' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-2:
+        <dt id='distinct-2'>
+          <a class='testlink' href='#distinct-2'>
+            distinct-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-2' property='mf:name'>Strings: Distinct</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-2' property='mf:name'>Strings: Distinct</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-2' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-3:
+        <dt id='no-distinct-3'>
+          <a class='testlink' href='#no-distinct-3'>
+            no-distinct-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-3' property='mf:name'>Nodes: No distinct</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-3' property='mf:name'>Nodes: No distinct</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-3' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-3:
+        <dt id='distinct-3'>
+          <a class='testlink' href='#distinct-3'>
+            distinct-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-3' property='mf:name'>Nodes: Distinct</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-3' property='mf:name'>Nodes: Distinct</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-3' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-4:
+        <dt id='no-distinct-4'>
+          <a class='testlink' href='#no-distinct-4'>
+            no-distinct-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-4' property='mf:name'>Opt: No distinct</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-4' property='mf:name'>Opt: No distinct</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-4' typeof='mf:QueryEvaluationTest'>
@@ -252,10 +259,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-4:
+        <dt id='distinct-4'>
+          <a class='testlink' href='#distinct-4'>
+            distinct-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-4' property='mf:name'>Opt: Distinct</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-4' property='mf:name'>Opt: Distinct</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-4' typeof='mf:QueryEvaluationTest'>
@@ -277,10 +285,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-9'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-9'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-9:
+        <dt id='no-distinct-9'>
+          <a class='testlink' href='#no-distinct-9'>
+            no-distinct-9:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-9' property='mf:name'>All: No distinct</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-9' property='mf:name'>All: No distinct</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#no-distinct-9' typeof='mf:QueryEvaluationTest'>
@@ -302,10 +311,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-9'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-9'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-9:
+        <dt id='distinct-9'>
+          <a class='testlink' href='#distinct-9'>
+            distinct-9:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-9' property='mf:name'>All: Distinct</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-9' property='mf:name'>All: Distinct</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-9' typeof='mf:QueryEvaluationTest'>
@@ -327,10 +337,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-star-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-star-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-star-1:
+        <dt id='distinct-star-1'>
+          <a class='testlink' href='#distinct-star-1'>
+            distinct-star-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-star-1' property='mf:name'>SELECT DISTINCT *</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-star-1' property='mf:name'>SELECT DISTINCT *</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/distinct/manifest#distinct-star-1' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/expr-builtin/index.html
+++ b/sparql/sparql10/expr-builtin/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-1:
+        <dt id='dawg-str-1'>
+          <a class='testlink' href='#dawg-str-1'>
+            dawg-str-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-1' property='mf:name'>str-1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-1' property='mf:name'>str-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-1' typeof='mf:QueryEvaluationTest'>
@@ -103,10 +104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-2:
+        <dt id='dawg-str-2'>
+          <a class='testlink' href='#dawg-str-2'>
+            dawg-str-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-2' property='mf:name'>str-2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-2' property='mf:name'>str-2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-2' typeof='mf:QueryEvaluationTest'>
@@ -128,10 +130,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-3:
+        <dt id='dawg-str-3'>
+          <a class='testlink' href='#dawg-str-3'>
+            dawg-str-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-3' property='mf:name'>str-3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-3' property='mf:name'>str-3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-3' typeof='mf:QueryEvaluationTest'>
@@ -153,10 +156,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-4:
+        <dt id='dawg-str-4'>
+          <a class='testlink' href='#dawg-str-4'>
+            dawg-str-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-4' property='mf:name'>str-4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-4' property='mf:name'>str-4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-str-4' typeof='mf:QueryEvaluationTest'>
@@ -178,10 +182,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isBlank-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isBlank-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isBlank-1:
+        <dt id='dawg-isBlank-1'>
+          <a class='testlink' href='#dawg-isBlank-1'>
+            dawg-isBlank-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isBlank-1' property='mf:name'>isBlank-1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isBlank-1' property='mf:name'>isBlank-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isBlank-1' typeof='mf:QueryEvaluationTest'>
@@ -203,10 +208,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isLiteral-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isLiteral-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isLiteral-1:
+        <dt id='dawg-isLiteral-1'>
+          <a class='testlink' href='#dawg-isLiteral-1'>
+            dawg-isLiteral-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isLiteral-1' property='mf:name'>isLiteral</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isLiteral-1' property='mf:name'>isLiteral</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isLiteral-1' typeof='mf:QueryEvaluationTest'>
@@ -228,10 +234,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-1:
+        <dt id='dawg-datatype-1'>
+          <a class='testlink' href='#dawg-datatype-1'>
+            dawg-datatype-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-1' property='mf:name'>datatype-1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-1' property='mf:name'>datatype-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-1' typeof='mf:QueryEvaluationTest'>
@@ -253,10 +260,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-2:
+        <dt id='dawg-datatype-2'>
+          <a class='testlink' href='#dawg-datatype-2'>
+            dawg-datatype-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-2' property='mf:name'>datatype-2 : Literals with a datatype</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-2' property='mf:name'>datatype-2 : Literals with a datatype</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-2' typeof='mf:QueryEvaluationTest'>
@@ -279,10 +287,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-3:
+        <dt id='dawg-datatype-3'>
+          <a class='testlink' href='#dawg-datatype-3'>
+            dawg-datatype-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-3' property='mf:name'>datatype-3 : Literals with a datatype of xsd:string</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-3' property='mf:name'>datatype-3 : Literals with a datatype of xsd:string</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-datatype-3' typeof='mf:QueryEvaluationTest'>
@@ -305,10 +314,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-1:
+        <dt id='dawg-lang-1'>
+          <a class='testlink' href='#dawg-lang-1'>
+            dawg-lang-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-1' property='mf:name'>lang-1 : Literals with a lang tag of some kind</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-1' property='mf:name'>lang-1 : Literals with a lang tag of some kind</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-1' typeof='mf:QueryEvaluationTest'>
@@ -331,10 +341,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-2:
+        <dt id='dawg-lang-2'>
+          <a class='testlink' href='#dawg-lang-2'>
+            dawg-lang-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-2' property='mf:name'>lang-2 : Literals with a lang tag of &#39;&#39;</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-2' property='mf:name'>lang-2 : Literals with a lang tag of &#39;&#39;</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-2' typeof='mf:QueryEvaluationTest'>
@@ -357,10 +368,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-3:
+        <dt id='dawg-lang-3'>
+          <a class='testlink' href='#dawg-lang-3'>
+            dawg-lang-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-3' property='mf:name'>lang-3 : Graph matching with lang tag being a different case</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-3' property='mf:name'>lang-3 : Graph matching with lang tag being a different case</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-lang-3' typeof='mf:QueryEvaluationTest'>
@@ -383,10 +395,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isURI-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isURI-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isURI-1:
+        <dt id='dawg-isURI-1'>
+          <a class='testlink' href='#dawg-isURI-1'>
+            dawg-isURI-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isURI-1' property='mf:name'>isURI-1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isURI-1' property='mf:name'>isURI-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isURI-1' typeof='mf:QueryEvaluationTest'>
@@ -408,10 +421,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isIRI-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isIRI-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isIRI-1:
+        <dt id='dawg-isIRI-1'>
+          <a class='testlink' href='#dawg-isIRI-1'>
+            dawg-isIRI-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isIRI-1' property='mf:name'>isIRI-1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isIRI-1' property='mf:name'>isIRI-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-isIRI-1' typeof='mf:QueryEvaluationTest'>
@@ -433,10 +447,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-1:
+        <dt id='dawg-langMatches-1'>
+          <a class='testlink' href='#dawg-langMatches-1'>
+            dawg-langMatches-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-1' property='mf:name'>LangMatches-1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-1' property='mf:name'>LangMatches-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-1' typeof='mf:QueryEvaluationTest'>
@@ -459,10 +474,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-2:
+        <dt id='dawg-langMatches-2'>
+          <a class='testlink' href='#dawg-langMatches-2'>
+            dawg-langMatches-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-2' property='mf:name'>LangMatches-2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-2' property='mf:name'>LangMatches-2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-2' typeof='mf:QueryEvaluationTest'>
@@ -485,10 +501,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-3:
+        <dt id='dawg-langMatches-3'>
+          <a class='testlink' href='#dawg-langMatches-3'>
+            dawg-langMatches-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-3' property='mf:name'>LangMatches-3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-3' property='mf:name'>LangMatches-3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-3' typeof='mf:QueryEvaluationTest'>
@@ -511,10 +528,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-4:
+        <dt id='dawg-langMatches-4'>
+          <a class='testlink' href='#dawg-langMatches-4'>
+            dawg-langMatches-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-4' property='mf:name'>LangMatches-4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-4' property='mf:name'>LangMatches-4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-4' typeof='mf:QueryEvaluationTest'>
@@ -537,10 +555,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-basic'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-basic'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-basic:
+        <dt id='dawg-langMatches-basic'>
+          <a class='testlink' href='#dawg-langMatches-basic'>
+            dawg-langMatches-basic:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-basic' property='mf:name'>LangMatches-basic</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-basic' property='mf:name'>LangMatches-basic</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#dawg-langMatches-basic' typeof='mf:QueryEvaluationTest'>
@@ -563,10 +582,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-eq'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-eq'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-eq:
+        <dt id='lang-case-insensitive-eq'>
+          <a class='testlink' href='#lang-case-insensitive-eq'>
+            lang-case-insensitive-eq:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-eq' property='mf:name'>lang-case-insensitive-eq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-eq' property='mf:name'>lang-case-insensitive-eq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-eq' typeof='mf:QueryEvaluationTest'>
@@ -589,10 +609,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-ne'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-ne'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-ne:
+        <dt id='lang-case-insensitive-ne'>
+          <a class='testlink' href='#lang-case-insensitive-ne'>
+            lang-case-insensitive-ne:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-ne' property='mf:name'>lang-case-insensitive-ne</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-ne' property='mf:name'>lang-case-insensitive-ne</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#lang-case-insensitive-ne' typeof='mf:QueryEvaluationTest'>
@@ -615,10 +636,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-simple'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-simple'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-simple:
+        <dt id='sameTerm-simple'>
+          <a class='testlink' href='#sameTerm-simple'>
+            sameTerm-simple:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-simple' property='mf:name'>sameTerm-simple</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-simple' property='mf:name'>sameTerm-simple</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-simple' typeof='mf:QueryEvaluationTest'>
@@ -641,10 +663,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-eq'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-eq'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-eq:
+        <dt id='sameTerm-eq'>
+          <a class='testlink' href='#sameTerm-eq'>
+            sameTerm-eq:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-eq' property='mf:name'>sameTerm-eq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-eq' property='mf:name'>sameTerm-eq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-eq' typeof='mf:QueryEvaluationTest'>
@@ -667,10 +690,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-not-eq'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-not-eq'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-not-eq:
+        <dt id='sameTerm-not-eq'>
+          <a class='testlink' href='#sameTerm-not-eq'>
+            sameTerm-not-eq:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-not-eq' property='mf:name'>sameTerm-not-eq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-not-eq' property='mf:name'>sameTerm-not-eq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-builtin/manifest#sameTerm-not-eq' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/expr-equals/index.html
+++ b/sparql/sparql10/expr-equals/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-1:
+        <dt id='eq-1'>
+          <a class='testlink' href='#eq-1'>
+            eq-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-1' property='mf:name'>Equality 1-1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-1' property='mf:name'>Equality 1-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-1' typeof='mf:QueryEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2:
+        <dt id='eq-2'>
+          <a class='testlink' href='#eq-2'>
+            eq-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2' property='mf:name'>Equality 1-2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2' property='mf:name'>Equality 1-2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2' typeof='mf:QueryEvaluationTest'>
@@ -130,10 +132,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-3:
+        <dt id='eq-3'>
+          <a class='testlink' href='#eq-3'>
+            eq-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-3' property='mf:name'>Equality 1-3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-3' property='mf:name'>Equality 1-3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-3' typeof='mf:QueryEvaluationTest'>
@@ -156,10 +159,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-4:
+        <dt id='eq-4'>
+          <a class='testlink' href='#eq-4'>
+            eq-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-4' property='mf:name'>Equality 1-4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-4' property='mf:name'>Equality 1-4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-4' typeof='mf:QueryEvaluationTest'>
@@ -182,10 +186,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-5'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-5'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-5:
+        <dt id='eq-5'>
+          <a class='testlink' href='#eq-5'>
+            eq-5:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-5' property='mf:name'>Equality 1-5</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-5' property='mf:name'>Equality 1-5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-5' typeof='mf:QueryEvaluationTest'>
@@ -208,10 +213,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-1:
+        <dt id='eq-2-1'>
+          <a class='testlink' href='#eq-2-1'>
+            eq-2-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-1' property='mf:name'>Equality - 2 var - test equals</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-1' property='mf:name'>Equality - 2 var - test equals</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-1' typeof='mf:QueryEvaluationTest'>
@@ -234,10 +240,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-2:
+        <dt id='eq-2-2'>
+          <a class='testlink' href='#eq-2-2'>
+            eq-2-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-2' property='mf:name'>Equality - 2 var - test not equals </span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-2' property='mf:name'>Equality - 2 var - test not equals </span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-2-2' typeof='mf:QueryEvaluationTest'>
@@ -260,10 +267,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-1:
+        <dt id='eq-graph-1'>
+          <a class='testlink' href='#eq-graph-1'>
+            eq-graph-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-1' property='mf:name'>Equality 1-1 -- graph</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-1' property='mf:name'>Equality 1-1 -- graph</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-1' typeof='mf:QueryEvaluationTest'>
@@ -286,10 +294,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-2:
+        <dt id='eq-graph-2'>
+          <a class='testlink' href='#eq-graph-2'>
+            eq-graph-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-2' property='mf:name'>Equality 1-2 -- graph</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-2' property='mf:name'>Equality 1-2 -- graph</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-2' typeof='mf:QueryEvaluationTest'>
@@ -312,10 +321,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-3:
+        <dt id='eq-graph-3'>
+          <a class='testlink' href='#eq-graph-3'>
+            eq-graph-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-3' property='mf:name'>Equality 1-3 -- graph</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-3' property='mf:name'>Equality 1-3 -- graph</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-3' typeof='mf:QueryEvaluationTest'>
@@ -338,10 +348,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-4:
+        <dt id='eq-graph-4'>
+          <a class='testlink' href='#eq-graph-4'>
+            eq-graph-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-4' property='mf:name'>Equality 1-4 -- graph</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-4' property='mf:name'>Equality 1-4 -- graph</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-4' typeof='mf:QueryEvaluationTest'>
@@ -364,10 +375,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-5'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-5'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-5:
+        <dt id='eq-graph-5'>
+          <a class='testlink' href='#eq-graph-5'>
+            eq-graph-5:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-5' property='mf:name'>Equality 1-5 -- graph</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-5' property='mf:name'>Equality 1-5 -- graph</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-graph-5' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/expr-ops/index.html
+++ b/sparql/sparql10/expr-ops/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#ge-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#ge-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#ge-1:
+        <dt id='ge-1'>
+          <a class='testlink' href='#ge-1'>
+            ge-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#ge-1' property='mf:name'>Greater-than or equals</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#ge-1' property='mf:name'>Greater-than or equals</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#ge-1' typeof='mf:QueryEvaluationTest'>
@@ -106,10 +107,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#le-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#le-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#le-1:
+        <dt id='le-1'>
+          <a class='testlink' href='#le-1'>
+            le-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#le-1' property='mf:name'>Less-than or equals</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#le-1' property='mf:name'>Less-than or equals</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#le-1' typeof='mf:QueryEvaluationTest'>
@@ -132,10 +134,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#mul-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#mul-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#mul-1:
+        <dt id='mul-1'>
+          <a class='testlink' href='#mul-1'>
+            mul-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#mul-1' property='mf:name'>Multiplication</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#mul-1' property='mf:name'>Multiplication</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#mul-1' typeof='mf:QueryEvaluationTest'>
@@ -158,10 +161,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#plus-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#plus-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#plus-1:
+        <dt id='plus-1'>
+          <a class='testlink' href='#plus-1'>
+            plus-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#plus-1' property='mf:name'>Addition</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#plus-1' property='mf:name'>Addition</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#plus-1' typeof='mf:QueryEvaluationTest'>
@@ -184,10 +188,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#minus-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#minus-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#minus-1:
+        <dt id='minus-1'>
+          <a class='testlink' href='#minus-1'>
+            minus-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#minus-1' property='mf:name'>Subtraction</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#minus-1' property='mf:name'>Subtraction</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#minus-1' typeof='mf:QueryEvaluationTest'>
@@ -210,10 +215,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unplus-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unplus-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unplus-1:
+        <dt id='unplus-1'>
+          <a class='testlink' href='#unplus-1'>
+            unplus-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unplus-1' property='mf:name'>Unary Plusn</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unplus-1' property='mf:name'>Unary Plusn</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unplus-1' typeof='mf:QueryEvaluationTest'>
@@ -236,10 +242,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unminus-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unminus-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unminus-1:
+        <dt id='unminus-1'>
+          <a class='testlink' href='#unminus-1'>
+            unminus-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unminus-1' property='mf:name'>Unary Minus</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unminus-1' property='mf:name'>Unary Minus</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#unminus-1' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/graph/index.html
+++ b/sparql/sparql10/graph/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-01:
+        <dt id='dawg-graph-01'>
+          <a class='testlink' href='#dawg-graph-01'>
+            dawg-graph-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-01' property='mf:name'>graph-01</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-01' property='mf:name'>graph-01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-01' typeof='mf:QueryEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-02:
+        <dt id='dawg-graph-02'>
+          <a class='testlink' href='#dawg-graph-02'>
+            dawg-graph-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-02' property='mf:name'>graph-02</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-02' property='mf:name'>graph-02</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-02' typeof='mf:QueryEvaluationTest'>
@@ -130,10 +132,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-03:
+        <dt id='dawg-graph-03'>
+          <a class='testlink' href='#dawg-graph-03'>
+            dawg-graph-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-03' property='mf:name'>graph-03</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-03' property='mf:name'>graph-03</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-03' typeof='mf:QueryEvaluationTest'>
@@ -156,10 +159,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-04:
+        <dt id='dawg-graph-04'>
+          <a class='testlink' href='#dawg-graph-04'>
+            dawg-graph-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-04' property='mf:name'>graph-04</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-04' property='mf:name'>graph-04</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-04' typeof='mf:QueryEvaluationTest'>
@@ -182,10 +186,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-05:
+        <dt id='dawg-graph-05'>
+          <a class='testlink' href='#dawg-graph-05'>
+            dawg-graph-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-05' property='mf:name'>graph-05</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-05' property='mf:name'>graph-05</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-05' typeof='mf:QueryEvaluationTest'>
@@ -208,10 +213,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-06:
+        <dt id='dawg-graph-06'>
+          <a class='testlink' href='#dawg-graph-06'>
+            dawg-graph-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-06' property='mf:name'>graph-06</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-06' property='mf:name'>graph-06</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-06' typeof='mf:QueryEvaluationTest'>
@@ -234,10 +240,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-07:
+        <dt id='dawg-graph-07'>
+          <a class='testlink' href='#dawg-graph-07'>
+            dawg-graph-07:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-07' property='mf:name'>graph-07</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-07' property='mf:name'>graph-07</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-07' typeof='mf:QueryEvaluationTest'>
@@ -260,10 +267,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-08'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-08'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-08:
+        <dt id='dawg-graph-08'>
+          <a class='testlink' href='#dawg-graph-08'>
+            dawg-graph-08:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-08' property='mf:name'>graph-08</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-08' property='mf:name'>graph-08</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-08' typeof='mf:QueryEvaluationTest'>
@@ -286,10 +294,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-09'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-09'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-09:
+        <dt id='dawg-graph-09'>
+          <a class='testlink' href='#dawg-graph-09'>
+            dawg-graph-09:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-09' property='mf:name'>graph-09</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-09' property='mf:name'>graph-09</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-09' typeof='mf:QueryEvaluationTest'>
@@ -312,10 +321,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-10b'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-10b'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-10b:
+        <dt id='dawg-graph-10b'>
+          <a class='testlink' href='#dawg-graph-10b'>
+            dawg-graph-10b:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-10b' property='mf:name'>graph-10b</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-10b' property='mf:name'>graph-10b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-10b' typeof='mf:QueryEvaluationTest'>
@@ -338,10 +348,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-11'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-11'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-11:
+        <dt id='dawg-graph-11'>
+          <a class='testlink' href='#dawg-graph-11'>
+            dawg-graph-11:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-11' property='mf:name'>graph-11</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-11' property='mf:name'>graph-11</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#dawg-graph-11' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/i18n/index.html
+++ b/sparql/sparql10/i18n/index.html
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-1:
+        <dt id='kanji-1'>
+          <a class='testlink' href='#kanji-1'>
+            kanji-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-1' property='mf:name'>kanji-01</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-1' property='mf:name'>kanji-01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-1' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-2:
+        <dt id='kanji-2'>
+          <a class='testlink' href='#kanji-2'>
+            kanji-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-2' property='mf:name'>kanji-02</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-2' property='mf:name'>kanji-02</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#kanji-2' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-1:
+        <dt id='normalization-1'>
+          <a class='testlink' href='#normalization-1'>
+            normalization-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-1' property='mf:name'>normalization-01</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-1' property='mf:name'>normalization-01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-1' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-2:
+        <dt id='normalization-2'>
+          <a class='testlink' href='#normalization-2'>
+            normalization-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-2' property='mf:name'>normalization-02</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-2' property='mf:name'>normalization-02</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-2' typeof='mf:QueryEvaluationTest'>
@@ -178,10 +182,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-3:
+        <dt id='normalization-3'>
+          <a class='testlink' href='#normalization-3'>
+            normalization-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-3' property='mf:name'>normalization-03</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-3' property='mf:name'>normalization-03</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/i18n/manifest#normalization-3' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/open-world/index.html
+++ b/sparql/sparql10/open-world/index.html
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-01:
+        <dt id='open-eq-01'>
+          <a class='testlink' href='#open-eq-01'>
+            open-eq-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-01' property='mf:name'>open-eq-01</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-01' property='mf:name'>open-eq-01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-01' typeof='mf:QueryEvaluationTest'>
@@ -103,10 +104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-02:
+        <dt id='open-eq-02'>
+          <a class='testlink' href='#open-eq-02'>
+            open-eq-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-02' property='mf:name'>open-eq-02</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-02' property='mf:name'>open-eq-02</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-02' typeof='mf:QueryEvaluationTest'>
@@ -129,10 +131,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-03:
+        <dt id='open-eq-03'>
+          <a class='testlink' href='#open-eq-03'>
+            open-eq-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-03' property='mf:name'>open-eq-03</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-03' property='mf:name'>open-eq-03</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-03' typeof='mf:QueryEvaluationTest'>
@@ -155,10 +158,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-04:
+        <dt id='open-eq-04'>
+          <a class='testlink' href='#open-eq-04'>
+            open-eq-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-04' property='mf:name'>open-eq-04</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-04' property='mf:name'>open-eq-04</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-04' typeof='mf:QueryEvaluationTest'>
@@ -181,10 +185,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-05:
+        <dt id='open-eq-05'>
+          <a class='testlink' href='#open-eq-05'>
+            open-eq-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-05' property='mf:name'>open-eq-05</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-05' property='mf:name'>open-eq-05</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-05' typeof='mf:QueryEvaluationTest'>
@@ -207,10 +212,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-06:
+        <dt id='open-eq-06'>
+          <a class='testlink' href='#open-eq-06'>
+            open-eq-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-06' property='mf:name'>open-eq-06</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-06' property='mf:name'>open-eq-06</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-06' typeof='mf:QueryEvaluationTest'>
@@ -233,10 +239,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-07:
+        <dt id='open-eq-07'>
+          <a class='testlink' href='#open-eq-07'>
+            open-eq-07:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-07' property='mf:name'>open-eq-07</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-07' property='mf:name'>open-eq-07</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-07' typeof='mf:QueryEvaluationTest'>
@@ -259,10 +266,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-08'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-08'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-08:
+        <dt id='open-eq-08'>
+          <a class='testlink' href='#open-eq-08'>
+            open-eq-08:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-08' property='mf:name'>open-eq-08</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-08' property='mf:name'>open-eq-08</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-08' typeof='mf:QueryEvaluationTest'>
@@ -285,10 +293,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-09'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-09'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-09:
+        <dt id='open-eq-09'>
+          <a class='testlink' href='#open-eq-09'>
+            open-eq-09:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-09' property='mf:name'>open-eq-09</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-09' property='mf:name'>open-eq-09</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-09' typeof='mf:QueryEvaluationTest'>
@@ -311,10 +320,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-10'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-10'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-10:
+        <dt id='open-eq-10'>
+          <a class='testlink' href='#open-eq-10'>
+            open-eq-10:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-10' property='mf:name'>open-eq-10</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-10' property='mf:name'>open-eq-10</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-10' typeof='mf:QueryEvaluationTest'>
@@ -337,10 +347,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-11'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-11'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-11:
+        <dt id='open-eq-11'>
+          <a class='testlink' href='#open-eq-11'>
+            open-eq-11:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-11' property='mf:name'>open-eq-11</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-11' property='mf:name'>open-eq-11</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-11' typeof='mf:QueryEvaluationTest'>
@@ -371,10 +382,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-12'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-12'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-12:
+        <dt id='open-eq-12'>
+          <a class='testlink' href='#open-eq-12'>
+            open-eq-12:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-12' property='mf:name'>open-eq-12</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-12' property='mf:name'>open-eq-12</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-12' typeof='mf:QueryEvaluationTest'>
@@ -397,10 +409,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-1:
+        <dt id='date-1'>
+          <a class='testlink' href='#date-1'>
+            date-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-1' property='mf:name'>date-1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-1' property='mf:name'>date-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-1' typeof='mf:QueryEvaluationTest'>
@@ -423,10 +436,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-2:
+        <dt id='date-2'>
+          <a class='testlink' href='#date-2'>
+            date-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-2' property='mf:name'>date-2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-2' property='mf:name'>date-2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-2' typeof='mf:QueryEvaluationTest'>
@@ -449,10 +463,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-3:
+        <dt id='date-3'>
+          <a class='testlink' href='#date-3'>
+            date-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-3' property='mf:name'>date-3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-3' property='mf:name'>date-3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-3' typeof='mf:QueryEvaluationTest'>
@@ -475,10 +490,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-4:
+        <dt id='date-4'>
+          <a class='testlink' href='#date-4'>
+            date-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-4' property='mf:name'>date-4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-4' property='mf:name'>date-4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#date-4' typeof='mf:QueryEvaluationTest'>
@@ -501,10 +517,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-01:
+        <dt id='open-cmp-01'>
+          <a class='testlink' href='#open-cmp-01'>
+            open-cmp-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-01' property='mf:name'>open-cmp-01</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-01' property='mf:name'>open-cmp-01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-01' typeof='mf:QueryEvaluationTest'>
@@ -527,10 +544,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-02:
+        <dt id='open-cmp-02'>
+          <a class='testlink' href='#open-cmp-02'>
+            open-cmp-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-02' property='mf:name'>open-cmp-02</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-02' property='mf:name'>open-cmp-02</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-cmp-02' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/optional-filter/index.html
+++ b/sparql/sparql10/optional-filter/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-001'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-001'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-001:
+        <dt id='dawg-optional-filter-001'>
+          <a class='testlink' href='#dawg-optional-filter-001'>
+            dawg-optional-filter-001:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-001' property='mf:name'>OPTIONAL-FILTER</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-001' property='mf:name'>OPTIONAL-FILTER</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-001' typeof='mf:QueryEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-002'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-002'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-002:
+        <dt id='dawg-optional-filter-002'>
+          <a class='testlink' href='#dawg-optional-filter-002'>
+            dawg-optional-filter-002:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-002' property='mf:name'>OPTIONAL - Outer FILTER</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-002' property='mf:name'>OPTIONAL - Outer FILTER</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-002' typeof='mf:QueryEvaluationTest'>
@@ -130,10 +132,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-003'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-003'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-003:
+        <dt id='dawg-optional-filter-003'>
+          <a class='testlink' href='#dawg-optional-filter-003'>
+            dawg-optional-filter-003:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-003' property='mf:name'>OPTIONAL - Outer FILTER with BOUND</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-003' property='mf:name'>OPTIONAL - Outer FILTER with BOUND</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-003' typeof='mf:QueryEvaluationTest'>
@@ -156,10 +159,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-004'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-004'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-004:
+        <dt id='dawg-optional-filter-004'>
+          <a class='testlink' href='#dawg-optional-filter-004'>
+            dawg-optional-filter-004:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-004' property='mf:name'>OPTIONAL - Inner FILTER with negative EBV for outer variables</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-004' property='mf:name'>OPTIONAL - Inner FILTER with negative EBV for outer variables</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-004' typeof='mf:QueryEvaluationTest'>
@@ -182,10 +186,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-005-not-simplified'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-005-not-simplified'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-005-not-simplified:
+        <dt id='dawg-optional-filter-005-not-simplified'>
+          <a class='testlink' href='#dawg-optional-filter-005-not-simplified'>
+            dawg-optional-filter-005-not-simplified:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-005-not-simplified' property='mf:name'>dawg-optional-filter-005-not-simplified</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-005-not-simplified' property='mf:name'>dawg-optional-filter-005-not-simplified</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional-filter/manifest#dawg-optional-filter-005-not-simplified' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/optional/index.html
+++ b/sparql/sparql10/optional/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-001'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-001'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-001:
+        <dt id='dawg-optional-001'>
+          <a class='testlink' href='#dawg-optional-001'>
+            dawg-optional-001:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-001' property='mf:name'>One optional clause</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-001' property='mf:name'>One optional clause</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-001' typeof='mf:QueryEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-002'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-002'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-002:
+        <dt id='dawg-optional-002'>
+          <a class='testlink' href='#dawg-optional-002'>
+            dawg-optional-002:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-002' property='mf:name'>Two optional clauses</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-002' property='mf:name'>Two optional clauses</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-002' typeof='mf:QueryEvaluationTest'>
@@ -130,10 +132,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-union-001'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-union-001'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-union-001:
+        <dt id='dawg-union-001'>
+          <a class='testlink' href='#dawg-union-001'>
+            dawg-union-001:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-union-001' property='mf:name'>Union is not optional</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-union-001' property='mf:name'>Union is not optional</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-union-001' typeof='mf:QueryEvaluationTest'>
@@ -156,10 +159,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-1:
+        <dt id='dawg-optional-complex-1'>
+          <a class='testlink' href='#dawg-optional-complex-1'>
+            dawg-optional-complex-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-1' property='mf:name'>Complex optional semantics: 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-1' property='mf:name'>Complex optional semantics: 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-1' typeof='mf:QueryEvaluationTest'>
@@ -182,10 +186,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-2:
+        <dt id='dawg-optional-complex-2'>
+          <a class='testlink' href='#dawg-optional-complex-2'>
+            dawg-optional-complex-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-2' property='mf:name'>Complex optional semantics: 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-2' property='mf:name'>Complex optional semantics: 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-2' typeof='mf:QueryEvaluationTest'>
@@ -208,10 +213,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-3:
+        <dt id='dawg-optional-complex-3'>
+          <a class='testlink' href='#dawg-optional-complex-3'>
+            dawg-optional-complex-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-3' property='mf:name'>Complex optional semantics: 3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-3' property='mf:name'>Complex optional semantics: 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-3' typeof='mf:QueryEvaluationTest'>
@@ -234,10 +240,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-4:
+        <dt id='dawg-optional-complex-4'>
+          <a class='testlink' href='#dawg-optional-complex-4'>
+            dawg-optional-complex-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-4' property='mf:name'>Complex optional semantics: 4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-4' property='mf:name'>Complex optional semantics: 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/optional/manifest#dawg-optional-complex-4' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/reduced/index.html
+++ b/sparql/sparql10/reduced/index.html
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-1:
+        <dt id='reduced-1'>
+          <a class='testlink' href='#reduced-1'>
+            reduced-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-1' property='mf:name'>SELECT REDUCED *</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-1' property='mf:name'>SELECT REDUCED *</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-1' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-2:
+        <dt id='reduced-2'>
+          <a class='testlink' href='#reduced-2'>
+            reduced-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-2' property='mf:name'>SELECT REDUCED ?x with strings</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-2' property='mf:name'>SELECT REDUCED ?x with strings</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/reduced/manifest#reduced-2' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/regex/index.html
+++ b/sparql/sparql10/regex/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-001'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-001'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-001:
+        <dt id='dawg-regex-001'>
+          <a class='testlink' href='#dawg-regex-001'>
+            dawg-regex-001:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-001' property='mf:name'>regex-query-001</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-001' property='mf:name'>regex-query-001</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-001' typeof='mf:QueryEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-002'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-002'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-002:
+        <dt id='dawg-regex-002'>
+          <a class='testlink' href='#dawg-regex-002'>
+            dawg-regex-002:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-002' property='mf:name'>regex-query-002</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-002' property='mf:name'>regex-query-002</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-002' typeof='mf:QueryEvaluationTest'>
@@ -130,10 +132,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-003'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-003'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-003:
+        <dt id='dawg-regex-003'>
+          <a class='testlink' href='#dawg-regex-003'>
+            dawg-regex-003:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-003' property='mf:name'>regex-query-003</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-003' property='mf:name'>regex-query-003</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-003' typeof='mf:QueryEvaluationTest'>
@@ -156,10 +159,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-004'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-004'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-004:
+        <dt id='dawg-regex-004'>
+          <a class='testlink' href='#dawg-regex-004'>
+            dawg-regex-004:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-004' property='mf:name'>regex-query-004</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-004' property='mf:name'>regex-query-004</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/regex/manifest#dawg-regex-004' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/solution-seq/index.html
+++ b/sparql/sparql10/solution-seq/index.html
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-1:
+        <dt id='limit-1'>
+          <a class='testlink' href='#limit-1'>
+            limit-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-1' property='mf:name'>Limit 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-1' property='mf:name'>Limit 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-1' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-2:
+        <dt id='limit-2'>
+          <a class='testlink' href='#limit-2'>
+            limit-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-2' property='mf:name'>Limit 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-2' property='mf:name'>Limit 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-2' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-3:
+        <dt id='limit-3'>
+          <a class='testlink' href='#limit-3'>
+            limit-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-3' property='mf:name'>Limit 3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-3' property='mf:name'>Limit 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-3' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-4:
+        <dt id='limit-4'>
+          <a class='testlink' href='#limit-4'>
+            limit-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-4' property='mf:name'>Limit 4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-4' property='mf:name'>Limit 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#limit-4' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-1:
+        <dt id='offset-1'>
+          <a class='testlink' href='#offset-1'>
+            offset-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-1' property='mf:name'>Offset 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-1' property='mf:name'>Offset 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-1' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-2:
+        <dt id='offset-2'>
+          <a class='testlink' href='#offset-2'>
+            offset-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-2' property='mf:name'>Offset 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-2' property='mf:name'>Offset 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-2' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-3:
+        <dt id='offset-3'>
+          <a class='testlink' href='#offset-3'>
+            offset-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-3' property='mf:name'>Offset 3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-3' property='mf:name'>Offset 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-3' typeof='mf:QueryEvaluationTest'>
@@ -252,10 +259,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-4:
+        <dt id='offset-4'>
+          <a class='testlink' href='#offset-4'>
+            offset-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-4' property='mf:name'>Offset 4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-4' property='mf:name'>Offset 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#offset-4' typeof='mf:QueryEvaluationTest'>
@@ -277,10 +285,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-1:
+        <dt id='slice-1'>
+          <a class='testlink' href='#slice-1'>
+            slice-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-1' property='mf:name'>Slice 1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-1' property='mf:name'>Slice 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-1' typeof='mf:QueryEvaluationTest'>
@@ -302,10 +311,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-2:
+        <dt id='slice-2'>
+          <a class='testlink' href='#slice-2'>
+            slice-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-2' property='mf:name'>Slice 2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-2' property='mf:name'>Slice 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-2' typeof='mf:QueryEvaluationTest'>
@@ -327,10 +337,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-3:
+        <dt id='slice-3'>
+          <a class='testlink' href='#slice-3'>
+            slice-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-3' property='mf:name'>Slice 3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-3' property='mf:name'>Slice 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-3' typeof='mf:QueryEvaluationTest'>
@@ -352,10 +363,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-4:
+        <dt id='slice-4'>
+          <a class='testlink' href='#slice-4'>
+            slice-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-4' property='mf:name'>Slice 4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-4' property='mf:name'>Slice 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-4' typeof='mf:QueryEvaluationTest'>
@@ -377,10 +389,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-5'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-5'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-5:
+        <dt id='slice-5'>
+          <a class='testlink' href='#slice-5'>
+            slice-5:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-5' property='mf:name'>Slice 5</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-5' property='mf:name'>Slice 5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/solution-seq/manifest#slice-5' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/sort/index.html
+++ b/sparql/sparql10/sort/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-1'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-1'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-1:
+        <dt id='dawg-sort-1'>
+          <a class='testlink' href='#dawg-sort-1'>
+            dawg-sort-1:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-1' property='mf:name'>sort-1</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-1' property='mf:name'>sort-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-1' typeof='mf:QueryEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-2'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-2'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-2:
+        <dt id='dawg-sort-2'>
+          <a class='testlink' href='#dawg-sort-2'>
+            dawg-sort-2:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-2' property='mf:name'>sort-2</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-2' property='mf:name'>sort-2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-2' typeof='mf:QueryEvaluationTest'>
@@ -130,10 +132,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-3'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-3'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-3:
+        <dt id='dawg-sort-3'>
+          <a class='testlink' href='#dawg-sort-3'>
+            dawg-sort-3:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-3' property='mf:name'>sort-3</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-3' property='mf:name'>sort-3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-3' typeof='mf:QueryEvaluationTest'>
@@ -156,10 +159,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-4'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-4'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-4:
+        <dt id='dawg-sort-4'>
+          <a class='testlink' href='#dawg-sort-4'>
+            dawg-sort-4:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-4' property='mf:name'>sort-4</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-4' property='mf:name'>sort-4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-4' typeof='mf:QueryEvaluationTest'>
@@ -182,10 +186,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-5'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-5'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-5:
+        <dt id='dawg-sort-5'>
+          <a class='testlink' href='#dawg-sort-5'>
+            dawg-sort-5:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-5' property='mf:name'>sort-5</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-5' property='mf:name'>sort-5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-5' typeof='mf:QueryEvaluationTest'>
@@ -208,10 +213,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-6'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-6'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-6:
+        <dt id='dawg-sort-6'>
+          <a class='testlink' href='#dawg-sort-6'>
+            dawg-sort-6:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-6' property='mf:name'>sort-6</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-6' property='mf:name'>sort-6</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-6' typeof='mf:QueryEvaluationTest'>
@@ -234,10 +240,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-7'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-7'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-7:
+        <dt id='dawg-sort-7'>
+          <a class='testlink' href='#dawg-sort-7'>
+            dawg-sort-7:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-7' property='mf:name'>sort-7</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-7' property='mf:name'>sort-7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-7' typeof='mf:QueryEvaluationTest'>
@@ -260,10 +267,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-8'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-8'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-8:
+        <dt id='dawg-sort-8'>
+          <a class='testlink' href='#dawg-sort-8'>
+            dawg-sort-8:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-8' property='mf:name'>sort-8</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-8' property='mf:name'>sort-8</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-8' typeof='mf:QueryEvaluationTest'>
@@ -286,10 +294,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-9'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-9'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-9:
+        <dt id='dawg-sort-9'>
+          <a class='testlink' href='#dawg-sort-9'>
+            dawg-sort-9:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-9' property='mf:name'>sort-9</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-9' property='mf:name'>sort-9</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-9' typeof='mf:QueryEvaluationTest'>
@@ -312,10 +321,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-10'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-10'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-10:
+        <dt id='dawg-sort-10'>
+          <a class='testlink' href='#dawg-sort-10'>
+            dawg-sort-10:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-10' property='mf:name'>sort-10</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-10' property='mf:name'>sort-10</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-10' typeof='mf:QueryEvaluationTest'>
@@ -338,10 +348,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-numbers'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-numbers'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-numbers:
+        <dt id='dawg-sort-numbers'>
+          <a class='testlink' href='#dawg-sort-numbers'>
+            dawg-sort-numbers:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-numbers' property='mf:name'>Expression sort</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-numbers' property='mf:name'>Expression sort</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-numbers' typeof='mf:QueryEvaluationTest'>
@@ -364,10 +375,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-builtin'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-builtin'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-builtin:
+        <dt id='dawg-sort-builtin'>
+          <a class='testlink' href='#dawg-sort-builtin'>
+            dawg-sort-builtin:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-builtin' property='mf:name'>Builtin sort</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-builtin' property='mf:name'>Builtin sort</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-builtin' typeof='mf:QueryEvaluationTest'>
@@ -390,10 +402,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-function'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-function'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-function:
+        <dt id='dawg-sort-function'>
+          <a class='testlink' href='#dawg-sort-function'>
+            dawg-sort-function:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-function' property='mf:name'>Function sort</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-function' property='mf:name'>Function sort</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/sort/manifest#dawg-sort-function' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql10/syntax-sparql1/index.html
+++ b/sparql/sparql10/syntax-sparql1/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-01:
+        <dt id='syntax-basic-01'>
+          <a class='testlink' href='#syntax-basic-01'>
+            syntax-basic-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-01' property='mf:name'>syntax-basic-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-01' property='mf:name'>syntax-basic-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-01' typeof='mf:PositiveSyntaxTest'>
@@ -98,10 +99,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-02:
+        <dt id='syntax-basic-02'>
+          <a class='testlink' href='#syntax-basic-02'>
+            syntax-basic-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-02' property='mf:name'>syntax-basic-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-02' property='mf:name'>syntax-basic-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-02' typeof='mf:PositiveSyntaxTest'>
@@ -118,10 +120,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-03:
+        <dt id='syntax-basic-03'>
+          <a class='testlink' href='#syntax-basic-03'>
+            syntax-basic-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-03' property='mf:name'>syntax-basic-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-03' property='mf:name'>syntax-basic-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-03' typeof='mf:PositiveSyntaxTest'>
@@ -138,10 +141,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-04:
+        <dt id='syntax-basic-04'>
+          <a class='testlink' href='#syntax-basic-04'>
+            syntax-basic-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-04' property='mf:name'>syntax-basic-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-04' property='mf:name'>syntax-basic-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-04' typeof='mf:PositiveSyntaxTest'>
@@ -158,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-05:
+        <dt id='syntax-basic-05'>
+          <a class='testlink' href='#syntax-basic-05'>
+            syntax-basic-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-05' property='mf:name'>syntax-basic-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-05' property='mf:name'>syntax-basic-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-05' typeof='mf:PositiveSyntaxTest'>
@@ -178,10 +183,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-06:
+        <dt id='syntax-basic-06'>
+          <a class='testlink' href='#syntax-basic-06'>
+            syntax-basic-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-06' property='mf:name'>syntax-basic-06.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-06' property='mf:name'>syntax-basic-06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-basic-06' typeof='mf:PositiveSyntaxTest'>
@@ -198,10 +204,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-01:
+        <dt id='syntax-qname-01'>
+          <a class='testlink' href='#syntax-qname-01'>
+            syntax-qname-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-01' property='mf:name'>syntax-qname-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-01' property='mf:name'>syntax-qname-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-01' typeof='mf:PositiveSyntaxTest'>
@@ -218,10 +225,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-02:
+        <dt id='syntax-qname-02'>
+          <a class='testlink' href='#syntax-qname-02'>
+            syntax-qname-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-02' property='mf:name'>syntax-qname-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-02' property='mf:name'>syntax-qname-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-02' typeof='mf:PositiveSyntaxTest'>
@@ -238,10 +246,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-03:
+        <dt id='syntax-qname-03'>
+          <a class='testlink' href='#syntax-qname-03'>
+            syntax-qname-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-03' property='mf:name'>syntax-qname-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-03' property='mf:name'>syntax-qname-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-03' typeof='mf:PositiveSyntaxTest'>
@@ -258,10 +267,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-04:
+        <dt id='syntax-qname-04'>
+          <a class='testlink' href='#syntax-qname-04'>
+            syntax-qname-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-04' property='mf:name'>syntax-qname-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-04' property='mf:name'>syntax-qname-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-04' typeof='mf:PositiveSyntaxTest'>
@@ -278,10 +288,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-05:
+        <dt id='syntax-qname-05'>
+          <a class='testlink' href='#syntax-qname-05'>
+            syntax-qname-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-05' property='mf:name'>syntax-qname-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-05' property='mf:name'>syntax-qname-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-05' typeof='mf:PositiveSyntaxTest'>
@@ -298,10 +309,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-06:
+        <dt id='syntax-qname-06'>
+          <a class='testlink' href='#syntax-qname-06'>
+            syntax-qname-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-06' property='mf:name'>syntax-qname-06.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-06' property='mf:name'>syntax-qname-06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-06' typeof='mf:PositiveSyntaxTest'>
@@ -318,10 +330,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-07:
+        <dt id='syntax-qname-07'>
+          <a class='testlink' href='#syntax-qname-07'>
+            syntax-qname-07:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-07' property='mf:name'>syntax-qname-07.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-07' property='mf:name'>syntax-qname-07.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-07' typeof='mf:PositiveSyntaxTest'>
@@ -338,10 +351,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-08'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-08'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-08:
+        <dt id='syntax-qname-08'>
+          <a class='testlink' href='#syntax-qname-08'>
+            syntax-qname-08:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-08' property='mf:name'>syntax-qname-08.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-08' property='mf:name'>syntax-qname-08.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-qname-08' typeof='mf:PositiveSyntaxTest'>
@@ -358,10 +372,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-01:
+        <dt id='syntax-lit-01'>
+          <a class='testlink' href='#syntax-lit-01'>
+            syntax-lit-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-01' property='mf:name'>syntax-lit-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-01' property='mf:name'>syntax-lit-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-01' typeof='mf:PositiveSyntaxTest'>
@@ -378,10 +393,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-02:
+        <dt id='syntax-lit-02'>
+          <a class='testlink' href='#syntax-lit-02'>
+            syntax-lit-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-02' property='mf:name'>syntax-lit-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-02' property='mf:name'>syntax-lit-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-02' typeof='mf:PositiveSyntaxTest'>
@@ -398,10 +414,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-03:
+        <dt id='syntax-lit-03'>
+          <a class='testlink' href='#syntax-lit-03'>
+            syntax-lit-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-03' property='mf:name'>syntax-lit-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-03' property='mf:name'>syntax-lit-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-03' typeof='mf:PositiveSyntaxTest'>
@@ -418,10 +435,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-04:
+        <dt id='syntax-lit-04'>
+          <a class='testlink' href='#syntax-lit-04'>
+            syntax-lit-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-04' property='mf:name'>syntax-lit-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-04' property='mf:name'>syntax-lit-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-04' typeof='mf:PositiveSyntaxTest'>
@@ -438,10 +456,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-05:
+        <dt id='syntax-lit-05'>
+          <a class='testlink' href='#syntax-lit-05'>
+            syntax-lit-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-05' property='mf:name'>syntax-lit-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-05' property='mf:name'>syntax-lit-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-05' typeof='mf:PositiveSyntaxTest'>
@@ -458,10 +477,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-06:
+        <dt id='syntax-lit-06'>
+          <a class='testlink' href='#syntax-lit-06'>
+            syntax-lit-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-06' property='mf:name'>syntax-lit-06.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-06' property='mf:name'>syntax-lit-06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-06' typeof='mf:PositiveSyntaxTest'>
@@ -478,10 +498,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-07:
+        <dt id='syntax-lit-07'>
+          <a class='testlink' href='#syntax-lit-07'>
+            syntax-lit-07:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-07' property='mf:name'>syntax-lit-07.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-07' property='mf:name'>syntax-lit-07.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-07' typeof='mf:PositiveSyntaxTest'>
@@ -498,10 +519,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-08'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-08'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-08:
+        <dt id='syntax-lit-08'>
+          <a class='testlink' href='#syntax-lit-08'>
+            syntax-lit-08:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-08' property='mf:name'>syntax-lit-08.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-08' property='mf:name'>syntax-lit-08.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-08' typeof='mf:PositiveSyntaxTest'>
@@ -518,10 +540,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-09'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-09'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-09:
+        <dt id='syntax-lit-09'>
+          <a class='testlink' href='#syntax-lit-09'>
+            syntax-lit-09:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-09' property='mf:name'>syntax-lit-09.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-09' property='mf:name'>syntax-lit-09.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-09' typeof='mf:PositiveSyntaxTest'>
@@ -538,10 +561,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-10'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-10'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-10:
+        <dt id='syntax-lit-10'>
+          <a class='testlink' href='#syntax-lit-10'>
+            syntax-lit-10:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-10' property='mf:name'>syntax-lit-10.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-10' property='mf:name'>syntax-lit-10.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-10' typeof='mf:PositiveSyntaxTest'>
@@ -558,10 +582,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-11'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-11'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-11:
+        <dt id='syntax-lit-11'>
+          <a class='testlink' href='#syntax-lit-11'>
+            syntax-lit-11:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-11' property='mf:name'>syntax-lit-11.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-11' property='mf:name'>syntax-lit-11.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-11' typeof='mf:PositiveSyntaxTest'>
@@ -578,10 +603,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-12'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-12'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-12:
+        <dt id='syntax-lit-12'>
+          <a class='testlink' href='#syntax-lit-12'>
+            syntax-lit-12:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-12' property='mf:name'>syntax-lit-12.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-12' property='mf:name'>syntax-lit-12.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-12' typeof='mf:PositiveSyntaxTest'>
@@ -598,10 +624,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-13'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-13'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-13:
+        <dt id='syntax-lit-13'>
+          <a class='testlink' href='#syntax-lit-13'>
+            syntax-lit-13:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-13' property='mf:name'>syntax-lit-13.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-13' property='mf:name'>syntax-lit-13.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-13' typeof='mf:PositiveSyntaxTest'>
@@ -618,10 +645,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-14'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-14'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-14:
+        <dt id='syntax-lit-14'>
+          <a class='testlink' href='#syntax-lit-14'>
+            syntax-lit-14:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-14' property='mf:name'>syntax-lit-14.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-14' property='mf:name'>syntax-lit-14.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-14' typeof='mf:PositiveSyntaxTest'>
@@ -638,10 +666,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-15'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-15'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-15:
+        <dt id='syntax-lit-15'>
+          <a class='testlink' href='#syntax-lit-15'>
+            syntax-lit-15:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-15' property='mf:name'>syntax-lit-15.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-15' property='mf:name'>syntax-lit-15.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-15' typeof='mf:PositiveSyntaxTest'>
@@ -658,10 +687,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-16'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-16'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-16:
+        <dt id='syntax-lit-16'>
+          <a class='testlink' href='#syntax-lit-16'>
+            syntax-lit-16:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-16' property='mf:name'>syntax-lit-16.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-16' property='mf:name'>syntax-lit-16.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-16' typeof='mf:PositiveSyntaxTest'>
@@ -678,10 +708,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-17'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-17'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-17:
+        <dt id='syntax-lit-17'>
+          <a class='testlink' href='#syntax-lit-17'>
+            syntax-lit-17:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-17' property='mf:name'>syntax-lit-17.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-17' property='mf:name'>syntax-lit-17.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-17' typeof='mf:PositiveSyntaxTest'>
@@ -698,10 +729,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-18'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-18'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-18:
+        <dt id='syntax-lit-18'>
+          <a class='testlink' href='#syntax-lit-18'>
+            syntax-lit-18:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-18' property='mf:name'>syntax-lit-18.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-18' property='mf:name'>syntax-lit-18.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-18' typeof='mf:PositiveSyntaxTest'>
@@ -718,10 +750,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-19'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-19'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-19:
+        <dt id='syntax-lit-19'>
+          <a class='testlink' href='#syntax-lit-19'>
+            syntax-lit-19:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-19' property='mf:name'>syntax-lit-19.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-19' property='mf:name'>syntax-lit-19.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-19' typeof='mf:PositiveSyntaxTest'>
@@ -738,10 +771,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-20'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-20'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-20:
+        <dt id='syntax-lit-20'>
+          <a class='testlink' href='#syntax-lit-20'>
+            syntax-lit-20:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-20' property='mf:name'>syntax-lit-20.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-20' property='mf:name'>syntax-lit-20.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lit-20' typeof='mf:PositiveSyntaxTest'>
@@ -758,10 +792,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-01:
+        <dt id='syntax-struct-01'>
+          <a class='testlink' href='#syntax-struct-01'>
+            syntax-struct-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-01' property='mf:name'>syntax-struct-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-01' property='mf:name'>syntax-struct-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-01' typeof='mf:PositiveSyntaxTest'>
@@ -778,10 +813,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-02:
+        <dt id='syntax-struct-02'>
+          <a class='testlink' href='#syntax-struct-02'>
+            syntax-struct-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-02' property='mf:name'>syntax-struct-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-02' property='mf:name'>syntax-struct-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-02' typeof='mf:PositiveSyntaxTest'>
@@ -798,10 +834,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-03:
+        <dt id='syntax-struct-03'>
+          <a class='testlink' href='#syntax-struct-03'>
+            syntax-struct-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-03' property='mf:name'>syntax-struct-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-03' property='mf:name'>syntax-struct-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-03' typeof='mf:PositiveSyntaxTest'>
@@ -818,10 +855,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-05:
+        <dt id='syntax-struct-05'>
+          <a class='testlink' href='#syntax-struct-05'>
+            syntax-struct-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-05' property='mf:name'>syntax-struct-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-05' property='mf:name'>syntax-struct-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-05' typeof='mf:PositiveSyntaxTest'>
@@ -838,10 +876,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-06:
+        <dt id='syntax-struct-06'>
+          <a class='testlink' href='#syntax-struct-06'>
+            syntax-struct-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-06' property='mf:name'>syntax-struct-06.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-06' property='mf:name'>syntax-struct-06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-06' typeof='mf:PositiveSyntaxTest'>
@@ -858,10 +897,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-07:
+        <dt id='syntax-struct-07'>
+          <a class='testlink' href='#syntax-struct-07'>
+            syntax-struct-07:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-07' property='mf:name'>syntax-struct-07.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-07' property='mf:name'>syntax-struct-07.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-07' typeof='mf:PositiveSyntaxTest'>
@@ -878,10 +918,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-08'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-08'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-08:
+        <dt id='syntax-struct-08'>
+          <a class='testlink' href='#syntax-struct-08'>
+            syntax-struct-08:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-08' property='mf:name'>syntax-struct-08.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-08' property='mf:name'>syntax-struct-08.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-08' typeof='mf:PositiveSyntaxTest'>
@@ -898,10 +939,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-09'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-09'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-09:
+        <dt id='syntax-struct-09'>
+          <a class='testlink' href='#syntax-struct-09'>
+            syntax-struct-09:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-09' property='mf:name'>syntax-struct-09.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-09' property='mf:name'>syntax-struct-09.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-09' typeof='mf:PositiveSyntaxTest'>
@@ -918,10 +960,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-10'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-10'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-10:
+        <dt id='syntax-struct-10'>
+          <a class='testlink' href='#syntax-struct-10'>
+            syntax-struct-10:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-10' property='mf:name'>syntax-struct-10.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-10' property='mf:name'>syntax-struct-10.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-10' typeof='mf:PositiveSyntaxTest'>
@@ -938,10 +981,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-11'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-11'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-11:
+        <dt id='syntax-struct-11'>
+          <a class='testlink' href='#syntax-struct-11'>
+            syntax-struct-11:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-11' property='mf:name'>syntax-struct-11.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-11' property='mf:name'>syntax-struct-11.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-11' typeof='mf:PositiveSyntaxTest'>
@@ -958,10 +1002,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-12'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-12'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-12:
+        <dt id='syntax-struct-12'>
+          <a class='testlink' href='#syntax-struct-12'>
+            syntax-struct-12:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-12' property='mf:name'>syntax-struct-12.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-12' property='mf:name'>syntax-struct-12.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-12' typeof='mf:PositiveSyntaxTest'>
@@ -978,10 +1023,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-13'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-13'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-13:
+        <dt id='syntax-struct-13'>
+          <a class='testlink' href='#syntax-struct-13'>
+            syntax-struct-13:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-13' property='mf:name'>syntax-struct-13.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-13' property='mf:name'>syntax-struct-13.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-13' typeof='mf:PositiveSyntaxTest'>
@@ -998,10 +1044,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-14'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-14'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-14:
+        <dt id='syntax-struct-14'>
+          <a class='testlink' href='#syntax-struct-14'>
+            syntax-struct-14:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-14' property='mf:name'>syntax-struct-14.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-14' property='mf:name'>syntax-struct-14.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-struct-14' typeof='mf:PositiveSyntaxTest'>
@@ -1018,10 +1065,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-01:
+        <dt id='syntax-lists-01'>
+          <a class='testlink' href='#syntax-lists-01'>
+            syntax-lists-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-01' property='mf:name'>syntax-lists-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-01' property='mf:name'>syntax-lists-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-01' typeof='mf:PositiveSyntaxTest'>
@@ -1038,10 +1086,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-02:
+        <dt id='syntax-lists-02'>
+          <a class='testlink' href='#syntax-lists-02'>
+            syntax-lists-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-02' property='mf:name'>syntax-lists-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-02' property='mf:name'>syntax-lists-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-02' typeof='mf:PositiveSyntaxTest'>
@@ -1058,10 +1107,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-03:
+        <dt id='syntax-lists-03'>
+          <a class='testlink' href='#syntax-lists-03'>
+            syntax-lists-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-03' property='mf:name'>syntax-lists-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-03' property='mf:name'>syntax-lists-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-03' typeof='mf:PositiveSyntaxTest'>
@@ -1078,10 +1128,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-04:
+        <dt id='syntax-lists-04'>
+          <a class='testlink' href='#syntax-lists-04'>
+            syntax-lists-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-04' property='mf:name'>syntax-lists-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-04' property='mf:name'>syntax-lists-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-04' typeof='mf:PositiveSyntaxTest'>
@@ -1098,10 +1149,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-05:
+        <dt id='syntax-lists-05'>
+          <a class='testlink' href='#syntax-lists-05'>
+            syntax-lists-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-05' property='mf:name'>syntax-lists-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-05' property='mf:name'>syntax-lists-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-lists-05' typeof='mf:PositiveSyntaxTest'>
@@ -1118,10 +1170,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-01:
+        <dt id='syntax-bnodes-01'>
+          <a class='testlink' href='#syntax-bnodes-01'>
+            syntax-bnodes-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-01' property='mf:name'>syntax-bnodes-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-01' property='mf:name'>syntax-bnodes-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-01' typeof='mf:PositiveSyntaxTest'>
@@ -1138,10 +1191,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-02:
+        <dt id='syntax-bnodes-02'>
+          <a class='testlink' href='#syntax-bnodes-02'>
+            syntax-bnodes-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-02' property='mf:name'>syntax-bnodes-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-02' property='mf:name'>syntax-bnodes-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-02' typeof='mf:PositiveSyntaxTest'>
@@ -1158,10 +1212,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-03:
+        <dt id='syntax-bnodes-03'>
+          <a class='testlink' href='#syntax-bnodes-03'>
+            syntax-bnodes-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-03' property='mf:name'>syntax-bnodes-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-03' property='mf:name'>syntax-bnodes-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-03' typeof='mf:PositiveSyntaxTest'>
@@ -1178,10 +1233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-04:
+        <dt id='syntax-bnodes-04'>
+          <a class='testlink' href='#syntax-bnodes-04'>
+            syntax-bnodes-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-04' property='mf:name'>syntax-bnodes-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-04' property='mf:name'>syntax-bnodes-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-04' typeof='mf:PositiveSyntaxTest'>
@@ -1198,10 +1254,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-05:
+        <dt id='syntax-bnodes-05'>
+          <a class='testlink' href='#syntax-bnodes-05'>
+            syntax-bnodes-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-05' property='mf:name'>syntax-bnodes-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-05' property='mf:name'>syntax-bnodes-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-bnodes-05' typeof='mf:PositiveSyntaxTest'>
@@ -1218,10 +1275,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-01:
+        <dt id='syntax-forms-01'>
+          <a class='testlink' href='#syntax-forms-01'>
+            syntax-forms-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-01' property='mf:name'>syntax-forms-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-01' property='mf:name'>syntax-forms-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-01' typeof='mf:PositiveSyntaxTest'>
@@ -1238,10 +1296,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-02:
+        <dt id='syntax-forms-02'>
+          <a class='testlink' href='#syntax-forms-02'>
+            syntax-forms-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-02' property='mf:name'>syntax-forms-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-02' property='mf:name'>syntax-forms-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-forms-02' typeof='mf:PositiveSyntaxTest'>
@@ -1258,10 +1317,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-01:
+        <dt id='syntax-union-01'>
+          <a class='testlink' href='#syntax-union-01'>
+            syntax-union-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-01' property='mf:name'>syntax-union-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-01' property='mf:name'>syntax-union-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-01' typeof='mf:PositiveSyntaxTest'>
@@ -1278,10 +1338,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-02:
+        <dt id='syntax-union-02'>
+          <a class='testlink' href='#syntax-union-02'>
+            syntax-union-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-02' property='mf:name'>syntax-union-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-02' property='mf:name'>syntax-union-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-union-02' typeof='mf:PositiveSyntaxTest'>
@@ -1298,10 +1359,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-01:
+        <dt id='syntax-expr-01'>
+          <a class='testlink' href='#syntax-expr-01'>
+            syntax-expr-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-01' property='mf:name'>syntax-expr-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-01' property='mf:name'>syntax-expr-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-01' typeof='mf:PositiveSyntaxTest'>
@@ -1318,10 +1380,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-02:
+        <dt id='syntax-expr-02'>
+          <a class='testlink' href='#syntax-expr-02'>
+            syntax-expr-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-02' property='mf:name'>syntax-expr-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-02' property='mf:name'>syntax-expr-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-02' typeof='mf:PositiveSyntaxTest'>
@@ -1338,10 +1401,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-03:
+        <dt id='syntax-expr-03'>
+          <a class='testlink' href='#syntax-expr-03'>
+            syntax-expr-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-03' property='mf:name'>syntax-expr-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-03' property='mf:name'>syntax-expr-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-03' typeof='mf:PositiveSyntaxTest'>
@@ -1358,10 +1422,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-04:
+        <dt id='syntax-expr-04'>
+          <a class='testlink' href='#syntax-expr-04'>
+            syntax-expr-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-04' property='mf:name'>syntax-expr-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-04' property='mf:name'>syntax-expr-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-04' typeof='mf:PositiveSyntaxTest'>
@@ -1378,10 +1443,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-05:
+        <dt id='syntax-expr-05'>
+          <a class='testlink' href='#syntax-expr-05'>
+            syntax-expr-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-05' property='mf:name'>syntax-expr-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-05' property='mf:name'>syntax-expr-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-expr-05' typeof='mf:PositiveSyntaxTest'>
@@ -1398,10 +1464,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-01:
+        <dt id='syntax-order-01'>
+          <a class='testlink' href='#syntax-order-01'>
+            syntax-order-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-01' property='mf:name'>syntax-order-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-01' property='mf:name'>syntax-order-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-01' typeof='mf:PositiveSyntaxTest'>
@@ -1418,10 +1485,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-02:
+        <dt id='syntax-order-02'>
+          <a class='testlink' href='#syntax-order-02'>
+            syntax-order-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-02' property='mf:name'>syntax-order-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-02' property='mf:name'>syntax-order-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-02' typeof='mf:PositiveSyntaxTest'>
@@ -1438,10 +1506,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-03:
+        <dt id='syntax-order-03'>
+          <a class='testlink' href='#syntax-order-03'>
+            syntax-order-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-03' property='mf:name'>syntax-order-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-03' property='mf:name'>syntax-order-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-03' typeof='mf:PositiveSyntaxTest'>
@@ -1458,10 +1527,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-04:
+        <dt id='syntax-order-04'>
+          <a class='testlink' href='#syntax-order-04'>
+            syntax-order-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-04' property='mf:name'>syntax-order-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-04' property='mf:name'>syntax-order-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-04' typeof='mf:PositiveSyntaxTest'>
@@ -1478,10 +1548,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-05:
+        <dt id='syntax-order-05'>
+          <a class='testlink' href='#syntax-order-05'>
+            syntax-order-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-05' property='mf:name'>syntax-order-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-05' property='mf:name'>syntax-order-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-05' typeof='mf:PositiveSyntaxTest'>
@@ -1498,10 +1569,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-06:
+        <dt id='syntax-order-06'>
+          <a class='testlink' href='#syntax-order-06'>
+            syntax-order-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-06' property='mf:name'>syntax-order-06.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-06' property='mf:name'>syntax-order-06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-06' typeof='mf:PositiveSyntaxTest'>
@@ -1518,10 +1590,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-07:
+        <dt id='syntax-order-07'>
+          <a class='testlink' href='#syntax-order-07'>
+            syntax-order-07:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-07' property='mf:name'>syntax-order-07.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-07' property='mf:name'>syntax-order-07.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-order-07' typeof='mf:PositiveSyntaxTest'>
@@ -1538,10 +1611,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-01:
+        <dt id='syntax-limit-offset-01'>
+          <a class='testlink' href='#syntax-limit-offset-01'>
+            syntax-limit-offset-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-01' property='mf:name'>syntax-limit-offset-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-01' property='mf:name'>syntax-limit-offset-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-01' typeof='mf:PositiveSyntaxTest'>
@@ -1558,10 +1632,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-02:
+        <dt id='syntax-limit-offset-02'>
+          <a class='testlink' href='#syntax-limit-offset-02'>
+            syntax-limit-offset-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-02' property='mf:name'>syntax-limit-offset-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-02' property='mf:name'>syntax-limit-offset-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-02' typeof='mf:PositiveSyntaxTest'>
@@ -1578,10 +1653,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-03:
+        <dt id='syntax-limit-offset-03'>
+          <a class='testlink' href='#syntax-limit-offset-03'>
+            syntax-limit-offset-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-03' property='mf:name'>syntax-limit-offset-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-03' property='mf:name'>syntax-limit-offset-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-03' typeof='mf:PositiveSyntaxTest'>
@@ -1598,10 +1674,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-04:
+        <dt id='syntax-limit-offset-04'>
+          <a class='testlink' href='#syntax-limit-offset-04'>
+            syntax-limit-offset-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-04' property='mf:name'>syntax-limit-offset-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-04' property='mf:name'>syntax-limit-offset-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-limit-offset-04' typeof='mf:PositiveSyntaxTest'>
@@ -1618,10 +1695,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-01:
+        <dt id='syntax-pat-01'>
+          <a class='testlink' href='#syntax-pat-01'>
+            syntax-pat-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-01' property='mf:name'>syntax-pat-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-01' property='mf:name'>syntax-pat-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-01' typeof='mf:PositiveSyntaxTest'>
@@ -1638,10 +1716,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-02:
+        <dt id='syntax-pat-02'>
+          <a class='testlink' href='#syntax-pat-02'>
+            syntax-pat-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-02' property='mf:name'>syntax-pat-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-02' property='mf:name'>syntax-pat-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-02' typeof='mf:PositiveSyntaxTest'>
@@ -1658,10 +1737,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-03:
+        <dt id='syntax-pat-03'>
+          <a class='testlink' href='#syntax-pat-03'>
+            syntax-pat-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-03' property='mf:name'>syntax-pat-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-03' property='mf:name'>syntax-pat-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-03' typeof='mf:PositiveSyntaxTest'>
@@ -1678,10 +1758,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-04:
+        <dt id='syntax-pat-04'>
+          <a class='testlink' href='#syntax-pat-04'>
+            syntax-pat-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-04' property='mf:name'>syntax-pat-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-04' property='mf:name'>syntax-pat-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql1/manifest#syntax-pat-04' typeof='mf:PositiveSyntaxTest'>

--- a/sparql/sparql10/syntax-sparql2/index.html
+++ b/sparql/sparql10/syntax-sparql2/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-01:
+        <dt id='syntax-general-01'>
+          <a class='testlink' href='#syntax-general-01'>
+            syntax-general-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-01' property='mf:name'>syntax-general-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-01' property='mf:name'>syntax-general-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-01' typeof='mf:PositiveSyntaxTest'>
@@ -98,10 +99,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-02:
+        <dt id='syntax-general-02'>
+          <a class='testlink' href='#syntax-general-02'>
+            syntax-general-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-02' property='mf:name'>syntax-general-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-02' property='mf:name'>syntax-general-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-02' typeof='mf:PositiveSyntaxTest'>
@@ -118,10 +120,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-03:
+        <dt id='syntax-general-03'>
+          <a class='testlink' href='#syntax-general-03'>
+            syntax-general-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-03' property='mf:name'>syntax-general-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-03' property='mf:name'>syntax-general-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-03' typeof='mf:PositiveSyntaxTest'>
@@ -138,10 +141,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-04:
+        <dt id='syntax-general-04'>
+          <a class='testlink' href='#syntax-general-04'>
+            syntax-general-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-04' property='mf:name'>syntax-general-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-04' property='mf:name'>syntax-general-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-04' typeof='mf:PositiveSyntaxTest'>
@@ -158,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-05:
+        <dt id='syntax-general-05'>
+          <a class='testlink' href='#syntax-general-05'>
+            syntax-general-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-05' property='mf:name'>syntax-general-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-05' property='mf:name'>syntax-general-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-05' typeof='mf:PositiveSyntaxTest'>
@@ -178,10 +183,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-06:
+        <dt id='syntax-general-06'>
+          <a class='testlink' href='#syntax-general-06'>
+            syntax-general-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-06' property='mf:name'>syntax-general-06.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-06' property='mf:name'>syntax-general-06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-06' typeof='mf:PositiveSyntaxTest'>
@@ -198,10 +204,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-07:
+        <dt id='syntax-general-07'>
+          <a class='testlink' href='#syntax-general-07'>
+            syntax-general-07:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-07' property='mf:name'>syntax-general-07.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-07' property='mf:name'>syntax-general-07.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-07' typeof='mf:PositiveSyntaxTest'>
@@ -218,10 +225,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-08'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-08'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-08:
+        <dt id='syntax-general-08'>
+          <a class='testlink' href='#syntax-general-08'>
+            syntax-general-08:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-08' property='mf:name'>syntax-general-08.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-08' property='mf:name'>syntax-general-08.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-08' typeof='mf:PositiveSyntaxTest'>
@@ -238,10 +246,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-09'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-09'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-09:
+        <dt id='syntax-general-09'>
+          <a class='testlink' href='#syntax-general-09'>
+            syntax-general-09:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-09' property='mf:name'>syntax-general-09.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-09' property='mf:name'>syntax-general-09.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-09' typeof='mf:PositiveSyntaxTest'>
@@ -258,10 +267,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-10'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-10'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-10:
+        <dt id='syntax-general-10'>
+          <a class='testlink' href='#syntax-general-10'>
+            syntax-general-10:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-10' property='mf:name'>syntax-general-10.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-10' property='mf:name'>syntax-general-10.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-10' typeof='mf:PositiveSyntaxTest'>
@@ -278,10 +288,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-11'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-11'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-11:
+        <dt id='syntax-general-11'>
+          <a class='testlink' href='#syntax-general-11'>
+            syntax-general-11:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-11' property='mf:name'>syntax-general-11.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-11' property='mf:name'>syntax-general-11.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-11' typeof='mf:PositiveSyntaxTest'>
@@ -298,10 +309,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-12'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-12'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-12:
+        <dt id='syntax-general-12'>
+          <a class='testlink' href='#syntax-general-12'>
+            syntax-general-12:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-12' property='mf:name'>syntax-general-12.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-12' property='mf:name'>syntax-general-12.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-12' typeof='mf:PositiveSyntaxTest'>
@@ -318,10 +330,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-13'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-13'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-13:
+        <dt id='syntax-general-13'>
+          <a class='testlink' href='#syntax-general-13'>
+            syntax-general-13:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-13' property='mf:name'>syntax-general-13.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-13' property='mf:name'>syntax-general-13.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-13' typeof='mf:PositiveSyntaxTest'>
@@ -338,10 +351,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-14'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-14'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-14:
+        <dt id='syntax-general-14'>
+          <a class='testlink' href='#syntax-general-14'>
+            syntax-general-14:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-14' property='mf:name'>syntax-general-14.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-14' property='mf:name'>syntax-general-14.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-general-14' typeof='mf:PositiveSyntaxTest'>
@@ -358,10 +372,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-01:
+        <dt id='syntax-keywords-01'>
+          <a class='testlink' href='#syntax-keywords-01'>
+            syntax-keywords-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-01' property='mf:name'>syntax-keywords-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-01' property='mf:name'>syntax-keywords-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-01' typeof='mf:PositiveSyntaxTest'>
@@ -378,10 +393,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-02:
+        <dt id='syntax-keywords-02'>
+          <a class='testlink' href='#syntax-keywords-02'>
+            syntax-keywords-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-02' property='mf:name'>syntax-keywords-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-02' property='mf:name'>syntax-keywords-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-02' typeof='mf:PositiveSyntaxTest'>
@@ -398,10 +414,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-03:
+        <dt id='syntax-keywords-03'>
+          <a class='testlink' href='#syntax-keywords-03'>
+            syntax-keywords-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-03' property='mf:name'>syntax-keywords-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-03' property='mf:name'>syntax-keywords-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-keywords-03' typeof='mf:PositiveSyntaxTest'>
@@ -418,10 +435,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-01:
+        <dt id='syntax-lists-01'>
+          <a class='testlink' href='#syntax-lists-01'>
+            syntax-lists-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-01' property='mf:name'>syntax-lists-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-01' property='mf:name'>syntax-lists-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-01' typeof='mf:PositiveSyntaxTest'>
@@ -438,10 +456,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-02:
+        <dt id='syntax-lists-02'>
+          <a class='testlink' href='#syntax-lists-02'>
+            syntax-lists-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-02' property='mf:name'>syntax-lists-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-02' property='mf:name'>syntax-lists-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-02' typeof='mf:PositiveSyntaxTest'>
@@ -458,10 +477,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-03:
+        <dt id='syntax-lists-03'>
+          <a class='testlink' href='#syntax-lists-03'>
+            syntax-lists-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-03' property='mf:name'>syntax-lists-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-03' property='mf:name'>syntax-lists-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-03' typeof='mf:PositiveSyntaxTest'>
@@ -478,10 +498,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-04:
+        <dt id='syntax-lists-04'>
+          <a class='testlink' href='#syntax-lists-04'>
+            syntax-lists-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-04' property='mf:name'>syntax-lists-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-04' property='mf:name'>syntax-lists-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-04' typeof='mf:PositiveSyntaxTest'>
@@ -498,10 +519,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-05:
+        <dt id='syntax-lists-05'>
+          <a class='testlink' href='#syntax-lists-05'>
+            syntax-lists-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-05' property='mf:name'>syntax-lists-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-05' property='mf:name'>syntax-lists-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-lists-05' typeof='mf:PositiveSyntaxTest'>
@@ -518,10 +540,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-01:
+        <dt id='syntax-bnode-01'>
+          <a class='testlink' href='#syntax-bnode-01'>
+            syntax-bnode-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-01' property='mf:name'>syntax-bnode-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-01' property='mf:name'>syntax-bnode-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-01' typeof='mf:PositiveSyntaxTest'>
@@ -538,10 +561,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-02:
+        <dt id='syntax-bnode-02'>
+          <a class='testlink' href='#syntax-bnode-02'>
+            syntax-bnode-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-02' property='mf:name'>syntax-bnode-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-02' property='mf:name'>syntax-bnode-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-02' typeof='mf:PositiveSyntaxTest'>
@@ -558,10 +582,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-03:
+        <dt id='syntax-bnode-03'>
+          <a class='testlink' href='#syntax-bnode-03'>
+            syntax-bnode-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-03' property='mf:name'>syntax-bnode-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-03' property='mf:name'>syntax-bnode-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-bnode-03' typeof='mf:PositiveSyntaxTest'>
@@ -578,10 +603,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-01:
+        <dt id='syntax-function-01'>
+          <a class='testlink' href='#syntax-function-01'>
+            syntax-function-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-01' property='mf:name'>syntax-function-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-01' property='mf:name'>syntax-function-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-01' typeof='mf:PositiveSyntaxTest'>
@@ -598,10 +624,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-02:
+        <dt id='syntax-function-02'>
+          <a class='testlink' href='#syntax-function-02'>
+            syntax-function-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-02' property='mf:name'>syntax-function-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-02' property='mf:name'>syntax-function-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-02' typeof='mf:PositiveSyntaxTest'>
@@ -618,10 +645,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-03:
+        <dt id='syntax-function-03'>
+          <a class='testlink' href='#syntax-function-03'>
+            syntax-function-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-03' property='mf:name'>syntax-function-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-03' property='mf:name'>syntax-function-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-03' typeof='mf:PositiveSyntaxTest'>
@@ -638,10 +666,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-04:
+        <dt id='syntax-function-04'>
+          <a class='testlink' href='#syntax-function-04'>
+            syntax-function-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-04' property='mf:name'>syntax-function-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-04' property='mf:name'>syntax-function-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-function-04' typeof='mf:PositiveSyntaxTest'>
@@ -658,10 +687,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-01:
+        <dt id='syntax-form-select-01'>
+          <a class='testlink' href='#syntax-form-select-01'>
+            syntax-form-select-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-01' property='mf:name'>syntax-form-select-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-01' property='mf:name'>syntax-form-select-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-01' typeof='mf:PositiveSyntaxTest'>
@@ -678,10 +708,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-02:
+        <dt id='syntax-form-select-02'>
+          <a class='testlink' href='#syntax-form-select-02'>
+            syntax-form-select-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-02' property='mf:name'>syntax-form-select-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-02' property='mf:name'>syntax-form-select-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-select-02' typeof='mf:PositiveSyntaxTest'>
@@ -698,10 +729,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-ask-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-ask-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-ask-02:
+        <dt id='syntax-form-ask-02'>
+          <a class='testlink' href='#syntax-form-ask-02'>
+            syntax-form-ask-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-ask-02' property='mf:name'>syntax-form-ask-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-ask-02' property='mf:name'>syntax-form-ask-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-ask-02' typeof='mf:PositiveSyntaxTest'>
@@ -718,10 +750,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct01:
+        <dt id='syntax-form-construct01'>
+          <a class='testlink' href='#syntax-form-construct01'>
+            syntax-form-construct01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct01' property='mf:name'>syntax-form-construct01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct01' property='mf:name'>syntax-form-construct01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct01' typeof='mf:PositiveSyntaxTest'>
@@ -738,10 +771,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct02:
+        <dt id='syntax-form-construct02'>
+          <a class='testlink' href='#syntax-form-construct02'>
+            syntax-form-construct02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct02' property='mf:name'>syntax-form-construct02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct02' property='mf:name'>syntax-form-construct02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct02' typeof='mf:PositiveSyntaxTest'>
@@ -758,10 +792,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct03:
+        <dt id='syntax-form-construct03'>
+          <a class='testlink' href='#syntax-form-construct03'>
+            syntax-form-construct03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct03' property='mf:name'>syntax-form-construct03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct03' property='mf:name'>syntax-form-construct03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct03' typeof='mf:PositiveSyntaxTest'>
@@ -778,10 +813,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct04:
+        <dt id='syntax-form-construct04'>
+          <a class='testlink' href='#syntax-form-construct04'>
+            syntax-form-construct04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct04' property='mf:name'>syntax-form-construct04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct04' property='mf:name'>syntax-form-construct04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct04' typeof='mf:PositiveSyntaxTest'>
@@ -798,10 +834,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct06:
+        <dt id='syntax-form-construct06'>
+          <a class='testlink' href='#syntax-form-construct06'>
+            syntax-form-construct06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct06' property='mf:name'>syntax-form-construct06.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct06' property='mf:name'>syntax-form-construct06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-construct06' typeof='mf:PositiveSyntaxTest'>
@@ -818,10 +855,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe01:
+        <dt id='syntax-form-describe01'>
+          <a class='testlink' href='#syntax-form-describe01'>
+            syntax-form-describe01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe01' property='mf:name'>syntax-form-describe01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe01' property='mf:name'>syntax-form-describe01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe01' typeof='mf:PositiveSyntaxTest'>
@@ -838,10 +876,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe02:
+        <dt id='syntax-form-describe02'>
+          <a class='testlink' href='#syntax-form-describe02'>
+            syntax-form-describe02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe02' property='mf:name'>syntax-form-describe02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe02' property='mf:name'>syntax-form-describe02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-form-describe02' typeof='mf:PositiveSyntaxTest'>
@@ -858,10 +897,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-01:
+        <dt id='syntax-dataset-01'>
+          <a class='testlink' href='#syntax-dataset-01'>
+            syntax-dataset-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-01' property='mf:name'>syntax-dataset-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-01' property='mf:name'>syntax-dataset-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-01' typeof='mf:PositiveSyntaxTest'>
@@ -878,10 +918,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-02:
+        <dt id='syntax-dataset-02'>
+          <a class='testlink' href='#syntax-dataset-02'>
+            syntax-dataset-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-02' property='mf:name'>syntax-dataset-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-02' property='mf:name'>syntax-dataset-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-02' typeof='mf:PositiveSyntaxTest'>
@@ -898,10 +939,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-03:
+        <dt id='syntax-dataset-03'>
+          <a class='testlink' href='#syntax-dataset-03'>
+            syntax-dataset-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-03' property='mf:name'>syntax-dataset-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-03' property='mf:name'>syntax-dataset-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-03' typeof='mf:PositiveSyntaxTest'>
@@ -918,10 +960,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-04:
+        <dt id='syntax-dataset-04'>
+          <a class='testlink' href='#syntax-dataset-04'>
+            syntax-dataset-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-04' property='mf:name'>syntax-dataset-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-04' property='mf:name'>syntax-dataset-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-dataset-04' typeof='mf:PositiveSyntaxTest'>
@@ -938,10 +981,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-01:
+        <dt id='syntax-graph-01'>
+          <a class='testlink' href='#syntax-graph-01'>
+            syntax-graph-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-01' property='mf:name'>syntax-graph-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-01' property='mf:name'>syntax-graph-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-01' typeof='mf:PositiveSyntaxTest'>
@@ -958,10 +1002,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-02:
+        <dt id='syntax-graph-02'>
+          <a class='testlink' href='#syntax-graph-02'>
+            syntax-graph-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-02' property='mf:name'>syntax-graph-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-02' property='mf:name'>syntax-graph-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-02' typeof='mf:PositiveSyntaxTest'>
@@ -978,10 +1023,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-03:
+        <dt id='syntax-graph-03'>
+          <a class='testlink' href='#syntax-graph-03'>
+            syntax-graph-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-03' property='mf:name'>syntax-graph-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-03' property='mf:name'>syntax-graph-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-03' typeof='mf:PositiveSyntaxTest'>
@@ -998,10 +1044,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-04:
+        <dt id='syntax-graph-04'>
+          <a class='testlink' href='#syntax-graph-04'>
+            syntax-graph-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-04' property='mf:name'>syntax-graph-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-04' property='mf:name'>syntax-graph-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-04' typeof='mf:PositiveSyntaxTest'>
@@ -1018,10 +1065,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-05:
+        <dt id='syntax-graph-05'>
+          <a class='testlink' href='#syntax-graph-05'>
+            syntax-graph-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-05' property='mf:name'>syntax-graph-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-05' property='mf:name'>syntax-graph-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-graph-05' typeof='mf:PositiveSyntaxTest'>
@@ -1038,10 +1086,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-01:
+        <dt id='syntax-esc-01'>
+          <a class='testlink' href='#syntax-esc-01'>
+            syntax-esc-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-01' property='mf:name'>syntax-esc-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-01' property='mf:name'>syntax-esc-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-01' typeof='mf:PositiveSyntaxTest'>
@@ -1058,10 +1107,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-02:
+        <dt id='syntax-esc-02'>
+          <a class='testlink' href='#syntax-esc-02'>
+            syntax-esc-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-02' property='mf:name'>syntax-esc-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-02' property='mf:name'>syntax-esc-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-02' typeof='mf:PositiveSyntaxTest'>
@@ -1078,10 +1128,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-03:
+        <dt id='syntax-esc-03'>
+          <a class='testlink' href='#syntax-esc-03'>
+            syntax-esc-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-03' property='mf:name'>syntax-esc-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-03' property='mf:name'>syntax-esc-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-03' typeof='mf:PositiveSyntaxTest'>
@@ -1098,10 +1149,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-04:
+        <dt id='syntax-esc-04'>
+          <a class='testlink' href='#syntax-esc-04'>
+            syntax-esc-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-04' property='mf:name'>syntax-esc-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-04' property='mf:name'>syntax-esc-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-04' typeof='mf:PositiveSyntaxTest'>
@@ -1118,10 +1170,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-05:
+        <dt id='syntax-esc-05'>
+          <a class='testlink' href='#syntax-esc-05'>
+            syntax-esc-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-05' property='mf:name'>syntax-esc-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-05' property='mf:name'>syntax-esc-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql2/manifest#syntax-esc-05' typeof='mf:PositiveSyntaxTest'>

--- a/sparql/sparql10/syntax-sparql3/index.html
+++ b/sparql/sparql10/syntax-sparql3/index.html
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-01:
+        <dt id='syn-01'>
+          <a class='testlink' href='#syn-01'>
+            syn-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-01' property='mf:name'>syn-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-01' property='mf:name'>syn-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-01' typeof='mf:PositiveSyntaxTest'>
@@ -98,10 +99,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-02:
+        <dt id='syn-02'>
+          <a class='testlink' href='#syn-02'>
+            syn-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-02' property='mf:name'>syn-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-02' property='mf:name'>syn-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-02' typeof='mf:PositiveSyntaxTest'>
@@ -118,10 +120,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-03:
+        <dt id='syn-03'>
+          <a class='testlink' href='#syn-03'>
+            syn-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-03' property='mf:name'>syn-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-03' property='mf:name'>syn-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-03' typeof='mf:PositiveSyntaxTest'>
@@ -138,10 +141,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-04:
+        <dt id='syn-04'>
+          <a class='testlink' href='#syn-04'>
+            syn-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-04' property='mf:name'>syn-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-04' property='mf:name'>syn-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-04' typeof='mf:PositiveSyntaxTest'>
@@ -158,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-05:
+        <dt id='syn-05'>
+          <a class='testlink' href='#syn-05'>
+            syn-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-05' property='mf:name'>syn-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-05' property='mf:name'>syn-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-05' typeof='mf:PositiveSyntaxTest'>
@@ -178,10 +183,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-06:
+        <dt id='syn-06'>
+          <a class='testlink' href='#syn-06'>
+            syn-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-06' property='mf:name'>syn-06.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-06' property='mf:name'>syn-06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-06' typeof='mf:PositiveSyntaxTest'>
@@ -198,10 +204,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-07:
+        <dt id='syn-07'>
+          <a class='testlink' href='#syn-07'>
+            syn-07:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-07' property='mf:name'>syn-07.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-07' property='mf:name'>syn-07.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-07' typeof='mf:PositiveSyntaxTest'>
@@ -218,10 +225,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-08'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-08'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-08:
+        <dt id='syn-08'>
+          <a class='testlink' href='#syn-08'>
+            syn-08:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-08' property='mf:name'>syn-08.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-08' property='mf:name'>syn-08.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-08' typeof='mf:PositiveSyntaxTest'>
@@ -238,10 +246,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-01:
+        <dt id='syn-bad-01'>
+          <a class='testlink' href='#syn-bad-01'>
+            syn-bad-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-01' property='mf:name'>syn-bad-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-01' property='mf:name'>syn-bad-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-01' typeof='mf:NegativeSyntaxTest'>
@@ -258,10 +267,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-02:
+        <dt id='syn-bad-02'>
+          <a class='testlink' href='#syn-bad-02'>
+            syn-bad-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-02' property='mf:name'>syn-bad-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-02' property='mf:name'>syn-bad-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-02' typeof='mf:NegativeSyntaxTest'>
@@ -278,10 +288,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-03:
+        <dt id='syn-bad-03'>
+          <a class='testlink' href='#syn-bad-03'>
+            syn-bad-03:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-03' property='mf:name'>syn-bad-03.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-03' property='mf:name'>syn-bad-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-03' typeof='mf:NegativeSyntaxTest'>
@@ -298,10 +309,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-04:
+        <dt id='syn-bad-04'>
+          <a class='testlink' href='#syn-bad-04'>
+            syn-bad-04:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-04' property='mf:name'>syn-bad-04.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-04' property='mf:name'>syn-bad-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-04' typeof='mf:NegativeSyntaxTest'>
@@ -318,10 +330,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-05:
+        <dt id='syn-bad-05'>
+          <a class='testlink' href='#syn-bad-05'>
+            syn-bad-05:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-05' property='mf:name'>syn-bad-05.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-05' property='mf:name'>syn-bad-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-05' typeof='mf:NegativeSyntaxTest'>
@@ -338,10 +351,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-06:
+        <dt id='syn-bad-06'>
+          <a class='testlink' href='#syn-bad-06'>
+            syn-bad-06:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-06' property='mf:name'>syn-bad-06.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-06' property='mf:name'>syn-bad-06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-06' typeof='mf:NegativeSyntaxTest'>
@@ -358,10 +372,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-07:
+        <dt id='syn-bad-07'>
+          <a class='testlink' href='#syn-bad-07'>
+            syn-bad-07:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-07' property='mf:name'>syn-bad-07.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-07' property='mf:name'>syn-bad-07.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-07' typeof='mf:NegativeSyntaxTest'>
@@ -378,10 +393,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-08'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-08'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-08:
+        <dt id='syn-bad-08'>
+          <a class='testlink' href='#syn-bad-08'>
+            syn-bad-08:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-08' property='mf:name'>syn-bad-08.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-08' property='mf:name'>syn-bad-08.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-08' typeof='mf:NegativeSyntaxTest'>
@@ -398,10 +414,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-09'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-09'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-09:
+        <dt id='syn-bad-09'>
+          <a class='testlink' href='#syn-bad-09'>
+            syn-bad-09:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-09' property='mf:name'>syn-bad-09.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-09' property='mf:name'>syn-bad-09.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-09' typeof='mf:NegativeSyntaxTest'>
@@ -418,10 +435,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-10'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-10'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-10:
+        <dt id='syn-bad-10'>
+          <a class='testlink' href='#syn-bad-10'>
+            syn-bad-10:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-10' property='mf:name'>syn-bad-10.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-10' property='mf:name'>syn-bad-10.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-10' typeof='mf:NegativeSyntaxTest'>
@@ -438,10 +456,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-11'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-11'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-11:
+        <dt id='syn-bad-11'>
+          <a class='testlink' href='#syn-bad-11'>
+            syn-bad-11:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-11' property='mf:name'>syn-bad-11.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-11' property='mf:name'>syn-bad-11.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-11' typeof='mf:NegativeSyntaxTest'>
@@ -458,10 +477,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-12'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-12'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-12:
+        <dt id='syn-bad-12'>
+          <a class='testlink' href='#syn-bad-12'>
+            syn-bad-12:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-12' property='mf:name'>syn-bad-12.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-12' property='mf:name'>syn-bad-12.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-12' typeof='mf:NegativeSyntaxTest'>
@@ -478,10 +498,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-13'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-13'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-13:
+        <dt id='syn-bad-13'>
+          <a class='testlink' href='#syn-bad-13'>
+            syn-bad-13:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-13' property='mf:name'>syn-bad-13.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-13' property='mf:name'>syn-bad-13.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-13' typeof='mf:NegativeSyntaxTest'>
@@ -498,10 +519,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-14'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-14'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-14:
+        <dt id='syn-bad-14'>
+          <a class='testlink' href='#syn-bad-14'>
+            syn-bad-14:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-14' property='mf:name'>syn-bad-14.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-14' property='mf:name'>syn-bad-14.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-14' typeof='mf:NegativeSyntaxTest'>
@@ -518,10 +540,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-15'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-15'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-15:
+        <dt id='syn-bad-15'>
+          <a class='testlink' href='#syn-bad-15'>
+            syn-bad-15:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-15' property='mf:name'>syn-bad-15.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-15' property='mf:name'>syn-bad-15.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-15' typeof='mf:NegativeSyntaxTest'>
@@ -538,10 +561,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-16'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-16'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-16:
+        <dt id='syn-bad-16'>
+          <a class='testlink' href='#syn-bad-16'>
+            syn-bad-16:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-16' property='mf:name'>syn-bad-16.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-16' property='mf:name'>syn-bad-16.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-16' typeof='mf:NegativeSyntaxTest'>
@@ -558,10 +582,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-17'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-17'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-17:
+        <dt id='syn-bad-17'>
+          <a class='testlink' href='#syn-bad-17'>
+            syn-bad-17:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-17' property='mf:name'>syn-bad-17.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-17' property='mf:name'>syn-bad-17.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-17' typeof='mf:NegativeSyntaxTest'>
@@ -578,10 +603,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-18'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-18'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-18:
+        <dt id='syn-bad-18'>
+          <a class='testlink' href='#syn-bad-18'>
+            syn-bad-18:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-18' property='mf:name'>syn-bad-18.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-18' property='mf:name'>syn-bad-18.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-18' typeof='mf:NegativeSyntaxTest'>
@@ -598,10 +624,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-19'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-19'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-19:
+        <dt id='syn-bad-19'>
+          <a class='testlink' href='#syn-bad-19'>
+            syn-bad-19:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-19' property='mf:name'>syn-bad-19.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-19' property='mf:name'>syn-bad-19.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-19' typeof='mf:NegativeSyntaxTest'>
@@ -618,10 +645,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-20'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-20'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-20:
+        <dt id='syn-bad-20'>
+          <a class='testlink' href='#syn-bad-20'>
+            syn-bad-20:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-20' property='mf:name'>syn-bad-20.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-20' property='mf:name'>syn-bad-20.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-20' typeof='mf:NegativeSyntaxTest'>
@@ -638,10 +666,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-21'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-21'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-21:
+        <dt id='syn-bad-21'>
+          <a class='testlink' href='#syn-bad-21'>
+            syn-bad-21:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-21' property='mf:name'>syn-bad-21.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-21' property='mf:name'>syn-bad-21.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-21' typeof='mf:NegativeSyntaxTest'>
@@ -658,10 +687,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-22'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-22'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-22:
+        <dt id='syn-bad-22'>
+          <a class='testlink' href='#syn-bad-22'>
+            syn-bad-22:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-22' property='mf:name'>syn-bad-22.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-22' property='mf:name'>syn-bad-22.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-22' typeof='mf:NegativeSyntaxTest'>
@@ -678,10 +708,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-23'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-23'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-23:
+        <dt id='syn-bad-23'>
+          <a class='testlink' href='#syn-bad-23'>
+            syn-bad-23:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-23' property='mf:name'>syn-bad-23.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-23' property='mf:name'>syn-bad-23.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-23' typeof='mf:NegativeSyntaxTest'>
@@ -698,10 +729,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-24'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-24'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-24:
+        <dt id='syn-bad-24'>
+          <a class='testlink' href='#syn-bad-24'>
+            syn-bad-24:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-24' property='mf:name'>syn-bad-24.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-24' property='mf:name'>syn-bad-24.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-24' typeof='mf:NegativeSyntaxTest'>
@@ -718,10 +750,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-25'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-25'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-25:
+        <dt id='syn-bad-25'>
+          <a class='testlink' href='#syn-bad-25'>
+            syn-bad-25:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-25' property='mf:name'>syn-bad-25.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-25' property='mf:name'>syn-bad-25.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-25' typeof='mf:NegativeSyntaxTest'>
@@ -738,10 +771,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-26'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-26'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-26:
+        <dt id='syn-bad-26'>
+          <a class='testlink' href='#syn-bad-26'>
+            syn-bad-26:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-26' property='mf:name'>syn-bad-26.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-26' property='mf:name'>syn-bad-26.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-26' typeof='mf:NegativeSyntaxTest'>
@@ -758,10 +792,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-27'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-27'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-27:
+        <dt id='syn-bad-27'>
+          <a class='testlink' href='#syn-bad-27'>
+            syn-bad-27:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-27' property='mf:name'>syn-bad-27.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-27' property='mf:name'>syn-bad-27.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-27' typeof='mf:NegativeSyntaxTest'>
@@ -778,10 +813,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-28'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-28'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-28:
+        <dt id='syn-bad-28'>
+          <a class='testlink' href='#syn-bad-28'>
+            syn-bad-28:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-28' property='mf:name'>syn-bad-28.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-28' property='mf:name'>syn-bad-28.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-28' typeof='mf:NegativeSyntaxTest'>
@@ -798,10 +834,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-29'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-29'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-29:
+        <dt id='syn-bad-29'>
+          <a class='testlink' href='#syn-bad-29'>
+            syn-bad-29:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-29' property='mf:name'>syn-bad-29.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-29' property='mf:name'>syn-bad-29.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-29' typeof='mf:NegativeSyntaxTest'>
@@ -818,10 +855,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-30'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-30'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-30:
+        <dt id='syn-bad-30'>
+          <a class='testlink' href='#syn-bad-30'>
+            syn-bad-30:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-30' property='mf:name'>syn-bad-30.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-30' property='mf:name'>syn-bad-30.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-30' typeof='mf:NegativeSyntaxTest'>
@@ -838,10 +876,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-31'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-31'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-31:
+        <dt id='syn-bad-31'>
+          <a class='testlink' href='#syn-bad-31'>
+            syn-bad-31:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-31' property='mf:name'>syn-bad-31.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-31' property='mf:name'>syn-bad-31.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#syn-bad-31' typeof='mf:NegativeSyntaxTest'>
@@ -858,10 +897,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnode-dot'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnode-dot'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnode-dot:
+        <dt id='bnode-dot'>
+          <a class='testlink' href='#bnode-dot'>
+            bnode-dot:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnode-dot' property='mf:name'>syn-bad-bnode-dot.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnode-dot' property='mf:name'>syn-bad-bnode-dot.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnode-dot' typeof='mf:NegativeSyntaxTest'>
@@ -878,10 +918,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-01:
+        <dt id='bnodes-missing-pvalues-01'>
+          <a class='testlink' href='#bnodes-missing-pvalues-01'>
+            bnodes-missing-pvalues-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-01' property='mf:name'>syn-bad-bnodes-missing-pvalues-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-01' property='mf:name'>syn-bad-bnodes-missing-pvalues-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-01' typeof='mf:NegativeSyntaxTest'>
@@ -898,10 +939,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-02:
+        <dt id='bnodes-missing-pvalues-02'>
+          <a class='testlink' href='#bnodes-missing-pvalues-02'>
+            bnodes-missing-pvalues-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-02' property='mf:name'>syn-bad-bnodes-missing-pvalues-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-02' property='mf:name'>syn-bad-bnodes-missing-pvalues-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#bnodes-missing-pvalues-02' typeof='mf:NegativeSyntaxTest'>
@@ -918,10 +960,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-01:
+        <dt id='empty-optional-01'>
+          <a class='testlink' href='#empty-optional-01'>
+            empty-optional-01:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-01' property='mf:name'>syn-bad-empty-optional-01.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-01' property='mf:name'>syn-bad-empty-optional-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-01' typeof='mf:NegativeSyntaxTest'>
@@ -938,10 +981,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-02:
+        <dt id='empty-optional-02'>
+          <a class='testlink' href='#empty-optional-02'>
+            empty-optional-02:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-02' property='mf:name'>syn-bad-empty-optional-02.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-02' property='mf:name'>syn-bad-empty-optional-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#empty-optional-02' typeof='mf:NegativeSyntaxTest'>
@@ -958,10 +1002,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#filter-missing-parens'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#filter-missing-parens'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#filter-missing-parens:
+        <dt id='filter-missing-parens'>
+          <a class='testlink' href='#filter-missing-parens'>
+            filter-missing-parens:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#filter-missing-parens' property='mf:name'>syn-bad-filter-missing-parens.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#filter-missing-parens' property='mf:name'>syn-bad-filter-missing-parens.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#filter-missing-parens' typeof='mf:NegativeSyntaxTest'>
@@ -978,10 +1023,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-list'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-list'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-list:
+        <dt id='lone-list'>
+          <a class='testlink' href='#lone-list'>
+            lone-list:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-list' property='mf:name'>syn-bad-lone-list.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-list' property='mf:name'>syn-bad-lone-list.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-list' typeof='mf:NegativeSyntaxTest'>
@@ -998,10 +1044,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-node'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-node'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-node:
+        <dt id='lone-node'>
+          <a class='testlink' href='#lone-node'>
+            lone-node:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-node' property='mf:name'>syn-bad-lone-node.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-node' property='mf:name'>syn-bad-lone-node.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#lone-node' typeof='mf:NegativeSyntaxTest'>
@@ -1018,10 +1065,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-filter'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-filter'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-filter:
+        <dt id='blabel-cross-filter'>
+          <a class='testlink' href='#blabel-cross-filter'>
+            blabel-cross-filter:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-filter' property='mf:name'>syn-blabel-cross-filter</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-filter' property='mf:name'>syn-blabel-cross-filter</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-filter' typeof='mf:PositiveSyntaxTest'>
@@ -1038,10 +1086,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-graph-bad'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-graph-bad'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-graph-bad:
+        <dt id='blabel-cross-graph-bad'>
+          <a class='testlink' href='#blabel-cross-graph-bad'>
+            blabel-cross-graph-bad:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-graph-bad' property='mf:name'>syn-blabel-cross-graph-bad</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-graph-bad' property='mf:name'>syn-blabel-cross-graph-bad</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-graph-bad' typeof='mf:NegativeSyntaxTest'>
@@ -1058,10 +1107,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-optional-bad'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-optional-bad'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-optional-bad:
+        <dt id='blabel-cross-optional-bad'>
+          <a class='testlink' href='#blabel-cross-optional-bad'>
+            blabel-cross-optional-bad:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-optional-bad' property='mf:name'>syn-blabel-cross-optional-bad</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-optional-bad' property='mf:name'>syn-blabel-cross-optional-bad</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-optional-bad' typeof='mf:NegativeSyntaxTest'>
@@ -1078,10 +1128,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-union-bad'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-union-bad'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-union-bad:
+        <dt id='blabel-cross-union-bad'>
+          <a class='testlink' href='#blabel-cross-union-bad'>
+            blabel-cross-union-bad:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-union-bad' property='mf:name'>syn-blabel-cross-union-bad</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-union-bad' property='mf:name'>syn-blabel-cross-union-bad</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql3/manifest#blabel-cross-union-bad' typeof='mf:NegativeSyntaxTest'>

--- a/sparql/sparql10/syntax-sparql4/index.html
+++ b/sparql/sparql10/syntax-sparql4/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-09'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-09'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-09:
+        <dt id='syn-09'>
+          <a class='testlink' href='#syn-09'>
+            syn-09:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-09' property='mf:name'>syn-09.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-09' property='mf:name'>syn-09.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-09' typeof='mf:PositiveSyntaxTest'>
@@ -98,10 +99,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-10'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-10'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-10:
+        <dt id='syn-10'>
+          <a class='testlink' href='#syn-10'>
+            syn-10:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-10' property='mf:name'>syn-10.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-10' property='mf:name'>syn-10.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-10' typeof='mf:PositiveSyntaxTest'>
@@ -118,10 +120,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-11'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-11'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-11:
+        <dt id='syn-11'>
+          <a class='testlink' href='#syn-11'>
+            syn-11:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-11' property='mf:name'>syn-11.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-11' property='mf:name'>syn-11.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-11' typeof='mf:PositiveSyntaxTest'>
@@ -138,10 +141,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-34'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-34'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-34:
+        <dt id='syn-bad-34'>
+          <a class='testlink' href='#syn-bad-34'>
+            syn-bad-34:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-34' property='mf:name'>syn-bad-34.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-34' property='mf:name'>syn-bad-34.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-34' typeof='mf:NegativeSyntaxTest'>
@@ -158,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-35'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-35'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-35:
+        <dt id='syn-bad-35'>
+          <a class='testlink' href='#syn-bad-35'>
+            syn-bad-35:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-35' property='mf:name'>syn-bad-35.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-35' property='mf:name'>syn-bad-35.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-35' typeof='mf:NegativeSyntaxTest'>
@@ -178,10 +183,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-36'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-36'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-36:
+        <dt id='syn-bad-36'>
+          <a class='testlink' href='#syn-bad-36'>
+            syn-bad-36:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-36' property='mf:name'>syn-bad-36.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-36' property='mf:name'>syn-bad-36.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-36' typeof='mf:NegativeSyntaxTest'>
@@ -198,10 +204,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-37'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-37'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-37:
+        <dt id='syn-bad-37'>
+          <a class='testlink' href='#syn-bad-37'>
+            syn-bad-37:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-37' property='mf:name'>syn-bad-37.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-37' property='mf:name'>syn-bad-37.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-37' typeof='mf:NegativeSyntaxTest'>
@@ -218,10 +225,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-38'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-38'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-38:
+        <dt id='syn-bad-38'>
+          <a class='testlink' href='#syn-bad-38'>
+            syn-bad-38:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-38' property='mf:name'>syn-bad-38.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-38' property='mf:name'>syn-bad-38.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-38' typeof='mf:NegativeSyntaxTest'>
@@ -238,10 +246,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-OPT-breaks-BGP'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-OPT-breaks-BGP'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-OPT-breaks-BGP:
+        <dt id='syn-bad-OPT-breaks-BGP'>
+          <a class='testlink' href='#syn-bad-OPT-breaks-BGP'>
+            syn-bad-OPT-breaks-BGP:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-OPT-breaks-BGP' property='mf:name'>syn-bad-OPT-breaks-BGP</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-OPT-breaks-BGP' property='mf:name'>syn-bad-OPT-breaks-BGP</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-OPT-breaks-BGP' typeof='mf:NegativeSyntaxTest'>
@@ -259,10 +268,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-UNION-breaks-BGP'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-UNION-breaks-BGP'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-UNION-breaks-BGP:
+        <dt id='syn-bad-UNION-breaks-BGP'>
+          <a class='testlink' href='#syn-bad-UNION-breaks-BGP'>
+            syn-bad-UNION-breaks-BGP:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-UNION-breaks-BGP' property='mf:name'>syn-bad-UNION-breaks-BGP</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-UNION-breaks-BGP' property='mf:name'>syn-bad-UNION-breaks-BGP</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-UNION-breaks-BGP' typeof='mf:NegativeSyntaxTest'>
@@ -280,10 +290,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-GRAPH-breaks-BGP'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-GRAPH-breaks-BGP'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-GRAPH-breaks-BGP:
+        <dt id='syn-bad-GRAPH-breaks-BGP'>
+          <a class='testlink' href='#syn-bad-GRAPH-breaks-BGP'>
+            syn-bad-GRAPH-breaks-BGP:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-GRAPH-breaks-BGP' property='mf:name'>syn-bad-GRAPH-breaks-BGP</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-GRAPH-breaks-BGP' property='mf:name'>syn-bad-GRAPH-breaks-BGP</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-bad-GRAPH-breaks-BGP' typeof='mf:NegativeSyntaxTest'>
@@ -301,10 +312,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-leading-digits-in-prefixed-names'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-leading-digits-in-prefixed-names'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-leading-digits-in-prefixed-names:
+        <dt id='syn-leading-digits-in-prefixed-names'>
+          <a class='testlink' href='#syn-leading-digits-in-prefixed-names'>
+            syn-leading-digits-in-prefixed-names:
           </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-leading-digits-in-prefixed-names' property='mf:name'>syn-leading-digits-in-prefixed-names.rq</span>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-leading-digits-in-prefixed-names' property='mf:name'>syn-leading-digits-in-prefixed-names.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql4/manifest#syn-leading-digits-in-prefixed-names' typeof='mf:PositiveSyntaxTest'>

--- a/sparql/sparql10/syntax-sparql5/index.html
+++ b/sparql/sparql10/syntax-sparql5/index.html
@@ -33,7 +33,7 @@
       Syntax 5
     </title>
     <style>
-      em.rfc2119 { 
+      em.rfc2119 {
         text-transform: lowercase;
         font-variant:   small-caps;
         font-style:     normal;
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -64,19 +64,13 @@
       <p property='rdfs:comment'>
         Syntax tests syntax-sparql5
       </p>
-      <p>This page describes W3C SPARQL Working Group&#39;s SPARQL1.0 test suite.</p>
-      
-      <h3>Contributing Tests</h3>
-      
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
-      
-      <h3>Distribution</h3>
-      
+      <h3 id="distribution">Distribution</h3>
       <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
-      
-      <h3>Disclaimer</h3>
-      
-      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+      <h3 id="disclaimer">Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
         COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
     </div>
     <div>
@@ -84,50 +78,42 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-01:
+        <dt id='syntax-reduced-01'>
+          <a class='testlink' href='#syntax-reduced-01'>
+            syntax-reduced-01:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-01' property='mf:name'>syntax-reduced-01.rq</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-01' property='mf:name'>syntax-reduced-01.rq</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-01' typeof='mf:PositiveSyntaxTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-01' typeof='mf:PositiveSyntaxTest'>
           <div property='rdfs:comment'>
-            
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
             <dd>mf:PositiveSyntaxTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://lists.w3.org/Archives/Public/public-rdf-dawg/2007OctDec/att-0069/13-dawg-minutes.html' property='dawgt:approvedBy'>http://lists.w3.org/Archives/Public/public-rdf-dawg/2007OctDec/att-0069/13-dawg-minutes.html</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='syntax-reduced-01.rq' property='mf:action'>syntax-reduced-01.rq</a>
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-02:
+        <dt id='syntax-reduced-02'>
+          <a class='testlink' href='#syntax-reduced-02'>
+            syntax-reduced-02:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-02' property='mf:name'>syntax-reduced-02.rq</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-02' property='mf:name'>syntax-reduced-02.rq</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-02' typeof='mf:PositiveSyntaxTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/syntax-sparql5/manifest#syntax-reduced-02' typeof='mf:PositiveSyntaxTest'>
           <div property='rdfs:comment'>
-            
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
             <dd>mf:PositiveSyntaxTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://lists.w3.org/Archives/Public/public-rdf-dawg/2007OctDec/att-0069/13-dawg-minutes.html' property='dawgt:approvedBy'>http://lists.w3.org/Archives/Public/public-rdf-dawg/2007OctDec/att-0069/13-dawg-minutes.html</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <a href='syntax-reduced-02.rq' property='mf:action'>syntax-reduced-02.rq</a>

--- a/sparql/sparql10/template.haml
+++ b/sparql/sparql10/template.haml
@@ -89,9 +89,10 @@
           Test Descriptions
         %dl.test-description
           - man['entries'].each do |test|
-            %dt{id: test['@id']}
-              %a.testlink{href: "##{test['@id']}"}
-                = "#{test['@id']}:"
+            %dt{id: test['@id'].split('#').last}
+              %a.testlink{href: "##{test['@id'].split('#').last}"}
+                = "#{test['@id'].split('#').last}:"
+              %span{about: test['@id'], property: "mf:name"}<~test['name']
               %span{about: test['@id'], property: "mf:name"}<~test['name']
             %dd{property: "mf:entry", inlist: true, resource: test['@id'], typeof: test['@type']}
               %div{property: "rdfs:comment"}

--- a/sparql/sparql10/triple-match/index.html
+++ b/sparql/sparql10/triple-match/index.html
@@ -33,7 +33,7 @@
       Triple Match
     </title>
     <style>
-      em.rfc2119 { 
+      em.rfc2119 {
         text-transform: lowercase;
         font-variant:   small-caps;
         font-style:     normal;
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -64,19 +64,13 @@
       <p property='rdfs:comment'>
         Some simple DAWG query evaluation test cases
       </p>
-      <p>This page describes W3C SPARQL Working Group&#39;s SPARQL1.0 test suite.</p>
-      
-      <h3>Contributing Tests</h3>
-      
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
-      
-      <h3>Distribution</h3>
-      
+      <h3 id="distribution">Distribution</h3>
       <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
-      
-      <h3>Disclaimer</h3>
-      
-      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+      <h3 id="disclaimer">Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
         COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
     </div>
     <div>
@@ -84,13 +78,14 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-001'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-001'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-001:
+        <dt id='dawg-triple-pattern-001'>
+          <a class='testlink' href='#dawg-triple-pattern-001'>
+            dawg-triple-pattern-001:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-001' property='mf:name'>dawg-triple-pattern-001</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-001' property='mf:name'>dawg-triple-pattern-001</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-001' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-001' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Simple triple match</p>
           </div>
@@ -98,22 +93,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://lists.w3.org/Archives/Public/public-rdf-dawg/2005JanMar/0358' property='dawgt:approvedBy'>http://lists.w3.org/Archives/Public/public-rdf-dawg/2005JanMar/0358</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='dawg-tp-01.rq' property='qt:query'>dawg-tp-01.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='data-01.ttl' property='qt:data'>data-01.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -122,13 +105,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-002'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-002'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-002:
+        <dt id='dawg-triple-pattern-002'>
+          <a class='testlink' href='#dawg-triple-pattern-002'>
+            dawg-triple-pattern-002:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-002' property='mf:name'>dawg-triple-pattern-002</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-002' property='mf:name'>dawg-triple-pattern-002</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-002' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-002' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Simple triple match</p>
           </div>
@@ -136,22 +120,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://lists.w3.org/Archives/Public/public-rdf-dawg/2005JanMar/0358' property='dawgt:approvedBy'>http://lists.w3.org/Archives/Public/public-rdf-dawg/2005JanMar/0358</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='dawg-tp-02.rq' property='qt:query'>dawg-tp-02.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='data-01.ttl' property='qt:data'>data-01.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -160,13 +132,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-003'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-003'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-003:
+        <dt id='dawg-triple-pattern-003'>
+          <a class='testlink' href='#dawg-triple-pattern-003'>
+            dawg-triple-pattern-003:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-003' property='mf:name'>dawg-triple-pattern-003</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-003' property='mf:name'>dawg-triple-pattern-003</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-003' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-003' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Simple triple match - repeated variable</p>
           </div>
@@ -174,22 +147,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://lists.w3.org/Archives/Public/public-rdf-dawg/2005JanMar/0358' property='dawgt:approvedBy'>http://lists.w3.org/Archives/Public/public-rdf-dawg/2005JanMar/0358</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='dawg-tp-03.rq' property='qt:query'>dawg-tp-03.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='data-02.ttl' property='qt:data'>data-02.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -198,13 +159,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-004'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-004'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-004:
+        <dt id='dawg-triple-pattern-004'>
+          <a class='testlink' href='#dawg-triple-pattern-004'>
+            dawg-triple-pattern-004:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-004' property='mf:name'>dawg-triple-pattern-004</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-004' property='mf:name'>dawg-triple-pattern-004</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-004' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/triple-match/manifest#dawg-triple-pattern-004' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Simple triple match - two triples, common variable</p>
           </div>
@@ -212,22 +174,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://lists.w3.org/Archives/Public/public-rdf-dawg/2005JanMar/0358' property='dawgt:approvedBy'>http://lists.w3.org/Archives/Public/public-rdf-dawg/2005JanMar/0358</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='dawg-tp-04.rq' property='qt:query'>dawg-tp-04.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='dawg-data-01.ttl' property='qt:data'>dawg-data-01.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>

--- a/sparql/sparql10/type-promotion/index.html
+++ b/sparql/sparql10/type-promotion/index.html
@@ -33,7 +33,7 @@
       Type Promotion
     </title>
     <style>
-      em.rfc2119 { 
+      em.rfc2119 {
         text-transform: lowercase;
         font-variant:   small-caps;
         font-style:     normal;
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -64,19 +64,13 @@
       <p property='rdfs:comment'>
         Type Promotion Tests
       </p>
-      <p>This page describes W3C SPARQL Working Group&#39;s SPARQL1.0 test suite.</p>
-      
-      <h3>Contributing Tests</h3>
-      
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
-      
-      <h3>Distribution</h3>
-      
+      <h3 id="distribution">Distribution</h3>
       <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
-      
-      <h3>Disclaimer</h3>
-      
-      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+      <h3 id="disclaimer">Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
         COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
     </div>
     <div>
@@ -84,13 +78,14 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-01'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-01'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-01:
+        <dt id='type-promotion-01'>
+          <a class='testlink' href='#type-promotion-01'>
+            type-promotion-01:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-01' property='mf:name'>tP-double-double</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-01' property='mf:name'>tP-double-double</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-01' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-01' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -98,22 +93,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-double-double.rq' property='qt:query'>tP-double-double.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -122,13 +105,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-02'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-02'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-02:
+        <dt id='type-promotion-02'>
+          <a class='testlink' href='#type-promotion-02'>
+            type-promotion-02:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-02' property='mf:name'>tP-double-float</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-02' property='mf:name'>tP-double-float</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-02' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-02' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -136,22 +120,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-double-float.rq' property='qt:query'>tP-double-float.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -160,13 +132,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-03'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-03'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-03:
+        <dt id='type-promotion-03'>
+          <a class='testlink' href='#type-promotion-03'>
+            type-promotion-03:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-03' property='mf:name'>tP-double-decimal</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-03' property='mf:name'>tP-double-decimal</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-03' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-03' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -174,22 +147,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-double-decimal.rq' property='qt:query'>tP-double-decimal.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -198,13 +159,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-04'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-04'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-04:
+        <dt id='type-promotion-04'>
+          <a class='testlink' href='#type-promotion-04'>
+            type-promotion-04:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-04' property='mf:name'>tP-float-float</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-04' property='mf:name'>tP-float-float</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-04' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-04' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -212,22 +174,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-float-float.rq' property='qt:query'>tP-float-float.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -236,13 +186,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-05'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-05'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-05:
+        <dt id='type-promotion-05'>
+          <a class='testlink' href='#type-promotion-05'>
+            type-promotion-05:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-05' property='mf:name'>tP-float-decimal</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-05' property='mf:name'>tP-float-decimal</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-05' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-05' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -250,22 +201,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-float-decimal.rq' property='qt:query'>tP-float-decimal.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -274,13 +213,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-06'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-06'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-06:
+        <dt id='type-promotion-06'>
+          <a class='testlink' href='#type-promotion-06'>
+            type-promotion-06:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-06' property='mf:name'>tP-decimal-decimal</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-06' property='mf:name'>tP-decimal-decimal</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-06' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-06' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -288,22 +228,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-decimal-decimal.rq' property='qt:query'>tP-decimal-decimal.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -312,13 +240,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-07'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-07'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-07:
+        <dt id='type-promotion-07'>
+          <a class='testlink' href='#type-promotion-07'>
+            type-promotion-07:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-07' property='mf:name'>tP-integer-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-07' property='mf:name'>tP-integer-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-07' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-07' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -326,22 +255,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-integer-short.rq' property='qt:query'>tP-integer-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -350,13 +267,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-08'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-08'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-08:
+        <dt id='type-promotion-08'>
+          <a class='testlink' href='#type-promotion-08'>
+            type-promotion-08:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-08' property='mf:name'>tP-nonPositiveInteger-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-08' property='mf:name'>tP-nonPositiveInteger-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-08' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-08' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -364,22 +282,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-nonPositiveInteger-short.rq' property='qt:query'>tP-nonPositiveInteger-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -388,13 +294,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-09'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-09'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-09:
+        <dt id='type-promotion-09'>
+          <a class='testlink' href='#type-promotion-09'>
+            type-promotion-09:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-09' property='mf:name'>tP-negativeInteger-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-09' property='mf:name'>tP-negativeInteger-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-09' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-09' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -402,22 +309,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-negativeInteger-short.rq' property='qt:query'>tP-negativeInteger-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -426,13 +321,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-10'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-10'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-10:
+        <dt id='type-promotion-10'>
+          <a class='testlink' href='#type-promotion-10'>
+            type-promotion-10:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-10' property='mf:name'>tP-long-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-10' property='mf:name'>tP-long-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-10' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-10' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -440,22 +336,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-long-short.rq' property='qt:query'>tP-long-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -464,13 +348,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-11'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-11'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-11:
+        <dt id='type-promotion-11'>
+          <a class='testlink' href='#type-promotion-11'>
+            type-promotion-11:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-11' property='mf:name'>tP-int-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-11' property='mf:name'>tP-int-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-11' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-11' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -478,22 +363,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-int-short.rq' property='qt:query'>tP-int-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -502,13 +375,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-12'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-12'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-12:
+        <dt id='type-promotion-12'>
+          <a class='testlink' href='#type-promotion-12'>
+            type-promotion-12:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-12' property='mf:name'>tP-short-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-12' property='mf:name'>tP-short-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-12' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-12' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -516,22 +390,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-short-short.rq' property='qt:query'>tP-short-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -540,13 +402,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-13'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-13'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-13:
+        <dt id='type-promotion-13'>
+          <a class='testlink' href='#type-promotion-13'>
+            type-promotion-13:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-13' property='mf:name'>tP-byte-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-13' property='mf:name'>tP-byte-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-13' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-13' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -554,22 +417,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-byte-short.rq' property='qt:query'>tP-byte-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -578,13 +429,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-14'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-14'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-14:
+        <dt id='type-promotion-14'>
+          <a class='testlink' href='#type-promotion-14'>
+            type-promotion-14:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-14' property='mf:name'>tP-nonNegativeInteger-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-14' property='mf:name'>tP-nonNegativeInteger-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-14' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-14' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -592,22 +444,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-nonNegativeInteger-short.rq' property='qt:query'>tP-nonNegativeInteger-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -616,13 +456,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-15'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-15'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-15:
+        <dt id='type-promotion-15'>
+          <a class='testlink' href='#type-promotion-15'>
+            type-promotion-15:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-15' property='mf:name'>tP-unsignedLong-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-15' property='mf:name'>tP-unsignedLong-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-15' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-15' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -630,22 +471,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-unsignedLong-short.rq' property='qt:query'>tP-unsignedLong-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -654,13 +483,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-16'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-16'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-16:
+        <dt id='type-promotion-16'>
+          <a class='testlink' href='#type-promotion-16'>
+            type-promotion-16:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-16' property='mf:name'>tP-unsignedInt-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-16' property='mf:name'>tP-unsignedInt-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-16' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-16' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -668,22 +498,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-unsignedInt-short.rq' property='qt:query'>tP-unsignedInt-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -692,13 +510,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-17'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-17'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-17:
+        <dt id='type-promotion-17'>
+          <a class='testlink' href='#type-promotion-17'>
+            type-promotion-17:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-17' property='mf:name'>tP-unsignedShort-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-17' property='mf:name'>tP-unsignedShort-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-17' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-17' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -706,22 +525,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-unsignedShort-short.rq' property='qt:query'>tP-unsignedShort-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -730,13 +537,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-18'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-18'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-18:
+        <dt id='type-promotion-18'>
+          <a class='testlink' href='#type-promotion-18'>
+            type-promotion-18:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-18' property='mf:name'>tP-unsignedByte-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-18' property='mf:name'>tP-unsignedByte-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-18' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-18' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -744,22 +552,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-unsignedByte-short.rq' property='qt:query'>tP-unsignedByte-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -768,13 +564,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-19'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-19'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-19:
+        <dt id='type-promotion-19'>
+          <a class='testlink' href='#type-promotion-19'>
+            type-promotion-19:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-19' property='mf:name'>tP-positiveInteger-short</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-19' property='mf:name'>tP-positiveInteger-short</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-19' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-19' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -782,22 +579,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-positiveInteger-short.rq' property='qt:query'>tP-positiveInteger-short.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -806,13 +591,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-20'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-20'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-20:
+        <dt id='type-promotion-20'>
+          <a class='testlink' href='#type-promotion-20'>
+            type-promotion-20:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-20' property='mf:name'>tP-short-double</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-20' property='mf:name'>tP-short-double</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-20' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-20' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -820,22 +606,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-short-double.rq' property='qt:query'>tP-short-double.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -844,13 +618,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-21'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-21'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-21:
+        <dt id='type-promotion-21'>
+          <a class='testlink' href='#type-promotion-21'>
+            type-promotion-21:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-21' property='mf:name'>tP-short-float</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-21' property='mf:name'>tP-short-float</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-21' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-21' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -858,22 +633,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-short-float.rq' property='qt:query'>tP-short-float.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -882,13 +645,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-22'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-22'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-22:
+        <dt id='type-promotion-22'>
+          <a class='testlink' href='#type-promotion-22'>
+            type-promotion-22:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-22' property='mf:name'>tP-short-decimal</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-22' property='mf:name'>tP-short-decimal</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-22' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-22' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -896,22 +660,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-short-decimal.rq' property='qt:query'>tP-short-decimal.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -920,13 +672,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-23'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-23'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-23:
+        <dt id='type-promotion-23'>
+          <a class='testlink' href='#type-promotion-23'>
+            type-promotion-23:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-23' property='mf:name'>tP-short-short-fail</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-23' property='mf:name'>tP-short-short-fail</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-23' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-23' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -934,22 +687,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-short-short-fail.rq' property='qt:query'>tP-short-short-fail.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -958,13 +699,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-24'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-24'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-24:
+        <dt id='type-promotion-24'>
+          <a class='testlink' href='#type-promotion-24'>
+            type-promotion-24:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-24' property='mf:name'>tP-byte-short-fail</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-24' property='mf:name'>tP-byte-short-fail</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-24' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-24' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -972,22 +714,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-byte-short-fail.rq' property='qt:query'>tP-byte-short-fail.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -996,13 +726,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-25'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-25'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-25:
+        <dt id='type-promotion-25'>
+          <a class='testlink' href='#type-promotion-25'>
+            type-promotion-25:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-25' property='mf:name'>tP-short-long-fail</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-25' property='mf:name'>tP-short-long-fail</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-25' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-25' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -1010,22 +741,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-short-long-fail.rq' property='qt:query'>tP-short-long-fail.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -1034,13 +753,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-26'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-26'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-26:
+        <dt id='type-promotion-26'>
+          <a class='testlink' href='#type-promotion-26'>
+            type-promotion-26:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-26' property='mf:name'>tP-short-int-fail</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-26' property='mf:name'>tP-short-int-fail</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-26' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-26' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -1048,22 +768,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-short-int-fail.rq' property='qt:query'>tP-short-int-fail.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -1072,13 +780,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-27'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-27'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-27:
+        <dt id='type-promotion-27'>
+          <a class='testlink' href='#type-promotion-27'>
+            type-promotion-27:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-27' property='mf:name'>tP-short-byte-fail</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-27' property='mf:name'>tP-short-byte-fail</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-27' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-27' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -1086,22 +795,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-short-byte-fail.rq' property='qt:query'>tP-short-byte-fail.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -1110,13 +807,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-28'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-28'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-28:
+        <dt id='type-promotion-28'>
+          <a class='testlink' href='#type-promotion-28'>
+            type-promotion-28:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-28' property='mf:name'>tP-double-float-fail</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-28' property='mf:name'>tP-double-float-fail</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-28' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-28' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -1124,22 +822,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-double-float-fail.rq' property='qt:query'>tP-double-float-fail.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -1148,13 +834,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-29'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-29'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-29:
+        <dt id='type-promotion-29'>
+          <a class='testlink' href='#type-promotion-29'>
+            type-promotion-29:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-29' property='mf:name'>tP-double-decimal-fail</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-29' property='mf:name'>tP-double-decimal-fail</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-29' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-29' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -1162,22 +849,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-double-decimal-fail.rq' property='qt:query'>tP-double-decimal-fail.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>
@@ -1186,13 +861,14 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-30'>
-          <a class='testlink' href='#http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-30'>
-            http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-30:
+        <dt id='type-promotion-30'>
+          <a class='testlink' href='#type-promotion-30'>
+            type-promotion-30:
           </a>
           <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-30' property='mf:name'>tP-float-decimal-fail</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-30' property='mf:name'>tP-float-decimal-fail</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-30' typeof='mf:QueryEvaluationTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/type-promotion/manifest#type-promotion-30' typeof='mf:QueryEvaluationTest'>
           <div property='rdfs:comment'>
             <p>Positive test: product of type promotion within the xsd:decimal type tree.</p>
           </div>
@@ -1200,22 +876,10 @@
             <dt>type</dt>
             <dd>mf:QueryEvaluationTest</dd>
             <dt>approval</dt>
-            <dd property='mf:approval' resource='dawgt:Approved'>dawgt:Approved</dd>
-            <dt>approvedBy</dt>
-            <dd>
-              <a href='http://www.w3.org/2007/07/17-dawg-minutes' property='dawgt:approvedBy'>http://www.w3.org/2007/07/17-dawg-minutes</a>
-            </dd>
+            <dd property='mf:approval' resource=''></dd>
             <dt>action</dt>
             <dd>
               <dl class='test-detail'>
-                <dt>query</dt>
-                <dd>
-                  <a href='tP-float-decimal-fail.rq' property='qt:query'>tP-float-decimal-fail.rq</a>
-                </dd>
-                <dt>data</dt>
-                <dd>
-                  <a href='tP.ttl' property='qt:data'>tP.ttl</a>
-                </dd>
               </dl>
             </dd>
             <dt>result</dt>

--- a/sparql/sparql11/add/index.html
+++ b/sparql/sparql11/add/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add01:
+        <dt id='add01'>
+          <a class='testlink' href='#add01'>
+            add01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add01' property='mf:name'>ADD 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add01' property='mf:name'>ADD 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add01' typeof='mf:UpdateEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add02:
+        <dt id='add02'>
+          <a class='testlink' href='#add02'>
+            add02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add02' property='mf:name'>ADD 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add02' property='mf:name'>ADD 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add02' typeof='mf:UpdateEvaluationTest'>
@@ -131,10 +133,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add03:
+        <dt id='add03'>
+          <a class='testlink' href='#add03'>
+            add03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add03' property='mf:name'>ADD 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add03' property='mf:name'>ADD 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add03' typeof='mf:UpdateEvaluationTest'>
@@ -158,10 +161,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add04:
+        <dt id='add04'>
+          <a class='testlink' href='#add04'>
+            add04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add04' property='mf:name'>ADD 4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add04' property='mf:name'>ADD 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add04' typeof='mf:UpdateEvaluationTest'>
@@ -185,10 +189,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add05:
+        <dt id='add05'>
+          <a class='testlink' href='#add05'>
+            add05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add05' property='mf:name'>ADD 5</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add05' property='mf:name'>ADD 5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add05' typeof='mf:UpdateEvaluationTest'>
@@ -212,10 +217,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add06:
+        <dt id='add06'>
+          <a class='testlink' href='#add06'>
+            add06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add06' property='mf:name'>ADD 6</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add06' property='mf:name'>ADD 6</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add06' typeof='mf:UpdateEvaluationTest'>
@@ -239,10 +245,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add07:
+        <dt id='add07'>
+          <a class='testlink' href='#add07'>
+            add07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add07' property='mf:name'>ADD 7</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add07' property='mf:name'>ADD 7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add07' typeof='mf:UpdateEvaluationTest'>
@@ -266,10 +273,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add08:
+        <dt id='add08'>
+          <a class='testlink' href='#add08'>
+            add08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add08' property='mf:name'>ADD 8</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add08' property='mf:name'>ADD 8</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/add/manifest#add08' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql11/aggregates/index.html
+++ b/sparql/sparql11/aggregates/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg01:
+        <dt id='agg01'>
+          <a class='testlink' href='#agg01'>
+            agg01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg01' property='mf:name'>COUNT 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg01' property='mf:name'>COUNT 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg01' typeof='mf:QueryEvaluationTest'>
@@ -103,10 +104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg02:
+        <dt id='agg02'>
+          <a class='testlink' href='#agg02'>
+            agg02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg02' property='mf:name'>COUNT 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg02' property='mf:name'>COUNT 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg02' typeof='mf:QueryEvaluationTest'>
@@ -129,10 +131,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg03:
+        <dt id='agg03'>
+          <a class='testlink' href='#agg03'>
+            agg03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg03' property='mf:name'>COUNT 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg03' property='mf:name'>COUNT 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg03' typeof='mf:QueryEvaluationTest'>
@@ -155,10 +158,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg04:
+        <dt id='agg04'>
+          <a class='testlink' href='#agg04'>
+            agg04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg04' property='mf:name'>COUNT 4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg04' property='mf:name'>COUNT 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg04' typeof='mf:QueryEvaluationTest'>
@@ -181,10 +185,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg05:
+        <dt id='agg05'>
+          <a class='testlink' href='#agg05'>
+            agg05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg05' property='mf:name'>COUNT 5</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg05' property='mf:name'>COUNT 5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg05' typeof='mf:QueryEvaluationTest'>
@@ -207,10 +212,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg06:
+        <dt id='agg06'>
+          <a class='testlink' href='#agg06'>
+            agg06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg06' property='mf:name'>COUNT 6</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg06' property='mf:name'>COUNT 6</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg06' typeof='mf:QueryEvaluationTest'>
@@ -233,10 +239,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg07:
+        <dt id='agg07'>
+          <a class='testlink' href='#agg07'>
+            agg07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg07' property='mf:name'>COUNT 7</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg07' property='mf:name'>COUNT 7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg07' typeof='mf:QueryEvaluationTest'>
@@ -259,10 +266,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08:
+        <dt id='agg08'>
+          <a class='testlink' href='#agg08'>
+            agg08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08' property='mf:name'>COUNT 8</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08' property='mf:name'>COUNT 8</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08' typeof='mf:NegativeSyntaxTest11'>
@@ -280,10 +288,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08b'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08b'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08b:
+        <dt id='agg08b'>
+          <a class='testlink' href='#agg08b'>
+            agg08b:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08b' property='mf:name'>COUNT 8b</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08b' property='mf:name'>COUNT 8b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg08b' typeof='mf:QueryEvaluationTest'>
@@ -306,10 +315,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg09'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg09'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg09:
+        <dt id='agg09'>
+          <a class='testlink' href='#agg09'>
+            agg09:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg09' property='mf:name'>COUNT 9</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg09' property='mf:name'>COUNT 9</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg09' typeof='mf:NegativeSyntaxTest11'>
@@ -327,10 +337,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg10'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg10'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg10:
+        <dt id='agg10'>
+          <a class='testlink' href='#agg10'>
+            agg10:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg10' property='mf:name'>COUNT 10</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg10' property='mf:name'>COUNT 10</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg10' typeof='mf:NegativeSyntaxTest11'>
@@ -348,10 +359,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg11:
+        <dt id='agg11'>
+          <a class='testlink' href='#agg11'>
+            agg11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg11' property='mf:name'>COUNT 11</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg11' property='mf:name'>COUNT 11</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg11' typeof='mf:NegativeSyntaxTest11'>
@@ -369,10 +381,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg12'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg12'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg12:
+        <dt id='agg12'>
+          <a class='testlink' href='#agg12'>
+            agg12:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg12' property='mf:name'>COUNT 12</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg12' property='mf:name'>COUNT 12</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg12' typeof='mf:NegativeSyntaxTest11'>
@@ -390,10 +403,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-01:
+        <dt id='agg-groupconcat-01'>
+          <a class='testlink' href='#agg-groupconcat-01'>
+            agg-groupconcat-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-01' property='mf:name'>GROUP_CONCAT 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-01' property='mf:name'>GROUP_CONCAT 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-01' typeof='mf:QueryEvaluationTest'>
@@ -415,10 +429,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-02:
+        <dt id='agg-groupconcat-02'>
+          <a class='testlink' href='#agg-groupconcat-02'>
+            agg-groupconcat-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-02' property='mf:name'>GROUP_CONCAT 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-02' property='mf:name'>GROUP_CONCAT 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-02' typeof='mf:QueryEvaluationTest'>
@@ -440,10 +455,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-03:
+        <dt id='agg-groupconcat-03'>
+          <a class='testlink' href='#agg-groupconcat-03'>
+            agg-groupconcat-03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-03' property='mf:name'>GROUP_CONCAT with SEPARATOR</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-03' property='mf:name'>GROUP_CONCAT with SEPARATOR</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-03' typeof='mf:QueryEvaluationTest'>
@@ -465,10 +481,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-01:
+        <dt id='agg-sum-01'>
+          <a class='testlink' href='#agg-sum-01'>
+            agg-sum-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-01' property='mf:name'>SUM</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-01' property='mf:name'>SUM</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-01' typeof='mf:QueryEvaluationTest'>
@@ -490,10 +507,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-02:
+        <dt id='agg-sum-02'>
+          <a class='testlink' href='#agg-sum-02'>
+            agg-sum-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-02' property='mf:name'>SUM with GROUP BY</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-02' property='mf:name'>SUM with GROUP BY</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sum-02' typeof='mf:QueryEvaluationTest'>
@@ -515,10 +533,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-01:
+        <dt id='agg-avg-01'>
+          <a class='testlink' href='#agg-avg-01'>
+            agg-avg-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-01' property='mf:name'>AVG</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-01' property='mf:name'>AVG</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-01' typeof='mf:QueryEvaluationTest'>
@@ -540,10 +559,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-02:
+        <dt id='agg-avg-02'>
+          <a class='testlink' href='#agg-avg-02'>
+            agg-avg-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-02' property='mf:name'>AVG with GROUP BY</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-02' property='mf:name'>AVG with GROUP BY</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-avg-02' typeof='mf:QueryEvaluationTest'>
@@ -565,10 +585,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-01:
+        <dt id='agg-min-01'>
+          <a class='testlink' href='#agg-min-01'>
+            agg-min-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-01' property='mf:name'>MIN</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-01' property='mf:name'>MIN</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-01' typeof='mf:QueryEvaluationTest'>
@@ -590,10 +611,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-02:
+        <dt id='agg-min-02'>
+          <a class='testlink' href='#agg-min-02'>
+            agg-min-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-02' property='mf:name'>MIN with GROUP BY</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-02' property='mf:name'>MIN with GROUP BY</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-min-02' typeof='mf:QueryEvaluationTest'>
@@ -615,10 +637,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-01:
+        <dt id='agg-max-01'>
+          <a class='testlink' href='#agg-max-01'>
+            agg-max-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-01' property='mf:name'>MAX</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-01' property='mf:name'>MAX</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-01' typeof='mf:QueryEvaluationTest'>
@@ -640,10 +663,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-02:
+        <dt id='agg-max-02'>
+          <a class='testlink' href='#agg-max-02'>
+            agg-max-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-02' property='mf:name'>MAX with GROUP BY</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-02' property='mf:name'>MAX with GROUP BY</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-max-02' typeof='mf:QueryEvaluationTest'>
@@ -665,10 +689,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sample-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sample-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sample-01:
+        <dt id='agg-sample-01'>
+          <a class='testlink' href='#agg-sample-01'>
+            agg-sample-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sample-01' property='mf:name'>SAMPLE</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sample-01' property='mf:name'>SAMPLE</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-sample-01' typeof='mf:QueryEvaluationTest'>
@@ -690,10 +715,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-01:
+        <dt id='agg-err-01'>
+          <a class='testlink' href='#agg-err-01'>
+            agg-err-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-01' property='mf:name'>Error in AVG</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-01' property='mf:name'>Error in AVG</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-01' typeof='mf:QueryEvaluationTest'>
@@ -716,10 +742,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-02:
+        <dt id='agg-err-02'>
+          <a class='testlink' href='#agg-err-02'>
+            agg-err-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-02' property='mf:name'>Protect from error in AVG</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-02' property='mf:name'>Protect from error in AVG</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-err-02' typeof='mf:QueryEvaluationTest'>
@@ -742,10 +769,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-1:
+        <dt id='agg-empty-group-max-1'>
+          <a class='testlink' href='#agg-empty-group-max-1'>
+            agg-empty-group-max-1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-1' property='mf:name'>agg on empty set, explicit grouping</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-1' property='mf:name'>agg on empty set, explicit grouping</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-1' typeof='mf:QueryEvaluationTest'>
@@ -768,10 +796,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-2:
+        <dt id='agg-empty-group-max-2'>
+          <a class='testlink' href='#agg-empty-group-max-2'>
+            agg-empty-group-max-2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-2' property='mf:name'>agg on empty set, no grouping</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-2' property='mf:name'>agg on empty set, no grouping</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-max-2' typeof='mf:QueryEvaluationTest'>
@@ -794,10 +823,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-1:
+        <dt id='agg-empty-group-count-1'>
+          <a class='testlink' href='#agg-empty-group-count-1'>
+            agg-empty-group-count-1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-1' property='mf:name'>COUNT: no match, with group</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-1' property='mf:name'>COUNT: no match, with group</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-1' typeof='mf:QueryEvaluationTest'>
@@ -820,10 +850,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-2:
+        <dt id='agg-empty-group-count-2'>
+          <a class='testlink' href='#agg-empty-group-count-2'>
+            agg-empty-group-count-2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-2' property='mf:name'>COUNT: no match, no group</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-2' property='mf:name'>COUNT: no match, no group</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-empty-group-count-2' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/basic-update/index.html
+++ b/sparql/sparql11/basic-update/index.html
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Basic SPARQL 1.1 Update test cases
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo1:
+        <dt id='insert-data-spo1'>
+          <a class='testlink' href='#insert-data-spo1'>
+            insert-data-spo1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo1' property='mf:name'>Simple insert data 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo1' property='mf:name'>Simple insert data 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo1' typeof='mf:UpdateEvaluationTest'>
@@ -105,10 +106,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named1:
+        <dt id='insert-data-spo-named1'>
+          <a class='testlink' href='#insert-data-spo-named1'>
+            insert-data-spo-named1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named1' property='mf:name'>Simple insert data named 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named1' property='mf:name'>Simple insert data named 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named1' typeof='mf:UpdateEvaluationTest'>
@@ -132,10 +134,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named2:
+        <dt id='insert-data-spo-named2'>
+          <a class='testlink' href='#insert-data-spo-named2'>
+            insert-data-spo-named2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named2' property='mf:name'>Simple insert data named 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named2' property='mf:name'>Simple insert data named 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named2' typeof='mf:UpdateEvaluationTest'>
@@ -159,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named3'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named3'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named3:
+        <dt id='insert-data-spo-named3'>
+          <a class='testlink' href='#insert-data-spo-named3'>
+            insert-data-spo-named3:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named3' property='mf:name'>Simple insert data named 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named3' property='mf:name'>Simple insert data named 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-spo-named3' typeof='mf:UpdateEvaluationTest'>
@@ -186,10 +190,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-01:
+        <dt id='insert-where-01'>
+          <a class='testlink' href='#insert-where-01'>
+            insert-where-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-01' property='mf:name'>INSERT 01</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-01' property='mf:name'>INSERT 01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-01' typeof='mf:UpdateEvaluationTest'>
@@ -213,10 +218,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-02:
+        <dt id='insert-where-02'>
+          <a class='testlink' href='#insert-where-02'>
+            insert-where-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-02' property='mf:name'>INSERT 02</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-02' property='mf:name'>INSERT 02</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-02' typeof='mf:UpdateEvaluationTest'>
@@ -240,10 +246,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-03:
+        <dt id='insert-where-03'>
+          <a class='testlink' href='#insert-where-03'>
+            insert-where-03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-03' property='mf:name'>INSERT 03</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-03' property='mf:name'>INSERT 03</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-03' typeof='mf:UpdateEvaluationTest'>
@@ -267,10 +274,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-04:
+        <dt id='insert-where-04'>
+          <a class='testlink' href='#insert-where-04'>
+            insert-where-04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-04' property='mf:name'>INSERT 04</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-04' property='mf:name'>INSERT 04</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-04' typeof='mf:UpdateEvaluationTest'>
@@ -294,10 +302,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-using-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-using-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-using-01:
+        <dt id='insert-using-01'>
+          <a class='testlink' href='#insert-using-01'>
+            insert-using-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-using-01' property='mf:name'>INSERT USING 01</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-using-01' property='mf:name'>INSERT USING 01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-using-01' typeof='mf:UpdateEvaluationTest'>
@@ -321,10 +330,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-05a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-05a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-05a:
+        <dt id='insert-05a'>
+          <a class='testlink' href='#insert-05a'>
+            insert-05a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-05a' property='mf:name'>INSERT same bnode twice</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-05a' property='mf:name'>INSERT same bnode twice</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-05a' typeof='mf:UpdateEvaluationTest'>
@@ -348,10 +358,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-same-bnode'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-same-bnode'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-same-bnode:
+        <dt id='insert-data-same-bnode'>
+          <a class='testlink' href='#insert-data-same-bnode'>
+            insert-data-same-bnode:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-same-bnode' property='mf:name'>INSERTing the same bnode with INSERT DATA into two different Graphs is the same bnode</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-same-bnode' property='mf:name'>INSERTing the same bnode with INSERT DATA into two different Graphs is the same bnode</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-data-same-bnode' typeof='mf:UpdateEvaluationTest'>
@@ -375,10 +386,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode:
+        <dt id='insert-where-same-bnode'>
+          <a class='testlink' href='#insert-where-same-bnode'>
+            insert-where-same-bnode:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode' property='mf:name'>INSERTing the same bnode with two INSERT WHERE statement within one request is NOT the same bnode</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode' property='mf:name'>INSERTing the same bnode with two INSERT WHERE statement within one request is NOT the same bnode</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode' typeof='mf:UpdateEvaluationTest'>
@@ -402,10 +414,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode2:
+        <dt id='insert-where-same-bnode2'>
+          <a class='testlink' href='#insert-where-same-bnode2'>
+            insert-where-same-bnode2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode2' property='mf:name'>INSERTing the same bnode with two INSERT WHERE statement within one request is NOT the same bnode even if both WHERE clauses have the empty solution mapping as the only solution.</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode2' property='mf:name'>INSERTing the same bnode with two INSERT WHERE statement within one request is NOT the same bnode even if both WHERE clauses have the empty solution mapping as the only solution.</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/basic-update/manifest#insert-where-same-bnode2' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql11/bind/index.html
+++ b/sparql/sparql11/bind/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind01:
+        <dt id='bind01'>
+          <a class='testlink' href='#bind01'>
+            bind01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind01' property='mf:name'>bind01 - BIND</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind01' property='mf:name'>bind01 - BIND</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind01' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind02:
+        <dt id='bind02'>
+          <a class='testlink' href='#bind02'>
+            bind02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind02' property='mf:name'>bind02 - BIND</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind02' property='mf:name'>bind02 - BIND</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind02' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind03:
+        <dt id='bind03'>
+          <a class='testlink' href='#bind03'>
+            bind03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind03' property='mf:name'>bind03 - BIND</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind03' property='mf:name'>bind03 - BIND</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind03' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind04:
+        <dt id='bind04'>
+          <a class='testlink' href='#bind04'>
+            bind04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind04' property='mf:name'>bind04 - BIND</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind04' property='mf:name'>bind04 - BIND</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind04' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind05:
+        <dt id='bind05'>
+          <a class='testlink' href='#bind05'>
+            bind05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind05' property='mf:name'>bind05 - BIND</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind05' property='mf:name'>bind05 - BIND</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind05' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind06:
+        <dt id='bind06'>
+          <a class='testlink' href='#bind06'>
+            bind06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind06' property='mf:name'>bind06 - BIND</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind06' property='mf:name'>bind06 - BIND</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind06' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind07:
+        <dt id='bind07'>
+          <a class='testlink' href='#bind07'>
+            bind07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind07' property='mf:name'>bind07 - BIND</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind07' property='mf:name'>bind07 - BIND</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind07' typeof='mf:QueryEvaluationTest'>
@@ -252,10 +259,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind08:
+        <dt id='bind08'>
+          <a class='testlink' href='#bind08'>
+            bind08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind08' property='mf:name'>bind08 - BIND</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind08' property='mf:name'>bind08 - BIND</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind08' typeof='mf:QueryEvaluationTest'>
@@ -277,10 +285,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind10'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind10'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind10:
+        <dt id='bind10'>
+          <a class='testlink' href='#bind10'>
+            bind10:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind10' property='mf:name'>bind10 - BIND scoping - Variable in filter not in scope</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind10' property='mf:name'>bind10 - BIND scoping - Variable in filter not in scope</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind10' typeof='mf:QueryEvaluationTest'>
@@ -302,10 +311,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind11:
+        <dt id='bind11'>
+          <a class='testlink' href='#bind11'>
+            bind11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind11' property='mf:name'>bind11 - BIND scoping - Variable in filter in scope</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind11' property='mf:name'>bind11 - BIND scoping - Variable in filter in scope</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bind/manifest#bind11' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/bindings/index.html
+++ b/sparql/sparql11/bindings/index.html
@@ -63,7 +63,7 @@
       <p property='rdfs:comment'>
         Bindings
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values1:
+        <dt id='values1'>
+          <a class='testlink' href='#values1'>
+            values1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values1' property='mf:name'>Post-query VALUES with subj-var, 1 row</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values1' property='mf:name'>Post-query VALUES with subj-var, 1 row</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values1' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values2:
+        <dt id='values2'>
+          <a class='testlink' href='#values2'>
+            values2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values2' property='mf:name'>Post-query VALUES with obj-var, 1 row</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values2' property='mf:name'>Post-query VALUES with obj-var, 1 row</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values2' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values3'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values3'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values3:
+        <dt id='values3'>
+          <a class='testlink' href='#values3'>
+            values3:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values3' property='mf:name'>Post-query VALUES with 2 obj-vars, 1 row</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values3' property='mf:name'>Post-query VALUES with 2 obj-vars, 1 row</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values3' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values4'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values4'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values4:
+        <dt id='values4'>
+          <a class='testlink' href='#values4'>
+            values4:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values4' property='mf:name'>Post-query VALUES with 2 obj-vars, 1 row with UNDEF</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values4' property='mf:name'>Post-query VALUES with 2 obj-vars, 1 row with UNDEF</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values4' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values5'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values5'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values5:
+        <dt id='values5'>
+          <a class='testlink' href='#values5'>
+            values5:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values5' property='mf:name'>Post-query VALUES with 2 obj-vars, 2 rows with UNDEF</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values5' property='mf:name'>Post-query VALUES with 2 obj-vars, 2 rows with UNDEF</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values5' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values6'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values6'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values6:
+        <dt id='values6'>
+          <a class='testlink' href='#values6'>
+            values6:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values6' property='mf:name'>Post-query VALUES with pred-var, 1 row</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values6' property='mf:name'>Post-query VALUES with pred-var, 1 row</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values6' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values7'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values7'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values7:
+        <dt id='values7'>
+          <a class='testlink' href='#values7'>
+            values7:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values7' property='mf:name'>Post-query VALUES with (OPTIONAL) obj-var, 1 row</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values7' property='mf:name'>Post-query VALUES with (OPTIONAL) obj-var, 1 row</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values7' typeof='mf:QueryEvaluationTest'>
@@ -252,10 +259,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values8'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values8'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values8:
+        <dt id='values8'>
+          <a class='testlink' href='#values8'>
+            values8:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values8' property='mf:name'>Post-query VALUES with subj/obj-vars, 2 rows with UNDEF</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values8' property='mf:name'>Post-query VALUES with subj/obj-vars, 2 rows with UNDEF</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#values8' typeof='mf:QueryEvaluationTest'>
@@ -277,10 +285,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline1:
+        <dt id='inline1'>
+          <a class='testlink' href='#inline1'>
+            inline1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline1' property='mf:name'>Inline VALUES graph pattern</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline1' property='mf:name'>Inline VALUES graph pattern</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline1' typeof='mf:QueryEvaluationTest'>
@@ -302,10 +311,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline2:
+        <dt id='inline2'>
+          <a class='testlink' href='#inline2'>
+            inline2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline2' property='mf:name'>Post-subquery VALUES</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline2' property='mf:name'>Post-subquery VALUES</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/bindings/manifest#inline2' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/cast/index.html
+++ b/sparql/sparql11/cast/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-bool'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-bool'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-bool:
+        <dt id='cast-bool'>
+          <a class='testlink' href='#cast-bool'>
+            cast-bool:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-bool' property='mf:name'>xsd:boolean cast</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-bool' property='mf:name'>xsd:boolean cast</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-bool' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-int'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-int'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-int:
+        <dt id='cast-int'>
+          <a class='testlink' href='#cast-int'>
+            cast-int:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-int' property='mf:name'>xsd:integer cast</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-int' property='mf:name'>xsd:integer cast</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-int' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-float'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-float'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-float:
+        <dt id='cast-float'>
+          <a class='testlink' href='#cast-float'>
+            cast-float:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-float' property='mf:name'>xsd:float cast</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-float' property='mf:name'>xsd:float cast</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-float' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-double'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-double'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-double:
+        <dt id='cast-double'>
+          <a class='testlink' href='#cast-double'>
+            cast-double:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-double' property='mf:name'>xsd:double cast</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-double' property='mf:name'>xsd:double cast</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-double' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-decimal'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-decimal'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-decimal:
+        <dt id='cast-decimal'>
+          <a class='testlink' href='#cast-decimal'>
+            cast-decimal:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-decimal' property='mf:name'>xsd:decimal cast</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-decimal' property='mf:name'>xsd:decimal cast</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-decimal' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-string'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-string'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-string:
+        <dt id='cast-string'>
+          <a class='testlink' href='#cast-string'>
+            cast-string:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-string' property='mf:name'>xsd:string cast</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-string' property='mf:name'>xsd:string cast</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/cast/manifest#cast-string' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/clear/index.html
+++ b/sparql/sparql11/clear/index.html
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Tests for SPARQL UPDATE
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-default-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-default-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-default-01:
+        <dt id='dawg-clear-default-01'>
+          <a class='testlink' href='#dawg-clear-default-01'>
+            dawg-clear-default-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-default-01' property='mf:name'>CLEAR DEFAULT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-default-01' property='mf:name'>CLEAR DEFAULT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-default-01' typeof='mf:UpdateEvaluationTest'>
@@ -105,10 +106,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-graph-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-graph-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-graph-01:
+        <dt id='dawg-clear-graph-01'>
+          <a class='testlink' href='#dawg-clear-graph-01'>
+            dawg-clear-graph-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-graph-01' property='mf:name'>CLEAR GRAPH</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-graph-01' property='mf:name'>CLEAR GRAPH</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-graph-01' typeof='mf:UpdateEvaluationTest'>
@@ -132,10 +134,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-named-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-named-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-named-01:
+        <dt id='dawg-clear-named-01'>
+          <a class='testlink' href='#dawg-clear-named-01'>
+            dawg-clear-named-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-named-01' property='mf:name'>CLEAR NAMED</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-named-01' property='mf:name'>CLEAR NAMED</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-named-01' typeof='mf:UpdateEvaluationTest'>
@@ -159,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-all-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-all-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-all-01:
+        <dt id='dawg-clear-all-01'>
+          <a class='testlink' href='#dawg-clear-all-01'>
+            dawg-clear-all-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-all-01' property='mf:name'>CLEAR ALL</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-all-01' property='mf:name'>CLEAR ALL</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/clear/manifest#dawg-clear-all-01' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql11/construct/index.html
+++ b/sparql/sparql11/construct/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere01:
+        <dt id='constructwhere01'>
+          <a class='testlink' href='#constructwhere01'>
+            constructwhere01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere01' property='mf:name'>constructwhere01 - CONSTRUCT WHERE</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere01' property='mf:name'>constructwhere01 - CONSTRUCT WHERE</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere01' typeof='mf:QueryEvaluationTest'>
@@ -103,10 +104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere02:
+        <dt id='constructwhere02'>
+          <a class='testlink' href='#constructwhere02'>
+            constructwhere02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere02' property='mf:name'>constructwhere02 - CONSTRUCT WHERE</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere02' property='mf:name'>constructwhere02 - CONSTRUCT WHERE</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere02' typeof='mf:QueryEvaluationTest'>
@@ -129,10 +131,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere03:
+        <dt id='constructwhere03'>
+          <a class='testlink' href='#constructwhere03'>
+            constructwhere03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere03' property='mf:name'>constructwhere03 - CONSTRUCT WHERE</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere03' property='mf:name'>constructwhere03 - CONSTRUCT WHERE</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere03' typeof='mf:QueryEvaluationTest'>
@@ -155,10 +158,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere04:
+        <dt id='constructwhere04'>
+          <a class='testlink' href='#constructwhere04'>
+            constructwhere04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere04' property='mf:name'>constructwhere04 - CONSTRUCT WHERE</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere04' property='mf:name'>constructwhere04 - CONSTRUCT WHERE</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere04' typeof='mf:QueryEvaluationTest'>
@@ -181,10 +185,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere05:
+        <dt id='constructwhere05'>
+          <a class='testlink' href='#constructwhere05'>
+            constructwhere05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere05' property='mf:name'>constructwhere05 - CONSTRUCT WHERE</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere05' property='mf:name'>constructwhere05 - CONSTRUCT WHERE</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere05' typeof='mf:NegativeSyntaxTest11'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere06:
+        <dt id='constructwhere06'>
+          <a class='testlink' href='#constructwhere06'>
+            constructwhere06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere06' property='mf:name'>constructwhere06 - CONSTRUCT WHERE</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere06' property='mf:name'>constructwhere06 - CONSTRUCT WHERE</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructwhere06' typeof='mf:NegativeSyntaxTest11'>
@@ -222,10 +228,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructlist'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructlist'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructlist:
+        <dt id='constructlist'>
+          <a class='testlink' href='#constructlist'>
+            constructlist:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructlist' property='mf:name'>CONSTRUCT list</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructlist' property='mf:name'>CONSTRUCT list</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/construct/manifest#constructlist' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/copy/index.html
+++ b/sparql/sparql11/copy/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy01:
+        <dt id='copy01'>
+          <a class='testlink' href='#copy01'>
+            copy01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy01' property='mf:name'>COPY 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy01' property='mf:name'>COPY 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy01' typeof='mf:UpdateEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy02:
+        <dt id='copy02'>
+          <a class='testlink' href='#copy02'>
+            copy02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy02' property='mf:name'>COPY 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy02' property='mf:name'>COPY 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy02' typeof='mf:UpdateEvaluationTest'>
@@ -131,10 +133,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy03:
+        <dt id='copy03'>
+          <a class='testlink' href='#copy03'>
+            copy03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy03' property='mf:name'>COPY 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy03' property='mf:name'>COPY 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy03' typeof='mf:UpdateEvaluationTest'>
@@ -158,10 +161,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy04:
+        <dt id='copy04'>
+          <a class='testlink' href='#copy04'>
+            copy04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy04' property='mf:name'>COPY 4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy04' property='mf:name'>COPY 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy04' typeof='mf:UpdateEvaluationTest'>
@@ -185,10 +189,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy06:
+        <dt id='copy06'>
+          <a class='testlink' href='#copy06'>
+            copy06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy06' property='mf:name'>COPY 6</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy06' property='mf:name'>COPY 6</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy06' typeof='mf:UpdateEvaluationTest'>
@@ -212,10 +217,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy07:
+        <dt id='copy07'>
+          <a class='testlink' href='#copy07'>
+            copy07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy07' property='mf:name'>COPY 7</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy07' property='mf:name'>COPY 7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/copy/manifest#copy07' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql11/csv-tsv-res/index.html
+++ b/sparql/sparql11/csv-tsv-res/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv01:
+        <dt id='csv01'>
+          <a class='testlink' href='#csv01'>
+            csv01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv01' property='mf:name'>csv01 - CSV Result Format</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv01' property='mf:name'>csv01 - CSV Result Format</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv01' typeof='mf:CSVResultFormatTest'>
@@ -103,10 +104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv01:
+        <dt id='tsv01'>
+          <a class='testlink' href='#tsv01'>
+            tsv01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv01' property='mf:name'>tsv01 - TSV Result Format</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv01' property='mf:name'>tsv01 - TSV Result Format</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv01' typeof='mf:QueryEvaluationTest'>
@@ -129,10 +131,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv02:
+        <dt id='csv02'>
+          <a class='testlink' href='#csv02'>
+            csv02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv02' property='mf:name'>cvs02 - CSV Result Format</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv02' property='mf:name'>cvs02 - CSV Result Format</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv02' typeof='mf:CSVResultFormatTest'>
@@ -155,10 +158,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv02:
+        <dt id='tsv02'>
+          <a class='testlink' href='#tsv02'>
+            tsv02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv02' property='mf:name'>tsv02 - TSV Result Format</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv02' property='mf:name'>tsv02 - TSV Result Format</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv02' typeof='mf:QueryEvaluationTest'>
@@ -181,10 +185,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv03:
+        <dt id='csv03'>
+          <a class='testlink' href='#csv03'>
+            csv03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv03' property='mf:name'>csv03 - CSV Result Format</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv03' property='mf:name'>csv03 - CSV Result Format</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#csv03' typeof='mf:CSVResultFormatTest'>
@@ -207,10 +212,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv03:
+        <dt id='tsv03'>
+          <a class='testlink' href='#tsv03'>
+            tsv03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv03' property='mf:name'>tsv03 - TSV Result Format</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv03' property='mf:name'>tsv03 - TSV Result Format</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/csv-tsv-res/manifest#tsv03' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/delete-data/index.html
+++ b/sparql/sparql11/delete-data/index.html
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Tests for SPARQL UPDATE
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-01:
+        <dt id='dawg-delete-data-01'>
+          <a class='testlink' href='#dawg-delete-data-01'>
+            dawg-delete-data-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-01' property='mf:name'>Simple DELETE DATA 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-01' property='mf:name'>Simple DELETE DATA 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-01' typeof='mf:UpdateEvaluationTest'>
@@ -105,10 +106,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-02:
+        <dt id='dawg-delete-data-02'>
+          <a class='testlink' href='#dawg-delete-data-02'>
+            dawg-delete-data-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-02' property='mf:name'>Simple DELETE DATA 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-02' property='mf:name'>Simple DELETE DATA 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-02' typeof='mf:UpdateEvaluationTest'>
@@ -132,10 +134,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-03:
+        <dt id='dawg-delete-data-03'>
+          <a class='testlink' href='#dawg-delete-data-03'>
+            dawg-delete-data-03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-03' property='mf:name'>Simple DELETE DATA 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-03' property='mf:name'>Simple DELETE DATA 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-03' typeof='mf:UpdateEvaluationTest'>
@@ -159,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-04:
+        <dt id='dawg-delete-data-04'>
+          <a class='testlink' href='#dawg-delete-data-04'>
+            dawg-delete-data-04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-04' property='mf:name'>Simple DELETE DATA 4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-04' property='mf:name'>Simple DELETE DATA 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-04' typeof='mf:UpdateEvaluationTest'>
@@ -186,10 +190,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-05:
+        <dt id='dawg-delete-data-05'>
+          <a class='testlink' href='#dawg-delete-data-05'>
+            dawg-delete-data-05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-05' property='mf:name'>Graph-specific DELETE DATA 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-05' property='mf:name'>Graph-specific DELETE DATA 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-05' typeof='mf:UpdateEvaluationTest'>
@@ -213,10 +218,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-06:
+        <dt id='dawg-delete-data-06'>
+          <a class='testlink' href='#dawg-delete-data-06'>
+            dawg-delete-data-06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-06' property='mf:name'>Graph-specific DELETE DATA 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-06' property='mf:name'>Graph-specific DELETE DATA 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-data/manifest#dawg-delete-data-06' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql11/delete-insert/index.html
+++ b/sparql/sparql11/delete-insert/index.html
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Tests for SPARQL UPDATE
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01:
+        <dt id='dawg-delete-insert-01'>
+          <a class='testlink' href='#dawg-delete-insert-01'>
+            dawg-delete-insert-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01' property='mf:name'>DELETE INSERT 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01' property='mf:name'>DELETE INSERT 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01' typeof='mf:UpdateEvaluationTest'>
@@ -105,10 +106,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01b'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01b'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01b:
+        <dt id='dawg-delete-insert-01b'>
+          <a class='testlink' href='#dawg-delete-insert-01b'>
+            dawg-delete-insert-01b:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01b' property='mf:name'>DELETE INSERT 1b</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01b' property='mf:name'>DELETE INSERT 1b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01b' typeof='mf:UpdateEvaluationTest'>
@@ -132,10 +134,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01c'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01c'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01c:
+        <dt id='dawg-delete-insert-01c'>
+          <a class='testlink' href='#dawg-delete-insert-01c'>
+            dawg-delete-insert-01c:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01c' property='mf:name'>DELETE INSERT 1c</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01c' property='mf:name'>DELETE INSERT 1c</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-01c' typeof='mf:UpdateEvaluationTest'>
@@ -159,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-02:
+        <dt id='dawg-delete-insert-02'>
+          <a class='testlink' href='#dawg-delete-insert-02'>
+            dawg-delete-insert-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-02' property='mf:name'>DELETE INSERT 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-02' property='mf:name'>DELETE INSERT 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-02' typeof='mf:UpdateEvaluationTest'>
@@ -186,10 +190,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03:
+        <dt id='dawg-delete-insert-03'>
+          <a class='testlink' href='#dawg-delete-insert-03'>
+            dawg-delete-insert-03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03' property='mf:name'>DELETE INSERT 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03' property='mf:name'>DELETE INSERT 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03' typeof='mf:NegativeSyntaxTest11'>
@@ -207,10 +212,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03b'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03b'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03b:
+        <dt id='dawg-delete-insert-03b'>
+          <a class='testlink' href='#dawg-delete-insert-03b'>
+            dawg-delete-insert-03b:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03b' property='mf:name'>DELETE INSERT 3b</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03b' property='mf:name'>DELETE INSERT 3b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-03b' typeof='mf:NegativeSyntaxTest11'>
@@ -228,10 +234,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04:
+        <dt id='dawg-delete-insert-04'>
+          <a class='testlink' href='#dawg-delete-insert-04'>
+            dawg-delete-insert-04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04' property='mf:name'>DELETE INSERT 4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04' property='mf:name'>DELETE INSERT 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04' typeof='mf:UpdateEvaluationTest'>
@@ -255,10 +262,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04b'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04b'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04b:
+        <dt id='dawg-delete-insert-04b'>
+          <a class='testlink' href='#dawg-delete-insert-04b'>
+            dawg-delete-insert-04b:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04b' property='mf:name'>DELETE INSERT 4b</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04b' property='mf:name'>DELETE INSERT 4b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-04b' typeof='mf:UpdateEvaluationTest'>
@@ -282,10 +290,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05:
+        <dt id='dawg-delete-insert-05'>
+          <a class='testlink' href='#dawg-delete-insert-05'>
+            dawg-delete-insert-05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05' property='mf:name'>DELETE INSERT 5</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05' property='mf:name'>DELETE INSERT 5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05' typeof='mf:NegativeSyntaxTest11'>
@@ -303,10 +312,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05b'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05b'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05b:
+        <dt id='dawg-delete-insert-05b'>
+          <a class='testlink' href='#dawg-delete-insert-05b'>
+            dawg-delete-insert-05b:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05b' property='mf:name'>DELETE INSERT 5b</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05b' property='mf:name'>DELETE INSERT 5b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-05b' typeof='mf:UpdateEvaluationTest'>
@@ -330,10 +340,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06:
+        <dt id='dawg-delete-insert-06'>
+          <a class='testlink' href='#dawg-delete-insert-06'>
+            dawg-delete-insert-06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06' property='mf:name'>DELETE INSERT 6</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06' property='mf:name'>DELETE INSERT 6</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06' typeof='mf:NegativeSyntaxTest11'>
@@ -351,10 +362,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06b'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06b'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06b:
+        <dt id='dawg-delete-insert-06b'>
+          <a class='testlink' href='#dawg-delete-insert-06b'>
+            dawg-delete-insert-06b:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06b' property='mf:name'>DELETE INSERT 6b</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06b' property='mf:name'>DELETE INSERT 6b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-06b' typeof='mf:UpdateEvaluationTest'>
@@ -378,10 +390,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07:
+        <dt id='dawg-delete-insert-07'>
+          <a class='testlink' href='#dawg-delete-insert-07'>
+            dawg-delete-insert-07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07' property='mf:name'>DELETE INSERT 7</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07' property='mf:name'>DELETE INSERT 7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07' typeof='mf:NegativeSyntaxTest11'>
@@ -399,10 +412,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07b'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07b'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07b:
+        <dt id='dawg-delete-insert-07b'>
+          <a class='testlink' href='#dawg-delete-insert-07b'>
+            dawg-delete-insert-07b:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07b' property='mf:name'>DELETE INSERT 7b</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07b' property='mf:name'>DELETE INSERT 7b</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-07b' typeof='mf:NegativeSyntaxTest11'>
@@ -420,10 +434,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-08:
+        <dt id='dawg-delete-insert-08'>
+          <a class='testlink' href='#dawg-delete-insert-08'>
+            dawg-delete-insert-08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-08' property='mf:name'>DELETE INSERT 8</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-08' property='mf:name'>DELETE INSERT 8</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-08' typeof='mf:NegativeSyntaxTest11'>
@@ -441,10 +456,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-09'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-09'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-09:
+        <dt id='dawg-delete-insert-09'>
+          <a class='testlink' href='#dawg-delete-insert-09'>
+            dawg-delete-insert-09:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-09' property='mf:name'>DELETE INSERT 9</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-09' property='mf:name'>DELETE INSERT 9</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#dawg-delete-insert-09' typeof='mf:NegativeSyntaxTest11'>
@@ -462,10 +478,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#delete-insert-halloween-problem'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#delete-insert-halloween-problem'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#delete-insert-halloween-problem:
+        <dt id='delete-insert-halloween-problem'>
+          <a class='testlink' href='#delete-insert-halloween-problem'>
+            delete-insert-halloween-problem:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#delete-insert-halloween-problem' property='mf:name'>Halloween Problem: A delete/insert operation should not be able to read its own writes</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#delete-insert-halloween-problem' property='mf:name'>Halloween Problem: A delete/insert operation should not be able to read its own writes</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-insert/manifest#delete-insert-halloween-problem' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql11/delete-where/index.html
+++ b/sparql/sparql11/delete-where/index.html
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Tests for SPARQL UPDATE
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-01:
+        <dt id='dawg-delete-where-01'>
+          <a class='testlink' href='#dawg-delete-where-01'>
+            dawg-delete-where-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-01' property='mf:name'>Simple DELETE WHERE 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-01' property='mf:name'>Simple DELETE WHERE 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-01' typeof='mf:UpdateEvaluationTest'>
@@ -105,10 +106,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-02:
+        <dt id='dawg-delete-where-02'>
+          <a class='testlink' href='#dawg-delete-where-02'>
+            dawg-delete-where-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-02' property='mf:name'>Simple DELETE WHERE 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-02' property='mf:name'>Simple DELETE WHERE 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-02' typeof='mf:UpdateEvaluationTest'>
@@ -132,10 +134,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-03:
+        <dt id='dawg-delete-where-03'>
+          <a class='testlink' href='#dawg-delete-where-03'>
+            dawg-delete-where-03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-03' property='mf:name'>Simple DELETE WHERE 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-03' property='mf:name'>Simple DELETE WHERE 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-03' typeof='mf:UpdateEvaluationTest'>
@@ -159,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-04:
+        <dt id='dawg-delete-where-04'>
+          <a class='testlink' href='#dawg-delete-where-04'>
+            dawg-delete-where-04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-04' property='mf:name'>Simple DELETE WHERE 4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-04' property='mf:name'>Simple DELETE WHERE 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-04' typeof='mf:UpdateEvaluationTest'>
@@ -186,10 +190,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-05:
+        <dt id='dawg-delete-where-05'>
+          <a class='testlink' href='#dawg-delete-where-05'>
+            dawg-delete-where-05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-05' property='mf:name'>Graph-specific DELETE WHERE 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-05' property='mf:name'>Graph-specific DELETE WHERE 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-05' typeof='mf:UpdateEvaluationTest'>
@@ -213,10 +218,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-06:
+        <dt id='dawg-delete-where-06'>
+          <a class='testlink' href='#dawg-delete-where-06'>
+            dawg-delete-where-06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-06' property='mf:name'>Graph-specific DELETE WHERE 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-06' property='mf:name'>Graph-specific DELETE WHERE 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete-where/manifest#dawg-delete-where-06' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql11/delete/index.html
+++ b/sparql/sparql11/delete/index.html
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Tests for SPARQL UPDATE
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-01:
+        <dt id='dawg-delete-01'>
+          <a class='testlink' href='#dawg-delete-01'>
+            dawg-delete-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-01' property='mf:name'>Simple DELETE 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-01' property='mf:name'>Simple DELETE 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-01' typeof='mf:UpdateEvaluationTest'>
@@ -105,10 +106,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-02:
+        <dt id='dawg-delete-02'>
+          <a class='testlink' href='#dawg-delete-02'>
+            dawg-delete-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-02' property='mf:name'>Simple DELETE 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-02' property='mf:name'>Simple DELETE 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-02' typeof='mf:UpdateEvaluationTest'>
@@ -132,10 +134,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-03:
+        <dt id='dawg-delete-03'>
+          <a class='testlink' href='#dawg-delete-03'>
+            dawg-delete-03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-03' property='mf:name'>Simple DELETE 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-03' property='mf:name'>Simple DELETE 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-03' typeof='mf:UpdateEvaluationTest'>
@@ -159,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-04:
+        <dt id='dawg-delete-04'>
+          <a class='testlink' href='#dawg-delete-04'>
+            dawg-delete-04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-04' property='mf:name'>Simple DELETE 4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-04' property='mf:name'>Simple DELETE 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-04' typeof='mf:UpdateEvaluationTest'>
@@ -186,10 +190,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-05:
+        <dt id='dawg-delete-05'>
+          <a class='testlink' href='#dawg-delete-05'>
+            dawg-delete-05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-05' property='mf:name'>Graph-specific DELETE 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-05' property='mf:name'>Graph-specific DELETE 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-05' typeof='mf:UpdateEvaluationTest'>
@@ -213,10 +218,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-06:
+        <dt id='dawg-delete-06'>
+          <a class='testlink' href='#dawg-delete-06'>
+            dawg-delete-06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-06' property='mf:name'>Graph-specific DELETE 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-06' property='mf:name'>Graph-specific DELETE 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-06' typeof='mf:UpdateEvaluationTest'>
@@ -240,10 +246,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-07:
+        <dt id='dawg-delete-07'>
+          <a class='testlink' href='#dawg-delete-07'>
+            dawg-delete-07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-07' property='mf:name'>Simple DELETE 7</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-07' property='mf:name'>Simple DELETE 7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-07' typeof='mf:UpdateEvaluationTest'>
@@ -267,10 +274,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-01:
+        <dt id='dawg-delete-with-01'>
+          <a class='testlink' href='#dawg-delete-with-01'>
+            dawg-delete-with-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-01' property='mf:name'>Simple DELETE 1 (WITH)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-01' property='mf:name'>Simple DELETE 1 (WITH)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-01' typeof='mf:UpdateEvaluationTest'>
@@ -294,10 +302,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-02:
+        <dt id='dawg-delete-with-02'>
+          <a class='testlink' href='#dawg-delete-with-02'>
+            dawg-delete-with-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-02' property='mf:name'>Simple DELETE 2 (WITH)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-02' property='mf:name'>Simple DELETE 2 (WITH)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-02' typeof='mf:UpdateEvaluationTest'>
@@ -321,10 +330,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-03:
+        <dt id='dawg-delete-with-03'>
+          <a class='testlink' href='#dawg-delete-with-03'>
+            dawg-delete-with-03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-03' property='mf:name'>Simple DELETE 3 (WITH)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-03' property='mf:name'>Simple DELETE 3 (WITH)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-03' typeof='mf:UpdateEvaluationTest'>
@@ -348,10 +358,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-04:
+        <dt id='dawg-delete-with-04'>
+          <a class='testlink' href='#dawg-delete-with-04'>
+            dawg-delete-with-04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-04' property='mf:name'>Simple DELETE 4 (WITH)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-04' property='mf:name'>Simple DELETE 4 (WITH)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-04' typeof='mf:UpdateEvaluationTest'>
@@ -375,10 +386,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-05:
+        <dt id='dawg-delete-with-05'>
+          <a class='testlink' href='#dawg-delete-with-05'>
+            dawg-delete-with-05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-05' property='mf:name'>Graph-specific DELETE 1 (WITH)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-05' property='mf:name'>Graph-specific DELETE 1 (WITH)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-05' typeof='mf:UpdateEvaluationTest'>
@@ -402,10 +414,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-06:
+        <dt id='dawg-delete-with-06'>
+          <a class='testlink' href='#dawg-delete-with-06'>
+            dawg-delete-with-06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-06' property='mf:name'>Graph-specific DELETE 2 (WITH)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-06' property='mf:name'>Graph-specific DELETE 2 (WITH)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-with-06' typeof='mf:UpdateEvaluationTest'>
@@ -429,10 +442,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-01:
+        <dt id='dawg-delete-using-01'>
+          <a class='testlink' href='#dawg-delete-using-01'>
+            dawg-delete-using-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-01' property='mf:name'>Simple DELETE 1 (USING)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-01' property='mf:name'>Simple DELETE 1 (USING)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-01' typeof='mf:UpdateEvaluationTest'>
@@ -456,10 +470,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-02a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-02a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-02a:
+        <dt id='dawg-delete-using-02a'>
+          <a class='testlink' href='#dawg-delete-using-02a'>
+            dawg-delete-using-02a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-02a' property='mf:name'>Simple DELETE 2 (USING)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-02a' property='mf:name'>Simple DELETE 2 (USING)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-02a' typeof='mf:UpdateEvaluationTest'>
@@ -483,10 +498,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-03:
+        <dt id='dawg-delete-using-03'>
+          <a class='testlink' href='#dawg-delete-using-03'>
+            dawg-delete-using-03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-03' property='mf:name'>Simple DELETE 3 (USING)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-03' property='mf:name'>Simple DELETE 3 (USING)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-03' typeof='mf:UpdateEvaluationTest'>
@@ -510,10 +526,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-04:
+        <dt id='dawg-delete-using-04'>
+          <a class='testlink' href='#dawg-delete-using-04'>
+            dawg-delete-using-04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-04' property='mf:name'>Simple DELETE 4 (USING)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-04' property='mf:name'>Simple DELETE 4 (USING)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-04' typeof='mf:UpdateEvaluationTest'>
@@ -537,10 +554,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-05:
+        <dt id='dawg-delete-using-05'>
+          <a class='testlink' href='#dawg-delete-using-05'>
+            dawg-delete-using-05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-05' property='mf:name'>Graph-specific DELETE 1 (USING)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-05' property='mf:name'>Graph-specific DELETE 1 (USING)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-05' typeof='mf:UpdateEvaluationTest'>
@@ -564,10 +582,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-06a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-06a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-06a:
+        <dt id='dawg-delete-using-06a'>
+          <a class='testlink' href='#dawg-delete-using-06a'>
+            dawg-delete-using-06a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-06a' property='mf:name'>Graph-specific DELETE 2 (USING)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-06a' property='mf:name'>Graph-specific DELETE 2 (USING)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/delete/manifest#dawg-delete-using-06a' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql11/drop/index.html
+++ b/sparql/sparql11/drop/index.html
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Tests for SPARQL UPDATE
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-default-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-default-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-default-01:
+        <dt id='dawg-drop-default-01'>
+          <a class='testlink' href='#dawg-drop-default-01'>
+            dawg-drop-default-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-default-01' property='mf:name'>DROP DEFAULT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-default-01' property='mf:name'>DROP DEFAULT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-default-01' typeof='mf:UpdateEvaluationTest'>
@@ -105,10 +106,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-graph-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-graph-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-graph-01:
+        <dt id='dawg-drop-graph-01'>
+          <a class='testlink' href='#dawg-drop-graph-01'>
+            dawg-drop-graph-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-graph-01' property='mf:name'>DROP GRAPH</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-graph-01' property='mf:name'>DROP GRAPH</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-graph-01' typeof='mf:UpdateEvaluationTest'>
@@ -132,10 +134,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-named-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-named-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-named-01:
+        <dt id='dawg-drop-named-01'>
+          <a class='testlink' href='#dawg-drop-named-01'>
+            dawg-drop-named-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-named-01' property='mf:name'>DROP NAMED</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-named-01' property='mf:name'>DROP NAMED</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-named-01' typeof='mf:UpdateEvaluationTest'>
@@ -159,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-all-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-all-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-all-01:
+        <dt id='dawg-drop-all-01'>
+          <a class='testlink' href='#dawg-drop-all-01'>
+            dawg-drop-all-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-all-01' property='mf:name'>DROP ALL</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-all-01' property='mf:name'>DROP ALL</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/drop/manifest#dawg-drop-all-01' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql11/entailment/index.html
+++ b/sparql/sparql11/entailment/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind01:
+        <dt id='bind01'>
+          <a class='testlink' href='#bind01'>
+            bind01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind01' property='mf:name'>bind01 - BIND fixed data for OWL DL</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind01' property='mf:name'>bind01 - BIND fixed data for OWL DL</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind01' typeof='mf:QueryEvaluationTest'>
@@ -106,10 +107,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind02:
+        <dt id='bind02'>
+          <a class='testlink' href='#bind02'>
+            bind02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind02' property='mf:name'>bind02 - BIND fixed data for OWL DL</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind02' property='mf:name'>bind02 - BIND fixed data for OWL DL</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind02' typeof='mf:QueryEvaluationTest'>
@@ -135,10 +137,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind03:
+        <dt id='bind03'>
+          <a class='testlink' href='#bind03'>
+            bind03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind03' property='mf:name'>bind03 - BIND fixed data for OWL DL</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind03' property='mf:name'>bind03 - BIND fixed data for OWL DL</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind03' typeof='mf:QueryEvaluationTest'>
@@ -164,10 +167,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind04:
+        <dt id='bind04'>
+          <a class='testlink' href='#bind04'>
+            bind04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind04' property='mf:name'>bind04 - BIND fixed data for OWL DL</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind04' property='mf:name'>bind04 - BIND fixed data for OWL DL</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind04' typeof='mf:QueryEvaluationTest'>
@@ -193,10 +197,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind05:
+        <dt id='bind05'>
+          <a class='testlink' href='#bind05'>
+            bind05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind05' property='mf:name'>bind05 - BIND fixed data for OWL DL</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind05' property='mf:name'>bind05 - BIND fixed data for OWL DL</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind05' typeof='mf:QueryEvaluationTest'>
@@ -222,10 +227,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind06:
+        <dt id='bind06'>
+          <a class='testlink' href='#bind06'>
+            bind06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind06' property='mf:name'>bind06 - BIND fixed data for OWL DL</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind06' property='mf:name'>bind06 - BIND fixed data for OWL DL</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind06' typeof='mf:QueryEvaluationTest'>
@@ -251,10 +257,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind07:
+        <dt id='bind07'>
+          <a class='testlink' href='#bind07'>
+            bind07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind07' property='mf:name'>bind07 - BIND fixed data for OWL DL</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind07' property='mf:name'>bind07 - BIND fixed data for OWL DL</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind07' typeof='mf:QueryEvaluationTest'>
@@ -280,10 +287,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind08:
+        <dt id='bind08'>
+          <a class='testlink' href='#bind08'>
+            bind08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind08' property='mf:name'>bind08 - BIND fixed data for OWL DL</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind08' property='mf:name'>bind08 - BIND fixed data for OWL DL</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#bind08' typeof='mf:QueryEvaluationTest'>
@@ -309,10 +317,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#d-ent-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#d-ent-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#d-ent-01:
+        <dt id='d-ent-01'>
+          <a class='testlink' href='#d-ent-01'>
+            d-ent-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#d-ent-01' property='mf:name'>D-Entailment test to show that  neither literals in subject position nor newly introduced surrogate blank nodes are to be returned in query answers</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#d-ent-01' property='mf:name'>D-Entailment test to show that  neither literals in subject position nor newly introduced surrogate blank nodes are to be returned in query answers</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#d-ent-01' typeof='mf:QueryEvaluationTest'>
@@ -336,10 +345,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#lang'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#lang'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#lang:
+        <dt id='lang'>
+          <a class='testlink' href='#lang'>
+            lang:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#lang' property='mf:name'>Literal with language tag test</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#lang' property='mf:name'>Literal with language tag test</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#lang' typeof='mf:QueryEvaluationTest'>
@@ -365,10 +375,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds01:
+        <dt id='owlds01'>
+          <a class='testlink' href='#owlds01'>
+            owlds01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds01' property='mf:name'>bnodes are not existentials</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds01' property='mf:name'>bnodes are not existentials</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds01' typeof='mf:QueryEvaluationTest'>
@@ -394,10 +405,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds02:
+        <dt id='owlds02'>
+          <a class='testlink' href='#owlds02'>
+            owlds02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds02' property='mf:name'>bnodes are not existentials with answer</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds02' property='mf:name'>bnodes are not existentials with answer</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#owlds02' typeof='mf:QueryEvaluationTest'>
@@ -423,10 +435,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1:
+        <dt id='paper-sparqldl-Q1'>
+          <a class='testlink' href='#paper-sparqldl-Q1'>
+            paper-sparqldl-Q1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1' property='mf:name'>paper-sparqldl-Q1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1' property='mf:name'>paper-sparqldl-Q1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1' typeof='mf:QueryEvaluationTest'>
@@ -452,10 +465,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1-rdfs'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1-rdfs'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1-rdfs:
+        <dt id='paper-sparqldl-Q1-rdfs'>
+          <a class='testlink' href='#paper-sparqldl-Q1-rdfs'>
+            paper-sparqldl-Q1-rdfs:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1-rdfs' property='mf:name'>paper-sparqldl-Q1-rdfs</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1-rdfs' property='mf:name'>paper-sparqldl-Q1-rdfs</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q1-rdfs' typeof='mf:QueryEvaluationTest'>
@@ -479,10 +493,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q2:
+        <dt id='paper-sparqldl-Q2'>
+          <a class='testlink' href='#paper-sparqldl-Q2'>
+            paper-sparqldl-Q2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q2' property='mf:name'>paper-sparqldl-Q2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q2' property='mf:name'>paper-sparqldl-Q2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q2' typeof='mf:QueryEvaluationTest'>
@@ -508,10 +523,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q3'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q3'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q3:
+        <dt id='paper-sparqldl-Q3'>
+          <a class='testlink' href='#paper-sparqldl-Q3'>
+            paper-sparqldl-Q3:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q3' property='mf:name'>paper-sparqldl-Q3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q3' property='mf:name'>paper-sparqldl-Q3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q3' typeof='mf:QueryEvaluationTest'>
@@ -537,10 +553,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q4'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q4'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q4:
+        <dt id='paper-sparqldl-Q4'>
+          <a class='testlink' href='#paper-sparqldl-Q4'>
+            paper-sparqldl-Q4:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q4' property='mf:name'>paper-sparqldl-Q4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q4' property='mf:name'>paper-sparqldl-Q4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q4' typeof='mf:QueryEvaluationTest'>
@@ -566,10 +583,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q5'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q5'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q5:
+        <dt id='paper-sparqldl-Q5'>
+          <a class='testlink' href='#paper-sparqldl-Q5'>
+            paper-sparqldl-Q5:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q5' property='mf:name'>paper-sparqldl-Q5</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q5' property='mf:name'>paper-sparqldl-Q5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#paper-sparqldl-Q5' typeof='mf:QueryEvaluationTest'>
@@ -595,10 +613,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent10'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent10'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent10:
+        <dt id='parent10'>
+          <a class='testlink' href='#parent10'>
+            parent10:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent10' property='mf:name'>filtered subclass query with (hasChild some Thing) restriction</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent10' property='mf:name'>filtered subclass query with (hasChild some Thing) restriction</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent10' typeof='mf:QueryEvaluationTest'>
@@ -624,10 +643,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent2:
+        <dt id='parent2'>
+          <a class='testlink' href='#parent2'>
+            parent2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent2' property='mf:name'>parent query with distinguished variable</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent2' property='mf:name'>parent query with distinguished variable</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent2' typeof='mf:QueryEvaluationTest'>
@@ -653,10 +673,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent3'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent3'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent3:
+        <dt id='parent3'>
+          <a class='testlink' href='#parent3'>
+            parent3:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent3' property='mf:name'>parent query with (hasChild some Thing) restriction</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent3' property='mf:name'>parent query with (hasChild some Thing) restriction</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent3' typeof='mf:QueryEvaluationTest'>
@@ -682,10 +703,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent4'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent4'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent4:
+        <dt id='parent4'>
+          <a class='testlink' href='#parent4'>
+            parent4:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent4' property='mf:name'>parent query with (hasChild min 1) restriction</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent4' property='mf:name'>parent query with (hasChild min 1) restriction</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent4' typeof='mf:QueryEvaluationTest'>
@@ -711,10 +733,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent5'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent5'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent5:
+        <dt id='parent5'>
+          <a class='testlink' href='#parent5'>
+            parent5:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent5' property='mf:name'>parent query with (hasChild some Female) restriction</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent5' property='mf:name'>parent query with (hasChild some Female) restriction</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent5' typeof='mf:QueryEvaluationTest'>
@@ -740,10 +763,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent6'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent6'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent6:
+        <dt id='parent6'>
+          <a class='testlink' href='#parent6'>
+            parent6:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent6' property='mf:name'>parent query with (hasChild min 1 Female) restriction</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent6' property='mf:name'>parent query with (hasChild min 1 Female) restriction</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent6' typeof='mf:QueryEvaluationTest'>
@@ -769,10 +793,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent7'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent7'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent7:
+        <dt id='parent7'>
+          <a class='testlink' href='#parent7'>
+            parent7:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent7' property='mf:name'>parent query with (hasChild max 1 Female) restriction</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent7' property='mf:name'>parent query with (hasChild max 1 Female) restriction</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent7' typeof='mf:QueryEvaluationTest'>
@@ -798,10 +823,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent8'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent8'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent8:
+        <dt id='parent8'>
+          <a class='testlink' href='#parent8'>
+            parent8:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent8' property='mf:name'>parent query with (hasChild exactly 1 Female) restriction</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent8' property='mf:name'>parent query with (hasChild exactly 1 Female) restriction</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent8' typeof='mf:QueryEvaluationTest'>
@@ -825,10 +851,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent9'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent9'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent9:
+        <dt id='parent9'>
+          <a class='testlink' href='#parent9'>
+            parent9:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent9' property='mf:name'>subclass query with (hasChild some Thing) restriction</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent9' property='mf:name'>subclass query with (hasChild some Thing) restriction</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#parent9' typeof='mf:QueryEvaluationTest'>
@@ -854,10 +881,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#plainLit'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#plainLit'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#plainLit:
+        <dt id='plainLit'>
+          <a class='testlink' href='#plainLit'>
+            plainLit:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#plainLit' property='mf:name'>Plain literals with language tag are not the same as the same literal without</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#plainLit' property='mf:name'>Plain literals with language tag are not the same as the same literal without</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#plainLit' typeof='mf:QueryEvaluationTest'>
@@ -883,10 +911,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf01:
+        <dt id='rdf01'>
+          <a class='testlink' href='#rdf01'>
+            rdf01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf01' property='mf:name'>RDF inference test</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf01' property='mf:name'>RDF inference test</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf01' typeof='mf:QueryEvaluationTest'>
@@ -910,10 +939,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf02:
+        <dt id='rdf02'>
+          <a class='testlink' href='#rdf02'>
+            rdf02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf02' property='mf:name'>RDF inference test</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf02' property='mf:name'>RDF inference test</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf02' typeof='mf:QueryEvaluationTest'>
@@ -937,10 +967,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf03:
+        <dt id='rdf03'>
+          <a class='testlink' href='#rdf03'>
+            rdf03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf03' property='mf:name'>RDF test for blank node cardinalities</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf03' property='mf:name'>RDF test for blank node cardinalities</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf03' typeof='mf:QueryEvaluationTest'>
@@ -964,10 +995,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf04:
+        <dt id='rdf04'>
+          <a class='testlink' href='#rdf04'>
+            rdf04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf04' property='mf:name'>simple triple pattern match</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf04' property='mf:name'>simple triple pattern match</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdf04' typeof='mf:QueryEvaluationTest'>
@@ -993,10 +1025,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs01:
+        <dt id='rdfs01'>
+          <a class='testlink' href='#rdfs01'>
+            rdfs01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs01' property='mf:name'>RDFS inference test rdfs:subPropertyOf</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs01' property='mf:name'>RDFS inference test rdfs:subPropertyOf</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs01' typeof='mf:QueryEvaluationTest'>
@@ -1022,10 +1055,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs02:
+        <dt id='rdfs02'>
+          <a class='testlink' href='#rdfs02'>
+            rdfs02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs02' property='mf:name'>RDFS inference test rdfs:subPropertyOf</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs02' property='mf:name'>RDFS inference test rdfs:subPropertyOf</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs02' typeof='mf:QueryEvaluationTest'>
@@ -1051,10 +1085,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs03:
+        <dt id='rdfs03'>
+          <a class='testlink' href='#rdfs03'>
+            rdfs03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs03' property='mf:name'>RDFS inference test combining subPropertyOf and domain</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs03' property='mf:name'>RDFS inference test combining subPropertyOf and domain</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs03' typeof='mf:QueryEvaluationTest'>
@@ -1078,10 +1113,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs04:
+        <dt id='rdfs04'>
+          <a class='testlink' href='#rdfs04'>
+            rdfs04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs04' property='mf:name'>RDFS inference test subClassOf</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs04' property='mf:name'>RDFS inference test subClassOf</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs04' typeof='mf:QueryEvaluationTest'>
@@ -1107,10 +1143,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs05:
+        <dt id='rdfs05'>
+          <a class='testlink' href='#rdfs05'>
+            rdfs05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs05' property='mf:name'>RDFS inference test subClassOf</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs05' property='mf:name'>RDFS inference test subClassOf</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs05' typeof='mf:QueryEvaluationTest'>
@@ -1136,10 +1173,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs06:
+        <dt id='rdfs06'>
+          <a class='testlink' href='#rdfs06'>
+            rdfs06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs06' property='mf:name'>RDFS inference test domain</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs06' property='mf:name'>RDFS inference test domain</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs06' typeof='mf:QueryEvaluationTest'>
@@ -1165,10 +1203,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs07:
+        <dt id='rdfs07'>
+          <a class='testlink' href='#rdfs07'>
+            rdfs07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs07' property='mf:name'>RDFS inference test range</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs07' property='mf:name'>RDFS inference test range</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs07' typeof='mf:QueryEvaluationTest'>
@@ -1194,10 +1233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs08:
+        <dt id='rdfs08'>
+          <a class='testlink' href='#rdfs08'>
+            rdfs08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs08' property='mf:name'>RDFS inference test rdf:XMLLiteral subclass of rdfs:Literal</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs08' property='mf:name'>RDFS inference test rdf:XMLLiteral subclass of rdfs:Literal</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs08' typeof='mf:QueryEvaluationTest'>
@@ -1221,10 +1261,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs09'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs09'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs09:
+        <dt id='rdfs09'>
+          <a class='testlink' href='#rdfs09'>
+            rdfs09:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs09' property='mf:name'>RDFS inference test transitivity of subClassOf</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs09' property='mf:name'>RDFS inference test transitivity of subClassOf</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs09' typeof='mf:QueryEvaluationTest'>
@@ -1250,10 +1291,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs10'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs10'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs10:
+        <dt id='rdfs10'>
+          <a class='testlink' href='#rdfs10'>
+            rdfs10:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs10' property='mf:name'>RDFS inference test transitivity of subPropertyOf</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs10' property='mf:name'>RDFS inference test transitivity of subPropertyOf</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs10' typeof='mf:QueryEvaluationTest'>
@@ -1279,10 +1321,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs11:
+        <dt id='rdfs11'>
+          <a class='testlink' href='#rdfs11'>
+            rdfs11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs11' property='mf:name'>RDFS inference test subProperty and instances</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs11' property='mf:name'>RDFS inference test subProperty and instances</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs11' typeof='mf:QueryEvaluationTest'>
@@ -1306,10 +1349,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs12'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs12'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs12:
+        <dt id='rdfs12'>
+          <a class='testlink' href='#rdfs12'>
+            rdfs12:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs12' property='mf:name'>RDFS inference test containers</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs12' property='mf:name'>RDFS inference test containers</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs12' typeof='mf:QueryEvaluationTest'>
@@ -1333,10 +1377,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs13'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs13'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs13:
+        <dt id='rdfs13'>
+          <a class='testlink' href='#rdfs13'>
+            rdfs13:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs13' property='mf:name'>RDFS inference test to show that neither literals in subject position nor newly introduced surrogate blank nodes are to be returned in query answers</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs13' property='mf:name'>RDFS inference test to show that neither literals in subject position nor newly introduced surrogate blank nodes are to be returned in query answers</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rdfs13' typeof='mf:QueryEvaluationTest'>
@@ -1362,10 +1407,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif01:
+        <dt id='rif01'>
+          <a class='testlink' href='#rif01'>
+            rif01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif01' property='mf:name'>RIF Logical Entailment (referencing RIF XML)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif01' property='mf:name'>RIF Logical Entailment (referencing RIF XML)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif01' typeof='mf:QueryEvaluationTest'>
@@ -1389,10 +1435,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif03:
+        <dt id='rif03'>
+          <a class='testlink' href='#rif03'>
+            rif03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif03' property='mf:name'>RIF Core WG tests: Frames</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif03' property='mf:name'>RIF Core WG tests: Frames</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif03' typeof='mf:QueryEvaluationTest'>
@@ -1416,10 +1463,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif04:
+        <dt id='rif04'>
+          <a class='testlink' href='#rif04'>
+            rif04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif04' property='mf:name'>RIF Core WG tests: Modeling Brain Anatomy</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif04' property='mf:name'>RIF Core WG tests: Modeling Brain Anatomy</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif04' typeof='mf:QueryEvaluationTest'>
@@ -1443,10 +1491,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif06:
+        <dt id='rif06'>
+          <a class='testlink' href='#rif06'>
+            rif06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif06' property='mf:name'>RIF Core WG tests: RDF Combination Blank Node</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif06' property='mf:name'>RIF Core WG tests: RDF Combination Blank Node</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#rif06' typeof='mf:QueryEvaluationTest'>
@@ -1470,10 +1519,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple1:
+        <dt id='simple1'>
+          <a class='testlink' href='#simple1'>
+            simple1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple1' property='mf:name'>simple 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple1' property='mf:name'>simple 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple1' typeof='mf:QueryEvaluationTest'>
@@ -1499,10 +1549,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple2:
+        <dt id='simple2'>
+          <a class='testlink' href='#simple2'>
+            simple2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple2' property='mf:name'>simple 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple2' property='mf:name'>simple 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple2' typeof='mf:QueryEvaluationTest'>
@@ -1528,10 +1579,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple3'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple3'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple3:
+        <dt id='simple3'>
+          <a class='testlink' href='#simple3'>
+            simple3:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple3' property='mf:name'>simple 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple3' property='mf:name'>simple 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple3' typeof='mf:QueryEvaluationTest'>
@@ -1557,10 +1609,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple4'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple4'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple4:
+        <dt id='simple4'>
+          <a class='testlink' href='#simple4'>
+            simple4:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple4' property='mf:name'>simple 4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple4' property='mf:name'>simple 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple4' typeof='mf:QueryEvaluationTest'>
@@ -1586,10 +1639,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple5'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple5'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple5:
+        <dt id='simple5'>
+          <a class='testlink' href='#simple5'>
+            simple5:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple5' property='mf:name'>simple 5</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple5' property='mf:name'>simple 5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple5' typeof='mf:QueryEvaluationTest'>
@@ -1615,10 +1669,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple6'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple6'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple6:
+        <dt id='simple6'>
+          <a class='testlink' href='#simple6'>
+            simple6:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple6' property='mf:name'>simple 6</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple6' property='mf:name'>simple 6</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple6' typeof='mf:QueryEvaluationTest'>
@@ -1644,10 +1699,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple7'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple7'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple7:
+        <dt id='simple7'>
+          <a class='testlink' href='#simple7'>
+            simple7:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple7' property='mf:name'>simple 7</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple7' property='mf:name'>simple 7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple7' typeof='mf:QueryEvaluationTest'>
@@ -1673,10 +1729,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple8'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple8'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple8:
+        <dt id='simple8'>
+          <a class='testlink' href='#simple8'>
+            simple8:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple8' property='mf:name'>simple 8</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple8' property='mf:name'>simple 8</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#simple8' typeof='mf:QueryEvaluationTest'>
@@ -1702,10 +1759,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-01:
+        <dt id='sparqldl-01'>
+          <a class='testlink' href='#sparqldl-01'>
+            sparqldl-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-01' property='mf:name'>sparqldl-01.rq: triple pattern</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-01' property='mf:name'>sparqldl-01.rq: triple pattern</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-01' typeof='mf:QueryEvaluationTest'>
@@ -1731,10 +1789,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-02:
+        <dt id='sparqldl-02'>
+          <a class='testlink' href='#sparqldl-02'>
+            sparqldl-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-02' property='mf:name'>sparqldl-02.rq: simple combined query</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-02' property='mf:name'>sparqldl-02.rq: simple combined query</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-02' typeof='mf:QueryEvaluationTest'>
@@ -1760,10 +1819,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-03:
+        <dt id='sparqldl-03'>
+          <a class='testlink' href='#sparqldl-03'>
+            sparqldl-03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-03' property='mf:name'>sparqldl-03.rq: combined query with complex class description</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-03' property='mf:name'>sparqldl-03.rq: combined query with complex class description</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-03' typeof='mf:QueryEvaluationTest'>
@@ -1789,10 +1849,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-04:
+        <dt id='sparqldl-04'>
+          <a class='testlink' href='#sparqldl-04'>
+            sparqldl-04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-04' property='mf:name'>sparqldl-04.rq: bug fixing test</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-04' property='mf:name'>sparqldl-04.rq: bug fixing test</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-04' typeof='mf:QueryEvaluationTest'>
@@ -1818,10 +1879,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-05:
+        <dt id='sparqldl-05'>
+          <a class='testlink' href='#sparqldl-05'>
+            sparqldl-05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-05' property='mf:name'>sparqldl-05.rq: simple undistinguished variable test.</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-05' property='mf:name'>sparqldl-05.rq: simple undistinguished variable test.</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-05' typeof='mf:QueryEvaluationTest'>
@@ -1847,10 +1909,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-06:
+        <dt id='sparqldl-06'>
+          <a class='testlink' href='#sparqldl-06'>
+            sparqldl-06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-06' property='mf:name'>sparqldl-06.rq: cycle of undistinguished variables</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-06' property='mf:name'>sparqldl-06.rq: cycle of undistinguished variables</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-06' typeof='mf:QueryEvaluationTest'>
@@ -1876,10 +1939,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-07:
+        <dt id='sparqldl-07'>
+          <a class='testlink' href='#sparqldl-07'>
+            sparqldl-07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-07' property='mf:name'>sparqldl-07.rq: two distinguished variables + undist.</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-07' property='mf:name'>sparqldl-07.rq: two distinguished variables + undist.</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-07' typeof='mf:QueryEvaluationTest'>
@@ -1905,10 +1969,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-08:
+        <dt id='sparqldl-08'>
+          <a class='testlink' href='#sparqldl-08'>
+            sparqldl-08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-08' property='mf:name'>sparqldl-08.rq: two distinguished variables + undist.</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-08' property='mf:name'>sparqldl-08.rq: two distinguished variables + undist.</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-08' typeof='mf:QueryEvaluationTest'>
@@ -1934,10 +1999,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-09'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-09'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-09:
+        <dt id='sparqldl-09'>
+          <a class='testlink' href='#sparqldl-09'>
+            sparqldl-09:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-09' property='mf:name'>sparqldl-09.rq: undist vars test</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-09' property='mf:name'>sparqldl-09.rq: undist vars test</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-09' typeof='mf:QueryEvaluationTest'>
@@ -1963,10 +2029,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-10'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-10'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-10:
+        <dt id='sparqldl-10'>
+          <a class='testlink' href='#sparqldl-10'>
+            sparqldl-10:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-10' property='mf:name'>sparqldl-10.rq: undist vars test</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-10' property='mf:name'>sparqldl-10.rq: undist vars test</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-10' typeof='mf:QueryEvaluationTest'>
@@ -1992,10 +2059,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-11:
+        <dt id='sparqldl-11'>
+          <a class='testlink' href='#sparqldl-11'>
+            sparqldl-11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-11' property='mf:name'>sparqldl-11.rq: domain test</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-11' property='mf:name'>sparqldl-11.rq: domain test</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-11' typeof='mf:QueryEvaluationTest'>
@@ -2021,10 +2089,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-12'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-12'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-12:
+        <dt id='sparqldl-12'>
+          <a class='testlink' href='#sparqldl-12'>
+            sparqldl-12:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-12' property='mf:name'>sparqldl-12.rq: range test</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-12' property='mf:name'>sparqldl-12.rq: range test</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-12' typeof='mf:QueryEvaluationTest'>
@@ -2050,10 +2119,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-13'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-13'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-13:
+        <dt id='sparqldl-13'>
+          <a class='testlink' href='#sparqldl-13'>
+            sparqldl-13:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-13' property='mf:name'>sparqldl-13.rq: sameAs</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-13' property='mf:name'>sparqldl-13.rq: sameAs</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/entailment/manifest#sparqldl-13' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/exists/index.html
+++ b/sparql/sparql11/exists/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists01:
+        <dt id='exists01'>
+          <a class='testlink' href='#exists01'>
+            exists01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists01' property='mf:name'>Exists with one constant</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists01' property='mf:name'>Exists with one constant</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists01' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists02:
+        <dt id='exists02'>
+          <a class='testlink' href='#exists02'>
+            exists02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists02' property='mf:name'>Exists with ground triple</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists02' property='mf:name'>Exists with ground triple</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists02' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists03:
+        <dt id='exists03'>
+          <a class='testlink' href='#exists03'>
+            exists03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists03' property='mf:name'>Exists within graph pattern</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists03' property='mf:name'>Exists within graph pattern</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists03' typeof='mf:QueryEvaluationTest'>
@@ -153,10 +156,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists04:
+        <dt id='exists04'>
+          <a class='testlink' href='#exists04'>
+            exists04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists04' property='mf:name'>Nested positive exists</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists04' property='mf:name'>Nested positive exists</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists04' typeof='mf:QueryEvaluationTest'>
@@ -178,10 +182,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists05:
+        <dt id='exists05'>
+          <a class='testlink' href='#exists05'>
+            exists05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists05' property='mf:name'>Nested negative exists in positive exists</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists05' property='mf:name'>Nested negative exists in positive exists</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/exists/manifest#exists05' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/functions/index.html
+++ b/sparql/sparql11/functions/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt01:
+        <dt id='strdt01'>
+          <a class='testlink' href='#strdt01'>
+            strdt01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt01' property='mf:name'>STRDT()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt01' property='mf:name'>STRDT()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt01' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt02:
+        <dt id='strdt02'>
+          <a class='testlink' href='#strdt02'>
+            strdt02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt02' property='mf:name'>STRDT(STR())</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt02' property='mf:name'>STRDT(STR())</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt02' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt03-rdf11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt03-rdf11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt03-rdf11:
+        <dt id='strdt03-rdf11'>
+          <a class='testlink' href='#strdt03-rdf11'>
+            strdt03-rdf11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt03-rdf11' property='mf:name'>STRDT() TypeErrors (updated for RDF 1.1)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt03-rdf11' property='mf:name'>STRDT() TypeErrors (updated for RDF 1.1)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strdt03-rdf11' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang01:
+        <dt id='strlang01'>
+          <a class='testlink' href='#strlang01'>
+            strlang01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang01' property='mf:name'>STRLANG()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang01' property='mf:name'>STRLANG()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang01' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang02:
+        <dt id='strlang02'>
+          <a class='testlink' href='#strlang02'>
+            strlang02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang02' property='mf:name'>STRLANG(STR())</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang02' property='mf:name'>STRLANG(STR())</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang02' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang03-rdf11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang03-rdf11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang03-rdf11:
+        <dt id='strlang03-rdf11'>
+          <a class='testlink' href='#strlang03-rdf11'>
+            strlang03-rdf11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang03-rdf11' property='mf:name'>STRLANG() TypeErrors (updated for RDF 1.1)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang03-rdf11' property='mf:name'>STRLANG() TypeErrors (updated for RDF 1.1)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strlang03-rdf11' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#isnumeric01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#isnumeric01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#isnumeric01:
+        <dt id='isnumeric01'>
+          <a class='testlink' href='#isnumeric01'>
+            isnumeric01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#isnumeric01' property='mf:name'>isNumeric()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#isnumeric01' property='mf:name'>isNumeric()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#isnumeric01' typeof='mf:QueryEvaluationTest'>
@@ -252,10 +259,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#abs01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#abs01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#abs01:
+        <dt id='abs01'>
+          <a class='testlink' href='#abs01'>
+            abs01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#abs01' property='mf:name'>ABS()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#abs01' property='mf:name'>ABS()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#abs01' typeof='mf:QueryEvaluationTest'>
@@ -277,10 +285,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ceil01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ceil01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ceil01:
+        <dt id='ceil01'>
+          <a class='testlink' href='#ceil01'>
+            ceil01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ceil01' property='mf:name'>CEIL()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ceil01' property='mf:name'>CEIL()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ceil01' typeof='mf:QueryEvaluationTest'>
@@ -302,10 +311,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#floor01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#floor01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#floor01:
+        <dt id='floor01'>
+          <a class='testlink' href='#floor01'>
+            floor01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#floor01' property='mf:name'>FLOOR()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#floor01' property='mf:name'>FLOOR()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#floor01' typeof='mf:QueryEvaluationTest'>
@@ -327,10 +337,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#round01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#round01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#round01:
+        <dt id='round01'>
+          <a class='testlink' href='#round01'>
+            round01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#round01' property='mf:name'>ROUND()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#round01' property='mf:name'>ROUND()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#round01' typeof='mf:QueryEvaluationTest'>
@@ -352,10 +363,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat01:
+        <dt id='concat01'>
+          <a class='testlink' href='#concat01'>
+            concat01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat01' property='mf:name'>CONCAT()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat01' property='mf:name'>CONCAT()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat01' typeof='mf:QueryEvaluationTest'>
@@ -377,10 +389,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat02:
+        <dt id='concat02'>
+          <a class='testlink' href='#concat02'>
+            concat02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat02' property='mf:name'>CONCAT() 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat02' property='mf:name'>CONCAT() 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat02' typeof='mf:QueryEvaluationTest'>
@@ -402,10 +415,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-empty'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-empty'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-empty:
+        <dt id='concat-empty'>
+          <a class='testlink' href='#concat-empty'>
+            concat-empty:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-empty' property='mf:name'>CONCAT() without parameter</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-empty' property='mf:name'>CONCAT() without parameter</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-empty' typeof='mf:QueryEvaluationTest'>
@@ -427,10 +441,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-single'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-single'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-single:
+        <dt id='concat-single'>
+          <a class='testlink' href='#concat-single'>
+            concat-single:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-single' property='mf:name'>CONCAT() with a single parameter</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-single' property='mf:name'>CONCAT() with a single parameter</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#concat-single' typeof='mf:QueryEvaluationTest'>
@@ -452,10 +467,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01:
+        <dt id='substring01'>
+          <a class='testlink' href='#substring01'>
+            substring01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01' property='mf:name'>SUBSTR() (3-argument)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01' property='mf:name'>SUBSTR() (3-argument)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01' typeof='mf:QueryEvaluationTest'>
@@ -477,10 +493,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01-non-bmp'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01-non-bmp'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01-non-bmp:
+        <dt id='substring01-non-bmp'>
+          <a class='testlink' href='#substring01-non-bmp'>
+            substring01-non-bmp:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01-non-bmp' property='mf:name'>SUBSTR() (3-argument) on non-BMP unicode strings</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01-non-bmp' property='mf:name'>SUBSTR() (3-argument) on non-BMP unicode strings</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring01-non-bmp' typeof='mf:QueryEvaluationTest'>
@@ -502,10 +519,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02:
+        <dt id='substring02'>
+          <a class='testlink' href='#substring02'>
+            substring02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02' property='mf:name'>SUBSTR() (2-argument)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02' property='mf:name'>SUBSTR() (2-argument)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02' typeof='mf:QueryEvaluationTest'>
@@ -527,10 +545,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02-non-bmp'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02-non-bmp'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02-non-bmp:
+        <dt id='substring02-non-bmp'>
+          <a class='testlink' href='#substring02-non-bmp'>
+            substring02-non-bmp:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02-non-bmp' property='mf:name'>SUBSTR() (2-argument) on non-BMP unicode strings</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02-non-bmp' property='mf:name'>SUBSTR() (2-argument) on non-BMP unicode strings</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#substring02-non-bmp' typeof='mf:QueryEvaluationTest'>
@@ -552,10 +571,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01:
+        <dt id='length01'>
+          <a class='testlink' href='#length01'>
+            length01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01' property='mf:name'>STRLEN()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01' property='mf:name'>STRLEN()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01' typeof='mf:QueryEvaluationTest'>
@@ -577,10 +597,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01-non-bmp'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01-non-bmp'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01-non-bmp:
+        <dt id='length01-non-bmp'>
+          <a class='testlink' href='#length01-non-bmp'>
+            length01-non-bmp:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01-non-bmp' property='mf:name'>STRLEN() on non-BMP unicode strings</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01-non-bmp' property='mf:name'>STRLEN() on non-BMP unicode strings</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#length01-non-bmp' typeof='mf:QueryEvaluationTest'>
@@ -602,10 +623,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01:
+        <dt id='ucase01'>
+          <a class='testlink' href='#ucase01'>
+            ucase01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01' property='mf:name'>UCASE()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01' property='mf:name'>UCASE()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01' typeof='mf:QueryEvaluationTest'>
@@ -627,10 +649,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01-non-bmp'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01-non-bmp'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01-non-bmp:
+        <dt id='ucase01-non-bmp'>
+          <a class='testlink' href='#ucase01-non-bmp'>
+            ucase01-non-bmp:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01-non-bmp' property='mf:name'>UCASE() on non-BMP unicode strings</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01-non-bmp' property='mf:name'>UCASE() on non-BMP unicode strings</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ucase01-non-bmp' typeof='mf:QueryEvaluationTest'>
@@ -652,10 +675,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01:
+        <dt id='lcase01'>
+          <a class='testlink' href='#lcase01'>
+            lcase01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01' property='mf:name'>LCASE()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01' property='mf:name'>LCASE()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01' typeof='mf:QueryEvaluationTest'>
@@ -677,10 +701,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01-non-bmp'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01-non-bmp'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01-non-bmp:
+        <dt id='lcase01-non-bmp'>
+          <a class='testlink' href='#lcase01-non-bmp'>
+            lcase01-non-bmp:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01-non-bmp' property='mf:name'>LCASE() on non-BMP unicode strings</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01-non-bmp' property='mf:name'>LCASE() on non-BMP unicode strings</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#lcase01-non-bmp' typeof='mf:QueryEvaluationTest'>
@@ -702,10 +727,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01:
+        <dt id='encode01'>
+          <a class='testlink' href='#encode01'>
+            encode01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01' property='mf:name'>ENCODE_FOR_URI()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01' property='mf:name'>ENCODE_FOR_URI()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01' typeof='mf:QueryEvaluationTest'>
@@ -727,10 +753,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01-non-bmp'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01-non-bmp'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01-non-bmp:
+        <dt id='encode01-non-bmp'>
+          <a class='testlink' href='#encode01-non-bmp'>
+            encode01-non-bmp:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01-non-bmp' property='mf:name'>ENCODE_FOR_URI() on non-BMP unicode strings</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01-non-bmp' property='mf:name'>ENCODE_FOR_URI() on non-BMP unicode strings</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#encode01-non-bmp' typeof='mf:QueryEvaluationTest'>
@@ -752,10 +779,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#contains01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#contains01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#contains01:
+        <dt id='contains01'>
+          <a class='testlink' href='#contains01'>
+            contains01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#contains01' property='mf:name'>CONTAINS()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#contains01' property='mf:name'>CONTAINS()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#contains01' typeof='mf:QueryEvaluationTest'>
@@ -777,10 +805,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#starts01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#starts01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#starts01:
+        <dt id='starts01'>
+          <a class='testlink' href='#starts01'>
+            starts01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#starts01' property='mf:name'>STRSTARTS()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#starts01' property='mf:name'>STRSTARTS()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#starts01' typeof='mf:QueryEvaluationTest'>
@@ -802,10 +831,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ends01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ends01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ends01:
+        <dt id='ends01'>
+          <a class='testlink' href='#ends01'>
+            ends01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ends01' property='mf:name'>STRENDS()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ends01' property='mf:name'>STRENDS()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#ends01' typeof='mf:QueryEvaluationTest'>
@@ -827,10 +857,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-1-corrected'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-1-corrected'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-1-corrected:
+        <dt id='plus-1-corrected'>
+          <a class='testlink' href='#plus-1-corrected'>
+            plus-1-corrected:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-1-corrected' property='mf:name'>plus-1-corrected</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-1-corrected' property='mf:name'>plus-1-corrected</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-1-corrected' typeof='mf:QueryEvaluationTest'>
@@ -853,10 +884,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-2-corrected'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-2-corrected'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-2-corrected:
+        <dt id='plus-2-corrected'>
+          <a class='testlink' href='#plus-2-corrected'>
+            plus-2-corrected:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-2-corrected' property='mf:name'>plus-2-corrected</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-2-corrected' property='mf:name'>plus-2-corrected</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#plus-2-corrected' typeof='mf:QueryEvaluationTest'>
@@ -879,10 +911,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-01:
+        <dt id='md5-01'>
+          <a class='testlink' href='#md5-01'>
+            md5-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-01' property='mf:name'>MD5()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-01' property='mf:name'>MD5()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-01' typeof='mf:QueryEvaluationTest'>
@@ -904,10 +937,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-02:
+        <dt id='md5-02'>
+          <a class='testlink' href='#md5-02'>
+            md5-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-02' property='mf:name'>MD5() over Unicode data</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-02' property='mf:name'>MD5() over Unicode data</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#md5-02' typeof='mf:QueryEvaluationTest'>
@@ -929,10 +963,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-01:
+        <dt id='sha1-01'>
+          <a class='testlink' href='#sha1-01'>
+            sha1-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-01' property='mf:name'>SHA1()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-01' property='mf:name'>SHA1()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-01' typeof='mf:QueryEvaluationTest'>
@@ -954,10 +989,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-02:
+        <dt id='sha1-02'>
+          <a class='testlink' href='#sha1-02'>
+            sha1-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-02' property='mf:name'>SHA1() on Unicode data</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-02' property='mf:name'>SHA1() on Unicode data</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha1-02' typeof='mf:QueryEvaluationTest'>
@@ -979,10 +1015,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-01:
+        <dt id='sha256-01'>
+          <a class='testlink' href='#sha256-01'>
+            sha256-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-01' property='mf:name'>SHA256()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-01' property='mf:name'>SHA256()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-01' typeof='mf:QueryEvaluationTest'>
@@ -1004,10 +1041,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-02:
+        <dt id='sha256-02'>
+          <a class='testlink' href='#sha256-02'>
+            sha256-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-02' property='mf:name'>SHA256() on Unicode data</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-02' property='mf:name'>SHA256() on Unicode data</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha256-02' typeof='mf:QueryEvaluationTest'>
@@ -1029,10 +1067,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-01:
+        <dt id='sha512-01'>
+          <a class='testlink' href='#sha512-01'>
+            sha512-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-01' property='mf:name'>SHA512()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-01' property='mf:name'>SHA512()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-01' typeof='mf:QueryEvaluationTest'>
@@ -1054,10 +1093,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-02:
+        <dt id='sha512-02'>
+          <a class='testlink' href='#sha512-02'>
+            sha512-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-02' property='mf:name'>SHA512() on Unicode data</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-02' property='mf:name'>SHA512() on Unicode data</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#sha512-02' typeof='mf:QueryEvaluationTest'>
@@ -1079,10 +1119,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#minutes'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#minutes'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#minutes:
+        <dt id='minutes'>
+          <a class='testlink' href='#minutes'>
+            minutes:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#minutes' property='mf:name'>MINUTES()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#minutes' property='mf:name'>MINUTES()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#minutes' typeof='mf:QueryEvaluationTest'>
@@ -1104,10 +1145,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#seconds'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#seconds'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#seconds:
+        <dt id='seconds'>
+          <a class='testlink' href='#seconds'>
+            seconds:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#seconds' property='mf:name'>SECONDS()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#seconds' property='mf:name'>SECONDS()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#seconds' typeof='mf:QueryEvaluationTest'>
@@ -1129,10 +1171,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#hours'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#hours'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#hours:
+        <dt id='hours'>
+          <a class='testlink' href='#hours'>
+            hours:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#hours' property='mf:name'>HOURS()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#hours' property='mf:name'>HOURS()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#hours' typeof='mf:QueryEvaluationTest'>
@@ -1154,10 +1197,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#month'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#month'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#month:
+        <dt id='month'>
+          <a class='testlink' href='#month'>
+            month:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#month' property='mf:name'>MONTH()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#month' property='mf:name'>MONTH()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#month' typeof='mf:QueryEvaluationTest'>
@@ -1179,10 +1223,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#year'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#year'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#year:
+        <dt id='year'>
+          <a class='testlink' href='#year'>
+            year:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#year' property='mf:name'>YEAR()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#year' property='mf:name'>YEAR()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#year' typeof='mf:QueryEvaluationTest'>
@@ -1204,10 +1249,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#day'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#day'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#day:
+        <dt id='day'>
+          <a class='testlink' href='#day'>
+            day:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#day' property='mf:name'>DAY()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#day' property='mf:name'>DAY()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#day' typeof='mf:QueryEvaluationTest'>
@@ -1229,10 +1275,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#timezone'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#timezone'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#timezone:
+        <dt id='timezone'>
+          <a class='testlink' href='#timezone'>
+            timezone:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#timezone' property='mf:name'>TIMEZONE()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#timezone' property='mf:name'>TIMEZONE()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#timezone' typeof='mf:QueryEvaluationTest'>
@@ -1254,10 +1301,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#tz'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#tz'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#tz:
+        <dt id='tz'>
+          <a class='testlink' href='#tz'>
+            tz:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#tz' property='mf:name'>TZ()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#tz' property='mf:name'>TZ()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#tz' typeof='mf:QueryEvaluationTest'>
@@ -1279,10 +1327,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode01:
+        <dt id='bnode01'>
+          <a class='testlink' href='#bnode01'>
+            bnode01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode01' property='mf:name'>BNODE(str)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode01' property='mf:name'>BNODE(str)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode01' typeof='mf:QueryEvaluationTest'>
@@ -1304,10 +1353,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode02:
+        <dt id='bnode02'>
+          <a class='testlink' href='#bnode02'>
+            bnode02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode02' property='mf:name'>BNODE()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode02' property='mf:name'>BNODE()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#bnode02' typeof='mf:QueryEvaluationTest'>
@@ -1329,10 +1379,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in01:
+        <dt id='in01'>
+          <a class='testlink' href='#in01'>
+            in01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in01' property='mf:name'>IN 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in01' property='mf:name'>IN 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in01' typeof='mf:QueryEvaluationTest'>
@@ -1354,10 +1405,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in02:
+        <dt id='in02'>
+          <a class='testlink' href='#in02'>
+            in02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in02' property='mf:name'>IN 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in02' property='mf:name'>IN 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#in02' typeof='mf:QueryEvaluationTest'>
@@ -1379,10 +1431,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin01:
+        <dt id='notin01'>
+          <a class='testlink' href='#notin01'>
+            notin01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin01' property='mf:name'>NOT IN 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin01' property='mf:name'>NOT IN 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin01' typeof='mf:QueryEvaluationTest'>
@@ -1404,10 +1457,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin02:
+        <dt id='notin02'>
+          <a class='testlink' href='#notin02'>
+            notin02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin02' property='mf:name'>NOT IN 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin02' property='mf:name'>NOT IN 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#notin02' typeof='mf:QueryEvaluationTest'>
@@ -1429,10 +1483,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#now01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#now01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#now01:
+        <dt id='now01'>
+          <a class='testlink' href='#now01'>
+            now01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#now01' property='mf:name'>NOW()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#now01' property='mf:name'>NOW()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#now01' typeof='mf:QueryEvaluationTest'>
@@ -1454,10 +1509,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#rand01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#rand01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#rand01:
+        <dt id='rand01'>
+          <a class='testlink' href='#rand01'>
+            rand01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#rand01' property='mf:name'>RAND()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#rand01' property='mf:name'>RAND()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#rand01' typeof='mf:QueryEvaluationTest'>
@@ -1479,10 +1535,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#iri01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#iri01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#iri01:
+        <dt id='iri01'>
+          <a class='testlink' href='#iri01'>
+            iri01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#iri01' property='mf:name'>IRI()/URI()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#iri01' property='mf:name'>IRI()/URI()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#iri01' typeof='mf:QueryEvaluationTest'>
@@ -1504,10 +1561,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if01:
+        <dt id='if01'>
+          <a class='testlink' href='#if01'>
+            if01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if01' property='mf:name'>IF()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if01' property='mf:name'>IF()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if01' typeof='mf:QueryEvaluationTest'>
@@ -1529,10 +1587,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if02:
+        <dt id='if02'>
+          <a class='testlink' href='#if02'>
+            if02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if02' property='mf:name'>IF() error propogation</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if02' property='mf:name'>IF() error propogation</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#if02' typeof='mf:QueryEvaluationTest'>
@@ -1554,10 +1613,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#coalesce01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#coalesce01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#coalesce01:
+        <dt id='coalesce01'>
+          <a class='testlink' href='#coalesce01'>
+            coalesce01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#coalesce01' property='mf:name'>COALESCE()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#coalesce01' property='mf:name'>COALESCE()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#coalesce01' typeof='mf:QueryEvaluationTest'>
@@ -1579,10 +1639,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore01a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore01a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore01a:
+        <dt id='strbefore01a'>
+          <a class='testlink' href='#strbefore01a'>
+            strbefore01a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore01a' property='mf:name'>STRBEFORE()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore01a' property='mf:name'>STRBEFORE()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore01a' typeof='mf:QueryEvaluationTest'>
@@ -1604,10 +1665,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore02:
+        <dt id='strbefore02'>
+          <a class='testlink' href='#strbefore02'>
+            strbefore02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore02' property='mf:name'>STRBEFORE() datatyping</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore02' property='mf:name'>STRBEFORE() datatyping</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strbefore02' typeof='mf:QueryEvaluationTest'>
@@ -1629,10 +1691,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter01a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter01a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter01a:
+        <dt id='strafter01a'>
+          <a class='testlink' href='#strafter01a'>
+            strafter01a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter01a' property='mf:name'>STRAFTER()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter01a' property='mf:name'>STRAFTER()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter01a' typeof='mf:QueryEvaluationTest'>
@@ -1654,10 +1717,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter02:
+        <dt id='strafter02'>
+          <a class='testlink' href='#strafter02'>
+            strafter02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter02' property='mf:name'>STRAFTER() datatyping</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter02' property='mf:name'>STRAFTER() datatyping</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#strafter02' typeof='mf:QueryEvaluationTest'>
@@ -1679,10 +1743,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace01:
+        <dt id='replace01'>
+          <a class='testlink' href='#replace01'>
+            replace01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace01' property='mf:name'>REPLACE()</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace01' property='mf:name'>REPLACE()</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace01' typeof='mf:QueryEvaluationTest'>
@@ -1704,10 +1769,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace02:
+        <dt id='replace02'>
+          <a class='testlink' href='#replace02'>
+            replace02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace02' property='mf:name'>REPLACE() with overlapping pattern</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace02' property='mf:name'>REPLACE() with overlapping pattern</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace02' typeof='mf:QueryEvaluationTest'>
@@ -1729,10 +1795,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace03:
+        <dt id='replace03'>
+          <a class='testlink' href='#replace03'>
+            replace03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace03' property='mf:name'>REPLACE() with captured substring</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace03' property='mf:name'>REPLACE() with captured substring</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#replace03' typeof='mf:QueryEvaluationTest'>
@@ -1754,10 +1821,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid01:
+        <dt id='uuid01'>
+          <a class='testlink' href='#uuid01'>
+            uuid01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid01' property='mf:name'>UUID() pattern match</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid01' property='mf:name'>UUID() pattern match</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid01' typeof='mf:QueryEvaluationTest'>
@@ -1779,10 +1847,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid02:
+        <dt id='uuid02'>
+          <a class='testlink' href='#uuid02'>
+            uuid02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid02' property='mf:name'>UUID() per binding</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid02' property='mf:name'>UUID() per binding</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#uuid02' typeof='mf:QueryEvaluationTest'>
@@ -1805,10 +1874,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#struuid01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#struuid01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#struuid01:
+        <dt id='struuid01'>
+          <a class='testlink' href='#struuid01'>
+            struuid01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#struuid01' property='mf:name'>STRUUID() pattern match</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#struuid01' property='mf:name'>STRUUID() pattern match</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#struuid01' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/grouping/index.html
+++ b/sparql/sparql11/grouping/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group01:
+        <dt id='group01'>
+          <a class='testlink' href='#group01'>
+            group01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group01' property='mf:name'>Group-1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group01' property='mf:name'>Group-1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group01' typeof='mf:QueryEvaluationTest'>
@@ -103,10 +104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group03:
+        <dt id='group03'>
+          <a class='testlink' href='#group03'>
+            group03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group03' property='mf:name'>Group-3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group03' property='mf:name'>Group-3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group03' typeof='mf:QueryEvaluationTest'>
@@ -129,10 +131,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group04:
+        <dt id='group04'>
+          <a class='testlink' href='#group04'>
+            group04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group04' property='mf:name'>Group-4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group04' property='mf:name'>Group-4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group04' typeof='mf:QueryEvaluationTest'>
@@ -155,10 +158,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group05:
+        <dt id='group05'>
+          <a class='testlink' href='#group05'>
+            group05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group05' property='mf:name'>Group-5</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group05' property='mf:name'>Group-5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group05' typeof='mf:QueryEvaluationTest'>
@@ -181,10 +185,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group06:
+        <dt id='group06'>
+          <a class='testlink' href='#group06'>
+            group06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group06' property='mf:name'>Group-6</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group06' property='mf:name'>Group-6</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group06' typeof='mf:NegativeSyntaxTest11'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group07:
+        <dt id='group07'>
+          <a class='testlink' href='#group07'>
+            group07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group07' property='mf:name'>Group-7</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group07' property='mf:name'>Group-7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#group07' typeof='mf:NegativeSyntaxTest11'>

--- a/sparql/sparql11/http-rdf-update/index.html
+++ b/sparql/sparql11/http-rdf-update/index.html
@@ -33,7 +33,7 @@
       SPARQL Graph Store Protocol
     </title>
     <style>
-      em.rfc2119 { 
+      em.rfc2119 {
         text-transform: lowercase;
         font-variant:   small-caps;
         font-style:     normal;
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -62,31 +62,23 @@
     <div>
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
-        
       </p>
-      <p>This page describes W3C SPARQL Working Group&#39;s SPARQL1.0 test suite.</p>
-      
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
       <p><strong>$HOST$</strong> is the host where the Graph Store Protocol implementation is listening</p>
-      
       <p><strong>$GRAPHSTORE$</strong> is the path of the URL of the graph store</p>
-      
       <p><strong>$NEWPATH$</strong> is the URL returned in the Location HTTP header</p>
-      
       <p>HTTP response messages are in the format:</p>
-      
-      <pre><code>HTTP Status code&#x000A;Headers&#x000A;&lt;space&gt;&#x000A;Body                    &#x000A;</code></pre>
-      
-      <h3>Contributing Tests</h3>
-      
+      <pre><code>HTTP Status code
+Headers
+&lt;space&gt;
+Body                    
+</code></pre>
+      <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
-      
-      <h3>Distribution</h3>
-      
+      <h3 id="distribution">Distribution</h3>
       <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
-      
-      <h3>Disclaimer</h3>
-      
-      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+      <h3 id="disclaimer">Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
         COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
     </div>
     <div>
@@ -94,20 +86,30 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__initial_state'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__initial_state'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__initial_state:
+        <dt id='put__initial_state'>
+          <a class='testlink' href='#put__initial_state'>
+            put__initial_state:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__initial_state' property='mf:name'>PUT - Initial state</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__initial_state' property='mf:name'>PUT - Initial state</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__initial_state' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__initial_state' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .&#x000A;&#x000A;&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;&#x000A;    foaf:businessCard [&#x000A;        a v:VCard;&#x000A;        v:fn &quot;John Doe&quot;&#x000A;    ].&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
+            <h4 id="request">Request</h4>
+            <pre><code>PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1
+Host: $HOST$
+Content-Type: text/turtle; charset=utf-8
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;
+    foaf:businessCard [
+        a v:VCard;
+        v:fn "John Doe"
+    ].
+</code></pre>
+            <h4 id="response">Response</h4>
             <p><code>201 Created</code></p>
           </div>
           <dl class='test-detail'>
@@ -121,21 +123,31 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__initial_state'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__initial_state'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__initial_state:
+        <dt id='get_of_put__initial_state'>
+          <a class='testlink' href='#get_of_put__initial_state'>
+            get_of_put__initial_state:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__initial_state' property='mf:name'>GET of PUT - Initial state</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__initial_state' property='mf:name'>GET of PUT - Initial state</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__initial_state' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__initial_state' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>GET $GRAPHSTORE$?graph=$GRAPHSTORE$/person/1.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;Accept: text/turtle&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>200 OK&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;Content-Length: ...&#x000A;&#x000A;&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;&#x000A;   foaf:businessCard [&#x000A;        a v:VCard;&#x000A;        v:fn &quot;John Doe&quot;&#x000A;   ].&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>GET $GRAPHSTORE$?graph=$GRAPHSTORE$/person/1.ttl HTTP/1.1
+Host: $HOST$
+Accept: text/turtle
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+Content-Type: text/turtle; charset=utf-8
+Content-Length: ...
+
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;
+   foaf:businessCard [
+        a v:VCard;
+        v:fn "John Doe"
+   ].
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -148,21 +160,32 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__graph_already_in_store'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__graph_already_in_store'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__graph_already_in_store:
+        <dt id='put__graph_already_in_store'>
+          <a class='testlink' href='#put__graph_already_in_store'>
+            put__graph_already_in_store:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__graph_already_in_store' property='mf:name'>PUT - graph already in store</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__graph_already_in_store' property='mf:name'>PUT - graph already in store</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__graph_already_in_store' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__graph_already_in_store' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .&#x000A;&#x000A;&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;&#x000A;    foaf:businessCard [&#x000A;        a v:VCard;&#x000A;        v:fn &quot;Jane Doe&quot;&#x000A;    ].&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>204 No Content&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1
+Host: $HOST$
+Content-Type: text/turtle; charset=utf-8
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;
+    foaf:businessCard [
+        a v:VCard;
+        v:fn "Jane Doe"
+    ].
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>204 No Content
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -175,21 +198,34 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__graph_already_in_store'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__graph_already_in_store'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__graph_already_in_store:
+        <dt id='get_of_put__graph_already_in_store'>
+          <a class='testlink' href='#get_of_put__graph_already_in_store'>
+            get_of_put__graph_already_in_store:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__graph_already_in_store' property='mf:name'>GET of PUT - graph already in store</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__graph_already_in_store' property='mf:name'>GET of PUT - graph already in store</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__graph_already_in_store' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__graph_already_in_store' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>GET $GRAPHSTORE$/person/1.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;Accept: text/turtle&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>200 OK&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;Content-Length: ...&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .&#x000A;&#x000A;&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;&#x000A;   foaf:businessCard [&#x000A;        a v:VCard;&#x000A;        v:fn &quot;Jane Doe&quot;&#x000A;   ] .&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>GET $GRAPHSTORE$/person/1.ttl HTTP/1.1
+Host: $HOST$
+Accept: text/turtle
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+Content-Type: text/turtle; charset=utf-8
+Content-Length: ...
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;
+   foaf:businessCard [
+        a v:VCard;
+        v:fn "Jane Doe"
+   ] .
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -202,21 +238,32 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__default_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__default_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__default_graph:
+        <dt id='put__default_graph'>
+          <a class='testlink' href='#put__default_graph'>
+            put__default_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__default_graph' property='mf:name'>PUT - default graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__default_graph' property='mf:name'>PUT - default graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__default_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__default_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>PUT $GRAPHSTORE$?default HTTP/1.1&#x000A;Host: $HOST$&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .&#x000A;&#x000A;[]  a foaf:Person;&#x000A;    foaf:businessCard [&#x000A;        a v:VCard;&#x000A;        v:given-name &quot;Alice&quot;&#x000A;    ] .&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>201 Created&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>PUT $GRAPHSTORE$?default HTTP/1.1
+Host: $HOST$
+Content-Type: text/turtle; charset=utf-8
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+[]  a foaf:Person;
+    foaf:businessCard [
+        a v:VCard;
+        v:given-name "Alice"
+    ] .
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>201 Created
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -229,21 +276,34 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__default_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__default_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__default_graph:
+        <dt id='get_of_put__default_graph'>
+          <a class='testlink' href='#get_of_put__default_graph'>
+            get_of_put__default_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__default_graph' property='mf:name'>GET of PUT - default graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__default_graph' property='mf:name'>GET of PUT - default graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__default_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__default_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>GET $GRAPHSTORE$?default HTTP/1.1&#x000A;Host: $HOST$&#x000A;Accept: text/turtle&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>200 OK&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;Content-Length: ...&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .&#x000A;&#x000A;[]  a foaf:Person;&#x000A;    foaf:businessCard [&#x000A;        a v:VCard;&#x000A;        v:given-name &quot;Alice&quot;&#x000A;    ] .&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>GET $GRAPHSTORE$?default HTTP/1.1
+Host: $HOST$
+Accept: text/turtle
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+Content-Type: text/turtle; charset=utf-8
+Content-Length: ...
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+[]  a foaf:Person;
+    foaf:businessCard [
+        a v:VCard;
+        v:given-name "Alice"
+    ] .
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -256,21 +316,32 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__mismatched_payload'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__mismatched_payload'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__mismatched_payload:
+        <dt id='put__mismatched_payload'>
+          <a class='testlink' href='#put__mismatched_payload'>
+            put__mismatched_payload:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__mismatched_payload' property='mf:name'>PUT - mismatched payload</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__mismatched_payload' property='mf:name'>PUT - mismatched payload</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__mismatched_payload' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#put__mismatched_payload' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .&#x000A;&#x000A;&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;&#x000A;    foaf:businessCard [&#x000A;        a v:VCard;&#x000A;        v:fn &quot;Jane Doe&quot;&#x000A;    ].&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>400 Bad Request&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1
+Host: $HOST$
+Content-Type: text/turtle; charset=utf-8
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;
+    foaf:businessCard [
+        a v:VCard;
+        v:fn "Jane Doe"
+    ].
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>400 Bad Request
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -283,21 +354,22 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__existing_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__existing_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__existing_graph:
+        <dt id='delete__existing_graph'>
+          <a class='testlink' href='#delete__existing_graph'>
+            delete__existing_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__existing_graph' property='mf:name'>DELETE - existing graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__existing_graph' property='mf:name'>DELETE - existing graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__existing_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__existing_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>DELETE $GRAPHSTORE$/person/2.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>200 OK&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>DELETE $GRAPHSTORE$/person/2.ttl HTTP/1.1
+Host: $HOST$
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -310,21 +382,22 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_delete__existing_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_delete__existing_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_delete__existing_graph:
+        <dt id='get_of_delete__existing_graph'>
+          <a class='testlink' href='#get_of_delete__existing_graph'>
+            get_of_delete__existing_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_delete__existing_graph' property='mf:name'>GET of DELETE - existing graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_delete__existing_graph' property='mf:name'>GET of DELETE - existing graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_delete__existing_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_delete__existing_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>GET $GRAPHSTORE$/person/2.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>404 Not Found&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>GET $GRAPHSTORE$/person/2.ttl HTTP/1.1
+Host: $HOST$
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>404 Not Found
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -337,21 +410,22 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__nonexistent_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__nonexistent_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__nonexistent_graph:
+        <dt id='delete__nonexistent_graph'>
+          <a class='testlink' href='#delete__nonexistent_graph'>
+            delete__nonexistent_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__nonexistent_graph' property='mf:name'>DELETE - non-existent graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__nonexistent_graph' property='mf:name'>DELETE - non-existent graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__nonexistent_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#delete__nonexistent_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>DELETE $GRAPHSTORE$/person/2.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>404 Not Found&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>DELETE $GRAPHSTORE$/person/2.ttl HTTP/1.1
+Host: $HOST$
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>404 Not Found
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -364,15 +438,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__existing_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__existing_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__existing_graph:
+        <dt id='post__existing_graph'>
+          <a class='testlink' href='#post__existing_graph'>
+            post__existing_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__existing_graph' property='mf:name'>POST - existing graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__existing_graph' property='mf:name'>POST - existing graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__existing_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__existing_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -385,21 +459,27 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__existing_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__existing_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__existing_graph:
+        <dt id='get_of_post__existing_graph'>
+          <a class='testlink' href='#get_of_post__existing_graph'>
+            get_of_post__existing_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__existing_graph' property='mf:name'>GET of POST - existing graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__existing_graph' property='mf:name'>GET of POST - existing graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__existing_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__existing_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>POST $GRAPHSTORE$/person/1.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;&#x000A;&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; foaf:name &quot;Jane Doe&quot;&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>200 OK&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>POST $GRAPHSTORE$/person/1.ttl HTTP/1.1
+Host: $HOST$
+Content-Type: text/turtle; charset=utf-8
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; foaf:name "Jane Doe"
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -412,21 +492,39 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__multipart_formdata'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__multipart_formdata'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__multipart_formdata:
+        <dt id='post__multipart_formdata'>
+          <a class='testlink' href='#post__multipart_formdata'>
+            post__multipart_formdata:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__multipart_formdata' property='mf:name'>POST - multipart/form-data</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__multipart_formdata' property='mf:name'>POST - multipart/form-data</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__multipart_formdata' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__multipart_formdata' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>POST $GRAPHSTORE$/person/1.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;Content-Type: multipart/form-data; boundary=a6fe4cd636164618814be9f8d3d1a0de&#x000A;&#x000A;--a6fe4cd636164618814be9f8d3d1a0de&#x000A;Content-Disposition: form-data; name=&quot;lastName.ttl&quot;; filename=&quot;lastName.ttl&quot;&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; foaf:familyName &quot;Doe&quot;&#x000A;&#x000A;--a6fe4cd636164618814be9f8d3d1a0de&#x000A;Content-Disposition: form-data; name=&quot;firstName.ttl&quot;; filename=&quot;firstName.ttl&quot;&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; foaf:givenName &quot;Jane&quot;&#x000A;&#x000A;--a6fe4cd636164618814be9f8d3d1a0de--&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>200 OK&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>POST $GRAPHSTORE$/person/1.ttl HTTP/1.1
+Host: $HOST$
+Content-Type: multipart/form-data; boundary=a6fe4cd636164618814be9f8d3d1a0de
+
+--a6fe4cd636164618814be9f8d3d1a0de
+Content-Disposition: form-data; name="lastName.ttl"; filename="lastName.ttl"
+Content-Type: text/turtle; charset=utf-8
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; foaf:familyName "Doe"
+
+--a6fe4cd636164618814be9f8d3d1a0de
+Content-Disposition: form-data; name="firstName.ttl"; filename="firstName.ttl"
+Content-Type: text/turtle; charset=utf-8
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; foaf:givenName "Jane"
+
+--a6fe4cd636164618814be9f8d3d1a0de--
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -439,21 +537,36 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__multipart_formdata'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__multipart_formdata'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__multipart_formdata:
+        <dt id='get_of_post__multipart_formdata'>
+          <a class='testlink' href='#get_of_post__multipart_formdata'>
+            get_of_post__multipart_formdata:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__multipart_formdata' property='mf:name'>GET of POST - multipart/form-data</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__multipart_formdata' property='mf:name'>GET of POST - multipart/form-data</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__multipart_formdata' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__multipart_formdata' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>GET $GRAPHSTORE$/person/1.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>200 OK&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;Content-Length: ...&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .&#x000A;&#x000A;&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;&#x000A;    foaf:name           &quot;Jane Doe&quot;;&#x000A;    foaf:givenName      &quot;Jane&quot;;&#x000A;    foaf:familyName     &quot;Doe&quot;;&#x000A;    foaf:businessCard [&#x000A;        a               v:VCard;&#x000A;        v:fn            &quot;Jane Doe&quot;&#x000A;    ] .&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>GET $GRAPHSTORE$/person/1.ttl HTTP/1.1
+Host: $HOST$
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+Content-Type: text/turtle; charset=utf-8
+Content-Length: ...
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;
+    foaf:name           "Jane Doe";
+    foaf:givenName      "Jane";
+    foaf:familyName     "Doe";
+    foaf:businessCard [
+        a               v:VCard;
+        v:fn            "Jane Doe"
+    ] .
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -466,21 +579,33 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__create__new_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__create__new_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__create__new_graph:
+        <dt id='post__create__new_graph'>
+          <a class='testlink' href='#post__create__new_graph'>
+            post__create__new_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__create__new_graph' property='mf:name'>POST - create new graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__create__new_graph' property='mf:name'>POST - create new graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__create__new_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__create__new_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>POST $GRAPHSTORE$ HTTP/1.1&#x000A;Host: $HOST$&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .&#x000A;&#x000A;[]  a foaf:Person;&#x000A;    foaf:businessCard [&#x000A;        a v:VCard;&#x000A;        v:given-name &quot;Alice&quot;&#x000A;    ] .&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>201 Created&#x000A;Location: $NEWPATH$&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>POST $GRAPHSTORE$ HTTP/1.1
+Host: $HOST$
+Content-Type: text/turtle; charset=utf-8
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+[]  a foaf:Person;
+    foaf:businessCard [
+        a v:VCard;
+        v:given-name "Alice"
+    ] .
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>201 Created
+Location: $NEWPATH$
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -493,21 +618,34 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__create__new_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__create__new_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__create__new_graph:
+        <dt id='get_of_post__create__new_graph'>
+          <a class='testlink' href='#get_of_post__create__new_graph'>
+            get_of_post__create__new_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__create__new_graph' property='mf:name'>GET of POST - create new graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__create__new_graph' property='mf:name'>GET of POST - create new graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__create__new_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__create__new_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>GET $NEWPATH$ HTTP/1.1&#x000A;Host: $HOST$&#x000A;Accept: text/turtle&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>200 OK&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;Content-Length: ...&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .&#x000A;&#x000A;[]  a foaf:Person;&#x000A;    foaf:businessCard [&#x000A;        a v:VCard;&#x000A;        v:given-name &quot;Alice&quot;&#x000A;    ] .&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>GET $NEWPATH$ HTTP/1.1
+Host: $HOST$
+Accept: text/turtle
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+Content-Type: text/turtle; charset=utf-8
+Content-Length: ...
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+[]  a foaf:Person;
+    foaf:businessCard [
+        a v:VCard;
+        v:given-name "Alice"
+    ] .
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -520,21 +658,34 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__after_noop'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__after_noop'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__after_noop:
+        <dt id='get_of_post__after_noop'>
+          <a class='testlink' href='#get_of_post__after_noop'>
+            get_of_post__after_noop:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__after_noop' property='mf:name'>GET of POST - after noop</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__after_noop' property='mf:name'>GET of POST - after noop</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__after_noop' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__after_noop' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>GET $NEWPATH$ HTTP/1.1&#x000A;Host: $HOST$&#x000A;Accept: text/turtle&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>200 OK&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;Content-Length: ...&#x000A;&#x000A;@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .&#x000A;@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .&#x000A;&#x000A;[]  a foaf:Person;&#x000A;    foaf:businessCard [&#x000A;        a v:VCard;&#x000A;        v:given-name &quot;Alice&quot;&#x000A;    ] .&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>GET $NEWPATH$ HTTP/1.1
+Host: $HOST$
+Accept: text/turtle
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+Content-Type: text/turtle; charset=utf-8
+Content-Length: ...
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+[]  a foaf:Person;
+    foaf:businessCard [
+        a v:VCard;
+        v:given-name "Alice"
+    ] .
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -547,21 +698,24 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_an_existing_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_an_existing_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_an_existing_graph:
+        <dt id='head_on_an_existing_graph'>
+          <a class='testlink' href='#head_on_an_existing_graph'>
+            head_on_an_existing_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_an_existing_graph' property='mf:name'>HEAD on an existing graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_an_existing_graph' property='mf:name'>HEAD on an existing graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_an_existing_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_an_existing_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>HEAD $GRAPHSTORE$/person/1.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>200 OK&#x000A;Content-Type: text/turtle; charset=utf-8&#x000A;Content-Length: ...&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>HEAD $GRAPHSTORE$/person/1.ttl HTTP/1.1
+Host: $HOST$
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+Content-Type: text/turtle; charset=utf-8
+Content-Length: ...
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -574,21 +728,22 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_a_nonexisting_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_a_nonexisting_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_a_nonexisting_graph:
+        <dt id='head_on_a_nonexisting_graph'>
+          <a class='testlink' href='#head_on_a_nonexisting_graph'>
+            head_on_a_nonexisting_graph:
           </a>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_a_nonexisting_graph' property='mf:name'>HEAD on a non-existing graph</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_a_nonexisting_graph' property='mf:name'>HEAD on a non-existing graph</span>
         </dt>
-        <dd inlist property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_a_nonexisting_graph' typeof='mf:GraphStoreProtocolTest'>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#head_on_a_nonexisting_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
-            <h4>Request</h4>
-            
-            <pre><code>HEAD $GRAPHSTORE$/person/4.ttl HTTP/1.1&#x000A;Host: $HOST$&#x000A;</code></pre>
-            
-            <h4>Response</h4>
-            
-            <pre><code>404 Not Found&#x000A;</code></pre>
+            <h4 id="request">Request</h4>
+            <pre><code>HEAD $GRAPHSTORE$/person/4.ttl HTTP/1.1
+Host: $HOST$
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>404 Not Found
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>

--- a/sparql/sparql11/http-rdf-update/template.haml
+++ b/sparql/sparql11/http-rdf-update/template.haml
@@ -102,9 +102,10 @@
           Test Descriptions
         %dl.test-description
           - man['entries'].each do |test|
-            %dt{id: test['@id']}
-              %a.testlink{href: "##{test['@id']}"}
-                = "#{test['@id']}:"
+            %dt{id: test['@id'].split('#').last}
+              %a.testlink{href: "##{test['@id'].split('#').last}"}
+                = "#{test['@id'].split('#').last}:"
+              %span{about: test['@id'], property: "mf:name"}<~test['name']
               %span{about: test['@id'], property: "mf:name"}<~test['name']
             %dd{property: "mf:entry", inlist: true, resource: test['@id'], typeof: test['@type']}
               %div{property: "rdfs:comment"}

--- a/sparql/sparql11/index-all.html
+++ b/sparql/sparql11/index-all.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>

--- a/sparql/sparql11/index-sparql11-query.html
+++ b/sparql/sparql11/index-sparql11-query.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>

--- a/sparql/sparql11/index-sparql11-results.html
+++ b/sparql/sparql11/index-sparql11-results.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>

--- a/sparql/sparql11/index-sparql11-update.html
+++ b/sparql/sparql11/index-sparql11-update.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>

--- a/sparql/sparql11/json-res/index.html
+++ b/sparql/sparql11/json-res/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres01:
+        <dt id='jsonres01'>
+          <a class='testlink' href='#jsonres01'>
+            jsonres01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres01' property='mf:name'>jsonres01 - JSON Result Format</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres01' property='mf:name'>jsonres01 - JSON Result Format</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres01' typeof='mf:QueryEvaluationTest'>
@@ -103,10 +104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres02:
+        <dt id='jsonres02'>
+          <a class='testlink' href='#jsonres02'>
+            jsonres02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres02' property='mf:name'>jsonres02 - JSON Result Format</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres02' property='mf:name'>jsonres02 - JSON Result Format</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres02' typeof='mf:QueryEvaluationTest'>
@@ -129,10 +131,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres03:
+        <dt id='jsonres03'>
+          <a class='testlink' href='#jsonres03'>
+            jsonres03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres03' property='mf:name'>jsonres03 - JSON Result Format</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres03' property='mf:name'>jsonres03 - JSON Result Format</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres03' typeof='mf:QueryEvaluationTest'>
@@ -155,10 +158,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres04:
+        <dt id='jsonres04'>
+          <a class='testlink' href='#jsonres04'>
+            jsonres04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres04' property='mf:name'>jsonres04 - JSON Result Format</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres04' property='mf:name'>jsonres04 - JSON Result Format</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/json-res/manifest#jsonres04' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/move/index.html
+++ b/sparql/sparql11/move/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move01:
+        <dt id='move01'>
+          <a class='testlink' href='#move01'>
+            move01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move01' property='mf:name'>MOVE 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move01' property='mf:name'>MOVE 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move01' typeof='mf:UpdateEvaluationTest'>
@@ -104,10 +105,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move02:
+        <dt id='move02'>
+          <a class='testlink' href='#move02'>
+            move02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move02' property='mf:name'>MOVE 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move02' property='mf:name'>MOVE 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move02' typeof='mf:UpdateEvaluationTest'>
@@ -131,10 +133,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move03:
+        <dt id='move03'>
+          <a class='testlink' href='#move03'>
+            move03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move03' property='mf:name'>MOVE 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move03' property='mf:name'>MOVE 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move03' typeof='mf:UpdateEvaluationTest'>
@@ -158,10 +161,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move04:
+        <dt id='move04'>
+          <a class='testlink' href='#move04'>
+            move04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move04' property='mf:name'>MOVE 4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move04' property='mf:name'>MOVE 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move04' typeof='mf:UpdateEvaluationTest'>
@@ -185,10 +189,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move06:
+        <dt id='move06'>
+          <a class='testlink' href='#move06'>
+            move06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move06' property='mf:name'>MOVE 6</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move06' property='mf:name'>MOVE 6</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move06' typeof='mf:UpdateEvaluationTest'>
@@ -212,10 +217,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move07:
+        <dt id='move07'>
+          <a class='testlink' href='#move07'>
+            move07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move07' property='mf:name'>MOVE 7</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move07' property='mf:name'>MOVE 7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/move/manifest#move07' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql11/negation/index.html
+++ b/sparql/sparql11/negation/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-nex-1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-nex-1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-nex-1:
+        <dt id='subset-by-exclusion-nex-1'>
+          <a class='testlink' href='#subset-by-exclusion-nex-1'>
+            subset-by-exclusion-nex-1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-nex-1' property='mf:name'>Subsets by exclusion (NOT EXISTS)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-nex-1' property='mf:name'>Subsets by exclusion (NOT EXISTS)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-nex-1' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-minus-1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-minus-1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-minus-1:
+        <dt id='subset-by-exclusion-minus-1'>
+          <a class='testlink' href='#subset-by-exclusion-minus-1'>
+            subset-by-exclusion-minus-1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-minus-1' property='mf:name'>Subsets by exclusion (MINUS)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-minus-1' property='mf:name'>Subsets by exclusion (MINUS)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-by-exclusion-minus-1' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#temporal-proximity-by-exclusion-nex-1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#temporal-proximity-by-exclusion-nex-1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#temporal-proximity-by-exclusion-nex-1:
+        <dt id='temporal-proximity-by-exclusion-nex-1'>
+          <a class='testlink' href='#temporal-proximity-by-exclusion-nex-1'>
+            temporal-proximity-by-exclusion-nex-1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#temporal-proximity-by-exclusion-nex-1' property='mf:name'>Medical, temporal proximity by exclusion (NOT EXISTS)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#temporal-proximity-by-exclusion-nex-1' property='mf:name'>Medical, temporal proximity by exclusion (NOT EXISTS)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#temporal-proximity-by-exclusion-nex-1' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-01:
+        <dt id='subset-01'>
+          <a class='testlink' href='#subset-01'>
+            subset-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-01' property='mf:name'>Calculate which sets are subsets of others (include A subsetOf A)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-01' property='mf:name'>Calculate which sets are subsets of others (include A subsetOf A)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-01' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-02:
+        <dt id='subset-02'>
+          <a class='testlink' href='#subset-02'>
+            subset-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-02' property='mf:name'>Calculate which sets are subsets of others (exclude A subsetOf A)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-02' property='mf:name'>Calculate which sets are subsets of others (exclude A subsetOf A)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-02' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#set-equals-1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#set-equals-1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#set-equals-1:
+        <dt id='set-equals-1'>
+          <a class='testlink' href='#set-equals-1'>
+            set-equals-1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#set-equals-1' property='mf:name'>Calculate which sets have the same elements</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#set-equals-1' property='mf:name'>Calculate which sets have the same elements</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#set-equals-1' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-03:
+        <dt id='subset-03'>
+          <a class='testlink' href='#subset-03'>
+            subset-03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-03' property='mf:name'>Calculate proper subset</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-03' property='mf:name'>Calculate proper subset</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#subset-03' typeof='mf:QueryEvaluationTest'>
@@ -252,10 +259,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-01:
+        <dt id='exists-01'>
+          <a class='testlink' href='#exists-01'>
+            exists-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-01' property='mf:name'>Positive EXISTS 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-01' property='mf:name'>Positive EXISTS 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-01' typeof='mf:QueryEvaluationTest'>
@@ -277,10 +285,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-02:
+        <dt id='exists-02'>
+          <a class='testlink' href='#exists-02'>
+            exists-02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-02' property='mf:name'>Positive EXISTS 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-02' property='mf:name'>Positive EXISTS 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#exists-02' typeof='mf:QueryEvaluationTest'>
@@ -302,10 +311,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#full-minuend'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#full-minuend'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#full-minuend:
+        <dt id='full-minuend'>
+          <a class='testlink' href='#full-minuend'>
+            full-minuend:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#full-minuend' property='mf:name'>Subtraction with MINUS from a fully bound minuend</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#full-minuend' property='mf:name'>Subtraction with MINUS from a fully bound minuend</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#full-minuend' typeof='mf:QueryEvaluationTest'>
@@ -327,10 +337,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#partial-minuend'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#partial-minuend'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#partial-minuend:
+        <dt id='partial-minuend'>
+          <a class='testlink' href='#partial-minuend'>
+            partial-minuend:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#partial-minuend' property='mf:name'>Subtraction with MINUS from a partially bound minuend</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#partial-minuend' property='mf:name'>Subtraction with MINUS from a partially bound minuend</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/negation/manifest#partial-minuend' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/project-expression/index.html
+++ b/sparql/sparql11/project-expression/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp01:
+        <dt id='projexp01'>
+          <a class='testlink' href='#projexp01'>
+            projexp01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp01' property='mf:name'>Expression is equality</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp01' property='mf:name'>Expression is equality</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp01' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp02:
+        <dt id='projexp02'>
+          <a class='testlink' href='#projexp02'>
+            projexp02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp02' property='mf:name'>Expression raise an error</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp02' property='mf:name'>Expression raise an error</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp02' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp03:
+        <dt id='projexp03'>
+          <a class='testlink' href='#projexp03'>
+            projexp03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp03' property='mf:name'>Reuse a project expression variable in select</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp03' property='mf:name'>Reuse a project expression variable in select</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp03' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp04:
+        <dt id='projexp04'>
+          <a class='testlink' href='#projexp04'>
+            projexp04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp04' property='mf:name'>Reuse a project expression variable in order by</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp04' property='mf:name'>Reuse a project expression variable in order by</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp04' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp05:
+        <dt id='projexp05'>
+          <a class='testlink' href='#projexp05'>
+            projexp05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp05' property='mf:name'>Expression may return no value</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp05' property='mf:name'>Expression may return no value</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp05' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp06:
+        <dt id='projexp06'>
+          <a class='testlink' href='#projexp06'>
+            projexp06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp06' property='mf:name'>Expression has undefined variable</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp06' property='mf:name'>Expression has undefined variable</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp06' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp07:
+        <dt id='projexp07'>
+          <a class='testlink' href='#projexp07'>
+            projexp07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp07' property='mf:name'>Expression has variable that may be unbound</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp07' property='mf:name'>Expression has variable that may be unbound</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/project-expression/manifest#projexp07' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/property-path/index.html
+++ b/sparql/sparql11/property-path/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp01:
+        <dt id='pp01'>
+          <a class='testlink' href='#pp01'>
+            pp01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp01' property='mf:name'>(pp01) Simple path</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp01' property='mf:name'>(pp01) Simple path</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp01' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp02:
+        <dt id='pp02'>
+          <a class='testlink' href='#pp02'>
+            pp02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp02' property='mf:name'>(pp02) Star path</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp02' property='mf:name'>(pp02) Star path</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp02' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp03:
+        <dt id='pp03'>
+          <a class='testlink' href='#pp03'>
+            pp03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp03' property='mf:name'>(pp03) Simple path with loop</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp03' property='mf:name'>(pp03) Simple path with loop</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp03' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp06:
+        <dt id='pp06'>
+          <a class='testlink' href='#pp06'>
+            pp06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp06' property='mf:name'>(pp06) Path with two graphs</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp06' property='mf:name'>(pp06) Path with two graphs</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp06' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp07:
+        <dt id='pp07'>
+          <a class='testlink' href='#pp07'>
+            pp07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp07' property='mf:name'>(pp07) Path with one graph</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp07' property='mf:name'>(pp07) Path with one graph</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp07' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp08:
+        <dt id='pp08'>
+          <a class='testlink' href='#pp08'>
+            pp08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp08' property='mf:name'>(pp08) Reverse path</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp08' property='mf:name'>(pp08) Reverse path</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp08' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp09'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp09'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp09:
+        <dt id='pp09'>
+          <a class='testlink' href='#pp09'>
+            pp09:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp09' property='mf:name'>(pp09) Reverse sequence path</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp09' property='mf:name'>(pp09) Reverse sequence path</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp09' typeof='mf:QueryEvaluationTest'>
@@ -252,10 +259,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp10'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp10'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp10:
+        <dt id='pp10'>
+          <a class='testlink' href='#pp10'>
+            pp10:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp10' property='mf:name'>(pp10) Path with negation</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp10' property='mf:name'>(pp10) Path with negation</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp10' typeof='mf:QueryEvaluationTest'>
@@ -277,10 +285,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp11:
+        <dt id='pp11'>
+          <a class='testlink' href='#pp11'>
+            pp11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp11' property='mf:name'>(pp11) Simple path and two paths to same target node</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp11' property='mf:name'>(pp11) Simple path and two paths to same target node</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp11' typeof='mf:QueryEvaluationTest'>
@@ -302,10 +311,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp12'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp12'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp12:
+        <dt id='pp12'>
+          <a class='testlink' href='#pp12'>
+            pp12:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp12' property='mf:name'>(pp12) Variable length path and two paths to same target node</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp12' property='mf:name'>(pp12) Variable length path and two paths to same target node</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp12' typeof='mf:QueryEvaluationTest'>
@@ -327,10 +337,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp14'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp14'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp14:
+        <dt id='pp14'>
+          <a class='testlink' href='#pp14'>
+            pp14:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp14' property='mf:name'>(pp14) Star path over foaf:knows</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp14' property='mf:name'>(pp14) Star path over foaf:knows</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp14' typeof='mf:QueryEvaluationTest'>
@@ -352,10 +363,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp16'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp16'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp16:
+        <dt id='pp16'>
+          <a class='testlink' href='#pp16'>
+            pp16:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp16' property='mf:name'>(pp16) Duplicate paths and cycles through foaf:knows*</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp16' property='mf:name'>(pp16) Duplicate paths and cycles through foaf:knows*</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp16' typeof='mf:QueryEvaluationTest'>
@@ -377,10 +389,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp21'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp21'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp21:
+        <dt id='pp21'>
+          <a class='testlink' href='#pp21'>
+            pp21:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp21' property='mf:name'>(pp21) Diamond -- :p+</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp21' property='mf:name'>(pp21) Diamond -- :p+</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp21' typeof='mf:QueryEvaluationTest'>
@@ -402,10 +415,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp23'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp23'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp23:
+        <dt id='pp23'>
+          <a class='testlink' href='#pp23'>
+            pp23:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp23' property='mf:name'>(pp23) Diamond, with tail -- :p+</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp23' property='mf:name'>(pp23) Diamond, with tail -- :p+</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp23' typeof='mf:QueryEvaluationTest'>
@@ -427,10 +441,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp25'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp25'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp25:
+        <dt id='pp25'>
+          <a class='testlink' href='#pp25'>
+            pp25:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp25' property='mf:name'>(pp25) Diamond, with loop -- :p+</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp25' property='mf:name'>(pp25) Diamond, with loop -- :p+</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp25' typeof='mf:QueryEvaluationTest'>
@@ -452,10 +467,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp28a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp28a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp28a:
+        <dt id='pp28a'>
+          <a class='testlink' href='#pp28a'>
+            pp28a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp28a' property='mf:name'>(pp28a) Diamond, with loop -- (:p/:p)?</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp28a' property='mf:name'>(pp28a) Diamond, with loop -- (:p/:p)?</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp28a' typeof='mf:QueryEvaluationTest'>
@@ -477,10 +493,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp30'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp30'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp30:
+        <dt id='pp30'>
+          <a class='testlink' href='#pp30'>
+            pp30:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp30' property='mf:name'>(pp30) Operator precedence 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp30' property='mf:name'>(pp30) Operator precedence 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp30' typeof='mf:QueryEvaluationTest'>
@@ -502,10 +519,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp31'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp31'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp31:
+        <dt id='pp31'>
+          <a class='testlink' href='#pp31'>
+            pp31:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp31' property='mf:name'>(pp31) Operator precedence 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp31' property='mf:name'>(pp31) Operator precedence 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp31' typeof='mf:QueryEvaluationTest'>
@@ -527,10 +545,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp32'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp32'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp32:
+        <dt id='pp32'>
+          <a class='testlink' href='#pp32'>
+            pp32:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp32' property='mf:name'>(pp32) Operator precedence 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp32' property='mf:name'>(pp32) Operator precedence 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp32' typeof='mf:QueryEvaluationTest'>
@@ -552,10 +571,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp33'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp33'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp33:
+        <dt id='pp33'>
+          <a class='testlink' href='#pp33'>
+            pp33:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp33' property='mf:name'>(pp33) Operator precedence 4</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp33' property='mf:name'>(pp33) Operator precedence 4</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp33' typeof='mf:QueryEvaluationTest'>
@@ -577,10 +597,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp34'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp34'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp34:
+        <dt id='pp34'>
+          <a class='testlink' href='#pp34'>
+            pp34:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp34' property='mf:name'>(pp34) Named Graph 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp34' property='mf:name'>(pp34) Named Graph 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp34' typeof='mf:QueryEvaluationTest'>
@@ -602,10 +623,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp35'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp35'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp35:
+        <dt id='pp35'>
+          <a class='testlink' href='#pp35'>
+            pp35:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp35' property='mf:name'>(pp35) Named Graph 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp35' property='mf:name'>(pp35) Named Graph 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp35' typeof='mf:QueryEvaluationTest'>
@@ -627,10 +649,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp36'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp36'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp36:
+        <dt id='pp36'>
+          <a class='testlink' href='#pp36'>
+            pp36:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp36' property='mf:name'>(pp36) Arbitrary path with bound endpoints</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp36' property='mf:name'>(pp36) Arbitrary path with bound endpoints</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp36' typeof='mf:QueryEvaluationTest'>
@@ -652,10 +675,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp37'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp37'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp37:
+        <dt id='pp37'>
+          <a class='testlink' href='#pp37'>
+            pp37:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp37' property='mf:name'>(pp37) Nested (*)*</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp37' property='mf:name'>(pp37) Nested (*)*</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#pp37' typeof='mf:QueryEvaluationTest'>
@@ -678,10 +702,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#values_and_path'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#values_and_path'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#values_and_path:
+        <dt id='values_and_path'>
+          <a class='testlink' href='#values_and_path'>
+            values_and_path:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#values_and_path' property='mf:name'>ZeroOrX property paths should only return terms in the graph and not also terms defined in the query</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#values_and_path' property='mf:name'>ZeroOrX property paths should only return terms in the graph and not also terms defined in the query</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#values_and_path' typeof='mf:QueryEvaluationTest'>
@@ -703,10 +728,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_inverse'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_inverse'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_inverse:
+        <dt id='nps_inverse'>
+          <a class='testlink' href='#nps_inverse'>
+            nps_inverse:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_inverse' property='mf:name'>Negated Property Set with inverse properties</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_inverse' property='mf:name'>Negated Property Set with inverse properties</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_inverse' typeof='mf:QueryEvaluationTest'>
@@ -728,10 +754,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_direct_and_inverse'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_direct_and_inverse'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_direct_and_inverse:
+        <dt id='nps_direct_and_inverse'>
+          <a class='testlink' href='#nps_direct_and_inverse'>
+            nps_direct_and_inverse:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_direct_and_inverse' property='mf:name'>Negated Property Set with both direct and inverse properties</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_direct_and_inverse' property='mf:name'>Negated Property Set with both direct and inverse properties</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#nps_direct_and_inverse' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/protocol/index.html
+++ b/sparql/sparql11/protocol/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -108,10 +108,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_form'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_form'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_form:
+        <dt id='query_post_form'>
+          <a class='testlink' href='#query_post_form'>
+            query_post_form:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_form' property='mf:name'>query via URL-encoded POST</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_form' property='mf:name'>query via URL-encoded POST</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_form' typeof='mf:ProtocolTest'>
@@ -139,10 +140,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_get'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_get'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_get:
+        <dt id='query_dataset_default_graphs_get'>
+          <a class='testlink' href='#query_dataset_default_graphs_get'>
+            query_dataset_default_graphs_get:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_get' property='mf:name'>GET query with protocol-specified default graph</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_get' property='mf:name'>GET query with protocol-specified default graph</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_get' typeof='mf:ProtocolTest'>
@@ -166,10 +168,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_post'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_post'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_post:
+        <dt id='query_dataset_default_graphs_post'>
+          <a class='testlink' href='#query_dataset_default_graphs_post'>
+            query_dataset_default_graphs_post:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_post' property='mf:name'>POST query with protocol-specified default graphs</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_post' property='mf:name'>POST query with protocol-specified default graphs</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_default_graphs_post' typeof='mf:ProtocolTest'>
@@ -197,10 +200,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_post'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_post'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_post:
+        <dt id='query_dataset_named_graphs_post'>
+          <a class='testlink' href='#query_dataset_named_graphs_post'>
+            query_dataset_named_graphs_post:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_post' property='mf:name'>POST query with protocol-specified named graphs</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_post' property='mf:name'>POST query with protocol-specified named graphs</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_post' typeof='mf:ProtocolTest'>
@@ -228,10 +232,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_get'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_get'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_get:
+        <dt id='query_dataset_named_graphs_get'>
+          <a class='testlink' href='#query_dataset_named_graphs_get'>
+            query_dataset_named_graphs_get:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_get' property='mf:name'>GET query with protocol-specified named graphs</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_get' property='mf:name'>GET query with protocol-specified named graphs</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_named_graphs_get' typeof='mf:ProtocolTest'>
@@ -255,10 +260,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_full'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_full'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_full:
+        <dt id='query_dataset_full'>
+          <a class='testlink' href='#query_dataset_full'>
+            query_dataset_full:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_full' property='mf:name'>query with protocol-specified dataset (both named and default graphs)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_full' property='mf:name'>query with protocol-specified dataset (both named and default graphs)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_dataset_full' typeof='mf:ProtocolTest'>
@@ -286,10 +292,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_multiple_dataset'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_multiple_dataset'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_multiple_dataset:
+        <dt id='query_multiple_dataset'>
+          <a class='testlink' href='#query_multiple_dataset'>
+            query_multiple_dataset:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_multiple_dataset' property='mf:name'>query specifying dataset in both query string and protocol; test for use of protocol-specified dataset</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_multiple_dataset' property='mf:name'>query specifying dataset in both query string and protocol; test for use of protocol-specified dataset</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_multiple_dataset' typeof='mf:ProtocolTest'>
@@ -317,10 +324,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_get'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_get'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_get:
+        <dt id='query_get'>
+          <a class='testlink' href='#query_get'>
+            query_get:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_get' property='mf:name'>query via GET</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_get' property='mf:name'>query via GET</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_get' typeof='mf:ProtocolTest'>
@@ -342,10 +350,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_select'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_select'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_select:
+        <dt id='query_content_type_select'>
+          <a class='testlink' href='#query_content_type_select'>
+            query_content_type_select:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_select' property='mf:name'>query appropriate content type (expect one of: XML, JSON, CSV, TSV)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_select' property='mf:name'>query appropriate content type (expect one of: XML, JSON, CSV, TSV)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_select' typeof='mf:ProtocolTest'>
@@ -371,10 +380,11 @@ Content-Type: application/sparql-results+xml, application/sparql-results+json, t
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_ask'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_ask'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_ask:
+        <dt id='query_content_type_ask'>
+          <a class='testlink' href='#query_content_type_ask'>
+            query_content_type_ask:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_ask' property='mf:name'>query appropriate content type (expect one of: XML, JSON)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_ask' property='mf:name'>query appropriate content type (expect one of: XML, JSON)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_ask' typeof='mf:ProtocolTest'>
@@ -400,10 +410,11 @@ Content-Type: application/sparql-results+xml or application/sparql-results+json
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_describe'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_describe'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_describe:
+        <dt id='query_content_type_describe'>
+          <a class='testlink' href='#query_content_type_describe'>
+            query_content_type_describe:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_describe' property='mf:name'>query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_describe' property='mf:name'>query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_describe' typeof='mf:ProtocolTest'>
@@ -429,10 +440,11 @@ Content-Type: application/rdf+xml, application/rdf+json or text/turtle
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_construct'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_construct'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_construct:
+        <dt id='query_content_type_construct'>
+          <a class='testlink' href='#query_content_type_construct'>
+            query_content_type_construct:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_construct' property='mf:name'>query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_construct' property='mf:name'>query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_content_type_construct' typeof='mf:ProtocolTest'>
@@ -458,10 +470,11 @@ Content-Type: application/rdf+xml, application/rdf+json or text/turtle
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graph'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graph'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graph:
+        <dt id='update_dataset_default_graph'>
+          <a class='testlink' href='#update_dataset_default_graph'>
+            update_dataset_default_graph:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graph' property='mf:name'>update with protocol-specified default graph</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graph' property='mf:name'>update with protocol-specified default graph</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graph' typeof='mf:ProtocolTest'>
@@ -522,10 +535,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graphs'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graphs'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graphs:
+        <dt id='update_dataset_default_graphs'>
+          <a class='testlink' href='#update_dataset_default_graphs'>
+            update_dataset_default_graphs:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graphs' property='mf:name'>update with protocol-specified default graphs</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graphs' property='mf:name'>update with protocol-specified default graphs</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_default_graphs' typeof='mf:ProtocolTest'>
@@ -592,10 +606,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_named_graphs'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_named_graphs'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_named_graphs:
+        <dt id='update_dataset_named_graphs'>
+          <a class='testlink' href='#update_dataset_named_graphs'>
+            update_dataset_named_graphs:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_named_graphs' property='mf:name'>update with protocol-specified named graphs</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_named_graphs' property='mf:name'>update with protocol-specified named graphs</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_named_graphs' typeof='mf:ProtocolTest'>
@@ -664,10 +679,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_full'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_full'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_full:
+        <dt id='update_dataset_full'>
+          <a class='testlink' href='#update_dataset_full'>
+            update_dataset_full:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_full' property='mf:name'>update with protocol-specified dataset (both named and default graphs)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_full' property='mf:name'>update with protocol-specified dataset (both named and default graphs)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_dataset_full' typeof='mf:ProtocolTest'>
@@ -742,10 +758,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_form'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_form'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_form:
+        <dt id='update_post_form'>
+          <a class='testlink' href='#update_post_form'>
+            update_post_form:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_form' property='mf:name'>update via URL-encoded POST</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_form' property='mf:name'>update via URL-encoded POST</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_form' typeof='mf:ProtocolTest'>
@@ -770,10 +787,11 @@ update=CLEAR%20ALL
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_direct'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_direct'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_direct:
+        <dt id='update_post_direct'>
+          <a class='testlink' href='#update_post_direct'>
+            update_post_direct:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_direct' property='mf:name'>update via POST directly</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_direct' property='mf:name'>update via POST directly</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_post_direct' typeof='mf:ProtocolTest'>
@@ -798,10 +816,11 @@ CLEAR ALL
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_base_uri'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_base_uri'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_base_uri:
+        <dt id='update_base_uri'>
+          <a class='testlink' href='#update_base_uri'>
+            update_base_uri:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_base_uri' property='mf:name'>test for service-defined BASE URI (&quot;which MAY be the service endpoint&quot;)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_base_uri' property='mf:name'>test for service-defined BASE URI (&quot;which MAY be the service endpoint&quot;)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#update_base_uri' typeof='mf:ProtocolTest'>
@@ -847,10 +866,11 @@ one result with `?o` bound to an IRI that is _not_ `&lt;test&gt;`
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_direct'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_direct'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_direct:
+        <dt id='query_post_direct'>
+          <a class='testlink' href='#query_post_direct'>
+            query_post_direct:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_direct' property='mf:name'>query via POST directly</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_direct' property='mf:name'>query via POST directly</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#query_post_direct' typeof='mf:ProtocolTest'>
@@ -878,10 +898,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_method'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_method'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_method:
+        <dt id='bad_query_method'>
+          <a class='testlink' href='#bad_query_method'>
+            bad_query_method:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_method' property='mf:name'>invoke query operation with a method other than GET or POST</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_method' property='mf:name'>invoke query operation with a method other than GET or POST</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_method' typeof='mf:ProtocolTest'>
@@ -900,10 +921,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_queries'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_queries'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_queries:
+        <dt id='bad_multiple_queries'>
+          <a class='testlink' href='#bad_multiple_queries'>
+            bad_multiple_queries:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_queries' property='mf:name'>invoke query operation with more than one query string</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_queries' property='mf:name'>invoke query operation with more than one query string</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_queries' typeof='mf:ProtocolTest'>
@@ -922,10 +944,11 @@ true
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_wrong_media_type'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_wrong_media_type'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_wrong_media_type:
+        <dt id='bad_query_wrong_media_type'>
+          <a class='testlink' href='#bad_query_wrong_media_type'>
+            bad_query_wrong_media_type:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_wrong_media_type' property='mf:name'>invoke query operation with a POST with media type that&#39;s not url-encoded or application/sparql-query</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_wrong_media_type' property='mf:name'>invoke query operation with a POST with media type that&#39;s not url-encoded or application/sparql-query</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_wrong_media_type' typeof='mf:ProtocolTest'>
@@ -950,10 +973,11 @@ ASK {}
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_form_type'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_form_type'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_form_type:
+        <dt id='bad_query_missing_form_type'>
+          <a class='testlink' href='#bad_query_missing_form_type'>
+            bad_query_missing_form_type:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_form_type' property='mf:name'>invoke query operation with url-encoded body, but without application/x-www-url-form-urlencoded media type</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_form_type' property='mf:name'>invoke query operation with url-encoded body, but without application/x-www-url-form-urlencoded media type</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_form_type' typeof='mf:ProtocolTest'>
@@ -977,10 +1001,11 @@ query=ASK%20%7B%7D
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_direct_type'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_direct_type'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_direct_type:
+        <dt id='bad_query_missing_direct_type'>
+          <a class='testlink' href='#bad_query_missing_direct_type'>
+            bad_query_missing_direct_type:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_direct_type' property='mf:name'>invoke query operation with SPARQL body, but without application/sparql-query media type</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_direct_type' property='mf:name'>invoke query operation with SPARQL body, but without application/sparql-query media type</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_missing_direct_type' typeof='mf:ProtocolTest'>
@@ -1004,10 +1029,11 @@ ASK {}
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_non_utf8'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_non_utf8'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_non_utf8:
+        <dt id='bad_query_non_utf8'>
+          <a class='testlink' href='#bad_query_non_utf8'>
+            bad_query_non_utf8:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_non_utf8' property='mf:name'>invoke query operation with direct POST, but with a non-UTF8 encoding (UTF-16)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_non_utf8' property='mf:name'>invoke query operation with direct POST, but with a non-UTF8 encoding (UTF-16)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_non_utf8' typeof='mf:ProtocolTest'>
@@ -1033,10 +1059,11 @@ ASK {}
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_syntax'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_syntax'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_syntax:
+        <dt id='bad_query_syntax'>
+          <a class='testlink' href='#bad_query_syntax'>
+            bad_query_syntax:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_syntax' property='mf:name'>invoke query operation with invalid query syntax (4XX result)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_syntax' property='mf:name'>invoke query operation with invalid query syntax (4XX result)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_query_syntax' typeof='mf:ProtocolTest'>
@@ -1055,10 +1082,11 @@ ASK {}
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_get'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_get'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_get:
+        <dt id='bad_update_get'>
+          <a class='testlink' href='#bad_update_get'>
+            bad_update_get:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_get' property='mf:name'>invoke update operation with GET</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_get' property='mf:name'>invoke update operation with GET</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_get' typeof='mf:ProtocolTest'>
@@ -1077,10 +1105,11 @@ ASK {}
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_updates'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_updates'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_updates:
+        <dt id='bad_multiple_updates'>
+          <a class='testlink' href='#bad_multiple_updates'>
+            bad_multiple_updates:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_updates' property='mf:name'>invoke update operation with more than one update string</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_updates' property='mf:name'>invoke update operation with more than one update string</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_multiple_updates' typeof='mf:ProtocolTest'>
@@ -1105,10 +1134,11 @@ update=CLEAR%20NAMED&amp;update=CLEAR%20DEFAULT
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_wrong_media_type'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_wrong_media_type'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_wrong_media_type:
+        <dt id='bad_update_wrong_media_type'>
+          <a class='testlink' href='#bad_update_wrong_media_type'>
+            bad_update_wrong_media_type:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_wrong_media_type' property='mf:name'>invoke update operation with a POST with media type that&#39;s not url-encoded or application/sparql-update</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_wrong_media_type' property='mf:name'>invoke update operation with a POST with media type that&#39;s not url-encoded or application/sparql-update</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_wrong_media_type' typeof='mf:ProtocolTest'>
@@ -1133,10 +1163,11 @@ CLEAR NAMED
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_missing_form_type'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_missing_form_type'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_missing_form_type:
+        <dt id='bad_update_missing_form_type'>
+          <a class='testlink' href='#bad_update_missing_form_type'>
+            bad_update_missing_form_type:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_missing_form_type' property='mf:name'>invoke update operation with url-encoded body, but without application/x-www-url-form-urlencoded media type</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_missing_form_type' property='mf:name'>invoke update operation with url-encoded body, but without application/x-www-url-form-urlencoded media type</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_missing_form_type' typeof='mf:ProtocolTest'>
@@ -1160,10 +1191,11 @@ update=CLEAR%20NAMED
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_non_utf8'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_non_utf8'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_non_utf8:
+        <dt id='bad_update_non_utf8'>
+          <a class='testlink' href='#bad_update_non_utf8'>
+            bad_update_non_utf8:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_non_utf8' property='mf:name'>invoke update operation with direct POST, but with a non-UTF8 encoding</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_non_utf8' property='mf:name'>invoke update operation with direct POST, but with a non-UTF8 encoding</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_non_utf8' typeof='mf:ProtocolTest'>
@@ -1189,10 +1221,11 @@ CLEAR NAMED
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_syntax'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_syntax'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_syntax:
+        <dt id='bad_update_syntax'>
+          <a class='testlink' href='#bad_update_syntax'>
+            bad_update_syntax:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_syntax' property='mf:name'>invoke update operation with invalid update syntax</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_syntax' property='mf:name'>invoke update operation with invalid update syntax</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_syntax' typeof='mf:ProtocolTest'>
@@ -1217,10 +1250,11 @@ update=CLEAR%20XYZ
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_dataset_conflict'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_dataset_conflict'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_dataset_conflict:
+        <dt id='bad_update_dataset_conflict'>
+          <a class='testlink' href='#bad_update_dataset_conflict'>
+            bad_update_dataset_conflict:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_dataset_conflict' property='mf:name'>invoke update with both using-graph-uri/using-named-graph-uri parameter and USING/WITH clause</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_dataset_conflict' property='mf:name'>invoke update with both using-graph-uri/using-named-graph-uri parameter and USING/WITH clause</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#bad_update_dataset_conflict' typeof='mf:ProtocolTest'>

--- a/sparql/sparql11/protocol/template.haml
+++ b/sparql/sparql11/protocol/template.haml
@@ -123,9 +123,10 @@
           Test Descriptions
         %dl.test-description
           - man['entries'].each do |test|
-            %dt{id: test['@id']}
-              %a.testlink{href: "##{test['@id']}"}
-                = "#{test['@id']}:"
+            %dt{id: test['@id'].split('#').last}
+              %a.testlink{href: "##{test['@id'].split('#').last}"}
+                = "#{test['@id'].split('#').last}:"
+              %span{about: test['@id'], property: "mf:name"}<~test['name']
               %span{about: test['@id'], property: "mf:name"}<~test['name']
             %dd{property: "mf:entry", inlist: true, resource: test['@id'], typeof: test['@type']}
               %div{property: "rdfs:comment"}

--- a/sparql/sparql11/service-description/index.html
+++ b/sparql/sparql11/service-description/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#has-endpoint-triple'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#has-endpoint-triple'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#has-endpoint-triple:
+        <dt id='has-endpoint-triple'>
+          <a class='testlink' href='#has-endpoint-triple'>
+            has-endpoint-triple:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#has-endpoint-triple' property='mf:name'>Service description contains a matching sd:endpoint triple</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#has-endpoint-triple' property='mf:name'>Service description contains a matching sd:endpoint triple</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#has-endpoint-triple' typeof='mf:ServiceDescriptionTest'>
@@ -93,10 +94,11 @@
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#returns-rdf'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#returns-rdf'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#returns-rdf:
+        <dt id='returns-rdf'>
+          <a class='testlink' href='#returns-rdf'>
+            returns-rdf:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#returns-rdf' property='mf:name'>GET on endpoint returns RDF</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#returns-rdf' property='mf:name'>GET on endpoint returns RDF</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#returns-rdf' typeof='mf:ServiceDescriptionTest'>
@@ -109,10 +111,11 @@
             <dd property='mf:approval' resource=''></dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#conforms-to-schema'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#conforms-to-schema'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#conforms-to-schema:
+        <dt id='conforms-to-schema'>
+          <a class='testlink' href='#conforms-to-schema'>
+            conforms-to-schema:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#conforms-to-schema' property='mf:name'>Service description conforms to schema</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#conforms-to-schema' property='mf:name'>Service description conforms to schema</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service-description/manifest#conforms-to-schema' typeof='mf:ServiceDescriptionTest'>

--- a/sparql/sparql11/service/index.html
+++ b/sparql/sparql11/service/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service1:
+        <dt id='service1'>
+          <a class='testlink' href='#service1'>
+            service1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service1' property='mf:name'>SERVICE test 1</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service1' property='mf:name'>SERVICE test 1</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service1' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service2:
+        <dt id='service2'>
+          <a class='testlink' href='#service2'>
+            service2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service2' property='mf:name'>SERVICE test 2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service2' property='mf:name'>SERVICE test 2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service2' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service3'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service3'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service3:
+        <dt id='service3'>
+          <a class='testlink' href='#service3'>
+            service3:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service3' property='mf:name'>SERVICE test 3</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service3' property='mf:name'>SERVICE test 3</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service3' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service4a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service4a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service4a:
+        <dt id='service4a'>
+          <a class='testlink' href='#service4a'>
+            service4a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service4a' property='mf:name'>SERVICE test 4a with VALUES clause</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service4a' property='mf:name'>SERVICE test 4a with VALUES clause</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service4a' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service5'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service5'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service5:
+        <dt id='service5'>
+          <a class='testlink' href='#service5'>
+            service5:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service5' property='mf:name'>SERVICE test 5</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service5' property='mf:name'>SERVICE test 5</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service5' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service6'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service6'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service6:
+        <dt id='service6'>
+          <a class='testlink' href='#service6'>
+            service6:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service6' property='mf:name'>SERVICE test 6</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service6' property='mf:name'>SERVICE test 6</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service6' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service7'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service7'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service7:
+        <dt id='service7'>
+          <a class='testlink' href='#service7'>
+            service7:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service7' property='mf:name'>SERVICE test 7</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service7' property='mf:name'>SERVICE test 7</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/service/manifest#service7' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/subquery/index.html
+++ b/sparql/sparql11/subquery/index.html
@@ -63,7 +63,7 @@
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -77,10 +77,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery01:
+        <dt id='subquery01'>
+          <a class='testlink' href='#subquery01'>
+            subquery01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery01' property='mf:name'>sq01 - Subquery within graph pattern</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery01' property='mf:name'>sq01 - Subquery within graph pattern</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery01' typeof='mf:QueryEvaluationTest'>
@@ -102,10 +103,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery02:
+        <dt id='subquery02'>
+          <a class='testlink' href='#subquery02'>
+            subquery02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery02' property='mf:name'>sq02 - Subquery within graph pattern, graph variable is bound</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery02' property='mf:name'>sq02 - Subquery within graph pattern, graph variable is bound</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery02' typeof='mf:QueryEvaluationTest'>
@@ -127,10 +129,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery03:
+        <dt id='subquery03'>
+          <a class='testlink' href='#subquery03'>
+            subquery03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery03' property='mf:name'>sq03 - Subquery within graph pattern, graph variable is not bound</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery03' property='mf:name'>sq03 - Subquery within graph pattern, graph variable is not bound</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery03' typeof='mf:QueryEvaluationTest'>
@@ -152,10 +155,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery04:
+        <dt id='subquery04'>
+          <a class='testlink' href='#subquery04'>
+            subquery04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery04' property='mf:name'>sq04 - Subquery within graph pattern, default graph does not apply</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery04' property='mf:name'>sq04 - Subquery within graph pattern, default graph does not apply</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery04' typeof='mf:QueryEvaluationTest'>
@@ -177,10 +181,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery05:
+        <dt id='subquery05'>
+          <a class='testlink' href='#subquery05'>
+            subquery05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery05' property='mf:name'>sq05 - Subquery within graph pattern, from named applies</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery05' property='mf:name'>sq05 - Subquery within graph pattern, from named applies</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery05' typeof='mf:QueryEvaluationTest'>
@@ -202,10 +207,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery06:
+        <dt id='subquery06'>
+          <a class='testlink' href='#subquery06'>
+            subquery06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery06' property='mf:name'>sq06 - Subquery with graph pattern, from named applies</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery06' property='mf:name'>sq06 - Subquery with graph pattern, from named applies</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery06' typeof='mf:QueryEvaluationTest'>
@@ -227,10 +233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery07:
+        <dt id='subquery07'>
+          <a class='testlink' href='#subquery07'>
+            subquery07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery07' property='mf:name'>sq07 - Subquery with from </span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery07' property='mf:name'>sq07 - Subquery with from </span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery07' typeof='mf:QueryEvaluationTest'>
@@ -252,10 +259,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery08:
+        <dt id='subquery08'>
+          <a class='testlink' href='#subquery08'>
+            subquery08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery08' property='mf:name'>sq08 - Subquery with aggregate</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery08' property='mf:name'>sq08 - Subquery with aggregate</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery08' typeof='mf:QueryEvaluationTest'>
@@ -277,10 +285,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery09'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery09'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery09:
+        <dt id='subquery09'>
+          <a class='testlink' href='#subquery09'>
+            subquery09:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery09' property='mf:name'>sq09 - Nested Subqueries</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery09' property='mf:name'>sq09 - Nested Subqueries</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery09' typeof='mf:QueryEvaluationTest'>
@@ -302,10 +311,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery10'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery10'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery10:
+        <dt id='subquery10'>
+          <a class='testlink' href='#subquery10'>
+            subquery10:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery10' property='mf:name'>sq10 - Subquery with exists</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery10' property='mf:name'>sq10 - Subquery with exists</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery10' typeof='mf:QueryEvaluationTest'>
@@ -327,10 +337,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery11:
+        <dt id='subquery11'>
+          <a class='testlink' href='#subquery11'>
+            subquery11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery11' property='mf:name'>sq11 - Subquery limit per resource</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery11' property='mf:name'>sq11 - Subquery limit per resource</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery11' typeof='mf:QueryEvaluationTest'>
@@ -353,10 +364,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery12'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery12'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery12:
+        <dt id='subquery12'>
+          <a class='testlink' href='#subquery12'>
+            subquery12:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery12' property='mf:name'>sq12 - Subquery in CONSTRUCT with built-ins</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery12' property='mf:name'>sq12 - Subquery in CONSTRUCT with built-ins</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery12' typeof='mf:QueryEvaluationTest'>
@@ -379,10 +391,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery13'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery13'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery13:
+        <dt id='subquery13'>
+          <a class='testlink' href='#subquery13'>
+            subquery13:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery13' property='mf:name'>sq13 - Subqueries don&#39;t inject bindings</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery13' property='mf:name'>sq13 - Subqueries don&#39;t inject bindings</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery13' typeof='mf:QueryEvaluationTest'>
@@ -405,10 +418,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery14'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery14'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery14:
+        <dt id='subquery14'>
+          <a class='testlink' href='#subquery14'>
+            subquery14:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery14' property='mf:name'>sq14 - limit by resource</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery14' property='mf:name'>sq14 - limit by resource</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/subquery/manifest#subquery14' typeof='mf:QueryEvaluationTest'>

--- a/sparql/sparql11/syntax-fed/index.html
+++ b/sparql/sparql11/syntax-fed/index.html
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Syntax tests Syntax SPARQL 1.1 Federation
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_1:
+        <dt id='test_1'>
+          <a class='testlink' href='#test_1'>
+            test_1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_1' property='mf:name'>syntax-service-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_1' property='mf:name'>syntax-service-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_1' typeof='mf:PositiveSyntaxTest11'>
@@ -98,10 +99,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_2:
+        <dt id='test_2'>
+          <a class='testlink' href='#test_2'>
+            test_2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_2' property='mf:name'>syntax-service-02.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_2' property='mf:name'>syntax-service-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_2' typeof='mf:PositiveSyntaxTest11'>
@@ -118,10 +120,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_3'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_3'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_3:
+        <dt id='test_3'>
+          <a class='testlink' href='#test_3'>
+            test_3:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_3' property='mf:name'>syntax-service-03.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_3' property='mf:name'>syntax-service-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-fed/manifest#test_3' typeof='mf:PositiveSyntaxTest11'>

--- a/sparql/sparql11/syntax-query/index.html
+++ b/sparql/sparql11/syntax-query/index.html
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Syntax tests Syntax SPARQL 1.1
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_1:
+        <dt id='test_1'>
+          <a class='testlink' href='#test_1'>
+            test_1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_1' property='mf:name'>syntax-select-expr-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_1' property='mf:name'>syntax-select-expr-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_1' typeof='mf:PositiveSyntaxTest11'>
@@ -98,10 +99,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_2:
+        <dt id='test_2'>
+          <a class='testlink' href='#test_2'>
+            test_2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_2' property='mf:name'>syntax-select-expr-02.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_2' property='mf:name'>syntax-select-expr-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_2' typeof='mf:PositiveSyntaxTest11'>
@@ -118,10 +120,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_3'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_3'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_3:
+        <dt id='test_3'>
+          <a class='testlink' href='#test_3'>
+            test_3:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_3' property='mf:name'>syntax-select-expr-03.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_3' property='mf:name'>syntax-select-expr-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_3' typeof='mf:PositiveSyntaxTest11'>
@@ -138,10 +141,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_4'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_4'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_4:
+        <dt id='test_4'>
+          <a class='testlink' href='#test_4'>
+            test_4:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_4' property='mf:name'>syntax-select-expr-04.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_4' property='mf:name'>syntax-select-expr-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_4' typeof='mf:PositiveSyntaxTest11'>
@@ -158,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_5'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_5'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_5:
+        <dt id='test_5'>
+          <a class='testlink' href='#test_5'>
+            test_5:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_5' property='mf:name'>syntax-select-expr-05.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_5' property='mf:name'>syntax-select-expr-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_5' typeof='mf:PositiveSyntaxTest11'>
@@ -178,10 +183,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_6'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_6'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_6:
+        <dt id='test_6'>
+          <a class='testlink' href='#test_6'>
+            test_6:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_6' property='mf:name'>syntax-aggregate-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_6' property='mf:name'>syntax-aggregate-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_6' typeof='mf:PositiveSyntaxTest11'>
@@ -198,10 +204,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_7'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_7'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_7:
+        <dt id='test_7'>
+          <a class='testlink' href='#test_7'>
+            test_7:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_7' property='mf:name'>syntax-aggregate-02.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_7' property='mf:name'>syntax-aggregate-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_7' typeof='mf:PositiveSyntaxTest11'>
@@ -218,10 +225,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_8'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_8'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_8:
+        <dt id='test_8'>
+          <a class='testlink' href='#test_8'>
+            test_8:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_8' property='mf:name'>syntax-aggregate-03.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_8' property='mf:name'>syntax-aggregate-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_8' typeof='mf:PositiveSyntaxTest11'>
@@ -238,10 +246,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_9'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_9'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_9:
+        <dt id='test_9'>
+          <a class='testlink' href='#test_9'>
+            test_9:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_9' property='mf:name'>syntax-aggregate-04.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_9' property='mf:name'>syntax-aggregate-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_9' typeof='mf:PositiveSyntaxTest11'>
@@ -258,10 +267,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_10'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_10'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_10:
+        <dt id='test_10'>
+          <a class='testlink' href='#test_10'>
+            test_10:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_10' property='mf:name'>syntax-aggregate-05.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_10' property='mf:name'>syntax-aggregate-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_10' typeof='mf:PositiveSyntaxTest11'>
@@ -278,10 +288,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_11:
+        <dt id='test_11'>
+          <a class='testlink' href='#test_11'>
+            test_11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_11' property='mf:name'>syntax-aggregate-06.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_11' property='mf:name'>syntax-aggregate-06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_11' typeof='mf:PositiveSyntaxTest11'>
@@ -298,10 +309,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_12'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_12'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_12:
+        <dt id='test_12'>
+          <a class='testlink' href='#test_12'>
+            test_12:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_12' property='mf:name'>syntax-aggregate-07.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_12' property='mf:name'>syntax-aggregate-07.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_12' typeof='mf:PositiveSyntaxTest11'>
@@ -318,10 +330,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_13'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_13'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_13:
+        <dt id='test_13'>
+          <a class='testlink' href='#test_13'>
+            test_13:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_13' property='mf:name'>syntax-aggregate-08.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_13' property='mf:name'>syntax-aggregate-08.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_13' typeof='mf:PositiveSyntaxTest11'>
@@ -338,10 +351,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_14'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_14'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_14:
+        <dt id='test_14'>
+          <a class='testlink' href='#test_14'>
+            test_14:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_14' property='mf:name'>syntax-aggregate-09.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_14' property='mf:name'>syntax-aggregate-09.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_14' typeof='mf:PositiveSyntaxTest11'>
@@ -358,10 +372,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_15'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_15'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_15:
+        <dt id='test_15'>
+          <a class='testlink' href='#test_15'>
+            test_15:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_15' property='mf:name'>syntax-aggregate-10.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_15' property='mf:name'>syntax-aggregate-10.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_15' typeof='mf:PositiveSyntaxTest11'>
@@ -378,10 +393,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_16'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_16'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_16:
+        <dt id='test_16'>
+          <a class='testlink' href='#test_16'>
+            test_16:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_16' property='mf:name'>syntax-aggregate-11.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_16' property='mf:name'>syntax-aggregate-11.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_16' typeof='mf:PositiveSyntaxTest11'>
@@ -398,10 +414,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_17'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_17'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_17:
+        <dt id='test_17'>
+          <a class='testlink' href='#test_17'>
+            test_17:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_17' property='mf:name'>syntax-aggregate-12.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_17' property='mf:name'>syntax-aggregate-12.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_17' typeof='mf:PositiveSyntaxTest11'>
@@ -418,10 +435,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_18'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_18'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_18:
+        <dt id='test_18'>
+          <a class='testlink' href='#test_18'>
+            test_18:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_18' property='mf:name'>syntax-aggregate-13.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_18' property='mf:name'>syntax-aggregate-13.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_18' typeof='mf:PositiveSyntaxTest11'>
@@ -438,10 +456,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_19'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_19'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_19:
+        <dt id='test_19'>
+          <a class='testlink' href='#test_19'>
+            test_19:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_19' property='mf:name'>syntax-aggregate-14.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_19' property='mf:name'>syntax-aggregate-14.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_19' typeof='mf:PositiveSyntaxTest11'>
@@ -458,10 +477,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_20'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_20'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_20:
+        <dt id='test_20'>
+          <a class='testlink' href='#test_20'>
+            test_20:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_20' property='mf:name'>syntax-aggregate-15.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_20' property='mf:name'>syntax-aggregate-15.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_20' typeof='mf:PositiveSyntaxTest11'>
@@ -478,10 +498,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_21'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_21'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_21:
+        <dt id='test_21'>
+          <a class='testlink' href='#test_21'>
+            test_21:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_21' property='mf:name'>syntax-subquery-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_21' property='mf:name'>syntax-subquery-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_21' typeof='mf:PositiveSyntaxTest11'>
@@ -498,10 +519,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_22'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_22'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_22:
+        <dt id='test_22'>
+          <a class='testlink' href='#test_22'>
+            test_22:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_22' property='mf:name'>syntax-subquery-02.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_22' property='mf:name'>syntax-subquery-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_22' typeof='mf:PositiveSyntaxTest11'>
@@ -518,10 +540,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_23'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_23'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_23:
+        <dt id='test_23'>
+          <a class='testlink' href='#test_23'>
+            test_23:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_23' property='mf:name'>syntax-subquery-03.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_23' property='mf:name'>syntax-subquery-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_23' typeof='mf:PositiveSyntaxTest11'>
@@ -538,10 +561,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_24'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_24'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_24:
+        <dt id='test_24'>
+          <a class='testlink' href='#test_24'>
+            test_24:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_24' property='mf:name'>syntax-not-exists-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_24' property='mf:name'>syntax-not-exists-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_24' typeof='mf:PositiveSyntaxTest11'>
@@ -558,10 +582,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_25'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_25'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_25:
+        <dt id='test_25'>
+          <a class='testlink' href='#test_25'>
+            test_25:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_25' property='mf:name'>syntax-not-exists-02.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_25' property='mf:name'>syntax-not-exists-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_25' typeof='mf:PositiveSyntaxTest11'>
@@ -578,10 +603,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_26'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_26'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_26:
+        <dt id='test_26'>
+          <a class='testlink' href='#test_26'>
+            test_26:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_26' property='mf:name'>syntax-not-exists-03.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_26' property='mf:name'>syntax-not-exists-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_26' typeof='mf:PositiveSyntaxTest11'>
@@ -598,10 +624,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_27'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_27'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_27:
+        <dt id='test_27'>
+          <a class='testlink' href='#test_27'>
+            test_27:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_27' property='mf:name'>syntax-exists-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_27' property='mf:name'>syntax-exists-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_27' typeof='mf:PositiveSyntaxTest11'>
@@ -618,10 +645,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_28'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_28'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_28:
+        <dt id='test_28'>
+          <a class='testlink' href='#test_28'>
+            test_28:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_28' property='mf:name'>syntax-exists-02.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_28' property='mf:name'>syntax-exists-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_28' typeof='mf:PositiveSyntaxTest11'>
@@ -638,10 +666,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_29'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_29'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_29:
+        <dt id='test_29'>
+          <a class='testlink' href='#test_29'>
+            test_29:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_29' property='mf:name'>syntax-exists-03.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_29' property='mf:name'>syntax-exists-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_29' typeof='mf:PositiveSyntaxTest11'>
@@ -658,10 +687,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_30'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_30'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_30:
+        <dt id='test_30'>
+          <a class='testlink' href='#test_30'>
+            test_30:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_30' property='mf:name'>syntax-minus-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_30' property='mf:name'>syntax-minus-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_30' typeof='mf:PositiveSyntaxTest11'>
@@ -678,10 +708,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_31'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_31'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_31:
+        <dt id='test_31'>
+          <a class='testlink' href='#test_31'>
+            test_31:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_31' property='mf:name'>syntax-oneof-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_31' property='mf:name'>syntax-oneof-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_31' typeof='mf:PositiveSyntaxTest11'>
@@ -698,10 +729,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_32'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_32'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_32:
+        <dt id='test_32'>
+          <a class='testlink' href='#test_32'>
+            test_32:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_32' property='mf:name'>syntax-oneof-02.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_32' property='mf:name'>syntax-oneof-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_32' typeof='mf:PositiveSyntaxTest11'>
@@ -718,10 +750,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_33'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_33'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_33:
+        <dt id='test_33'>
+          <a class='testlink' href='#test_33'>
+            test_33:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_33' property='mf:name'>syntax-oneof-03.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_33' property='mf:name'>syntax-oneof-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_33' typeof='mf:PositiveSyntaxTest11'>
@@ -738,10 +771,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_34'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_34'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_34:
+        <dt id='test_34'>
+          <a class='testlink' href='#test_34'>
+            test_34:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_34' property='mf:name'>syntax-bindingBINDscopes-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_34' property='mf:name'>syntax-bindingBINDscopes-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_34' typeof='mf:PositiveSyntaxTest11'>
@@ -758,10 +792,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_35a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_35a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_35a:
+        <dt id='test_35a'>
+          <a class='testlink' href='#test_35a'>
+            test_35a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_35a' property='mf:name'>syntax-bindings-02a.rq with VALUES clause</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_35a' property='mf:name'>syntax-bindings-02a.rq with VALUES clause</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_35a' typeof='mf:PositiveSyntaxTest11'>
@@ -778,10 +813,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_36a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_36a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_36a:
+        <dt id='test_36a'>
+          <a class='testlink' href='#test_36a'>
+            test_36a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_36a' property='mf:name'>syntax-bindings-03a.rq with VALUES clause</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_36a' property='mf:name'>syntax-bindings-03a.rq with VALUES clause</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_36a' typeof='mf:PositiveSyntaxTest11'>
@@ -798,10 +834,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_38a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_38a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_38a:
+        <dt id='test_38a'>
+          <a class='testlink' href='#test_38a'>
+            test_38a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_38a' property='mf:name'>syntax-bindings-05a.rq with VALUES clause</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_38a' property='mf:name'>syntax-bindings-05a.rq with VALUES clause</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_38a' typeof='mf:PositiveSyntaxTest11'>
@@ -818,10 +855,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_40'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_40'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_40:
+        <dt id='test_40'>
+          <a class='testlink' href='#test_40'>
+            test_40:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_40' property='mf:name'>syntax-bind-02.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_40' property='mf:name'>syntax-bind-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_40' typeof='mf:PositiveSyntaxTest11'>
@@ -838,10 +876,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_41'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_41'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_41:
+        <dt id='test_41'>
+          <a class='testlink' href='#test_41'>
+            test_41:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_41' property='mf:name'>syntax-construct-where-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_41' property='mf:name'>syntax-construct-where-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_41' typeof='mf:PositiveSyntaxTest11'>
@@ -858,10 +897,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_42'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_42'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_42:
+        <dt id='test_42'>
+          <a class='testlink' href='#test_42'>
+            test_42:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_42' property='mf:name'>syntax-construct-where-02.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_42' property='mf:name'>syntax-construct-where-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_42' typeof='mf:PositiveSyntaxTest11'>
@@ -878,10 +918,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_43'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_43'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_43:
+        <dt id='test_43'>
+          <a class='testlink' href='#test_43'>
+            test_43:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_43' property='mf:name'>syn-bad-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_43' property='mf:name'>syn-bad-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_43' typeof='mf:NegativeSyntaxTest11'>
@@ -898,10 +939,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_44'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_44'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_44:
+        <dt id='test_44'>
+          <a class='testlink' href='#test_44'>
+            test_44:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_44' property='mf:name'>syn-bad-02.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_44' property='mf:name'>syn-bad-02.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_44' typeof='mf:NegativeSyntaxTest11'>
@@ -918,10 +960,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_45'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_45'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_45:
+        <dt id='test_45'>
+          <a class='testlink' href='#test_45'>
+            test_45:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_45' property='mf:name'>syn-bad-03.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_45' property='mf:name'>syn-bad-03.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_45' typeof='mf:NegativeSyntaxTest11'>
@@ -938,10 +981,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_46'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_46'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_46:
+        <dt id='test_46'>
+          <a class='testlink' href='#test_46'>
+            test_46:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_46' property='mf:name'>syn-bad-04.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_46' property='mf:name'>syn-bad-04.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_46' typeof='mf:NegativeSyntaxTest11'>
@@ -958,10 +1002,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_47'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_47'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_47:
+        <dt id='test_47'>
+          <a class='testlink' href='#test_47'>
+            test_47:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_47' property='mf:name'>syn-bad-05.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_47' property='mf:name'>syn-bad-05.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_47' typeof='mf:NegativeSyntaxTest11'>
@@ -978,10 +1023,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_48'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_48'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_48:
+        <dt id='test_48'>
+          <a class='testlink' href='#test_48'>
+            test_48:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_48' property='mf:name'>syn-bad-06.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_48' property='mf:name'>syn-bad-06.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_48' typeof='mf:NegativeSyntaxTest11'>
@@ -998,10 +1044,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_49'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_49'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_49:
+        <dt id='test_49'>
+          <a class='testlink' href='#test_49'>
+            test_49:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_49' property='mf:name'>syn-bad-07.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_49' property='mf:name'>syn-bad-07.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_49' typeof='mf:NegativeSyntaxTest11'>
@@ -1018,10 +1065,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_50'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_50'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_50:
+        <dt id='test_50'>
+          <a class='testlink' href='#test_50'>
+            test_50:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_50' property='mf:name'>syn-bad-08.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_50' property='mf:name'>syn-bad-08.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_50' typeof='mf:NegativeSyntaxTest11'>
@@ -1038,10 +1086,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_51'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_51'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_51:
+        <dt id='test_51'>
+          <a class='testlink' href='#test_51'>
+            test_51:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_51' property='mf:name'>syntax-bindings-09.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_51' property='mf:name'>syntax-bindings-09.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_51' typeof='mf:NegativeSyntaxTest11'>
@@ -1058,10 +1107,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_53'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_53'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_53:
+        <dt id='test_53'>
+          <a class='testlink' href='#test_53'>
+            test_53:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_53' property='mf:name'>PrefixName with hex-encoded colons</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_53' property='mf:name'>PrefixName with hex-encoded colons</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_53' typeof='mf:PositiveSyntaxTest11'>
@@ -1078,10 +1128,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_54'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_54'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_54:
+        <dt id='test_54'>
+          <a class='testlink' href='#test_54'>
+            test_54:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_54' property='mf:name'>PrefixName with unescaped colons</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_54' property='mf:name'>PrefixName with unescaped colons</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_54' typeof='mf:PositiveSyntaxTest11'>
@@ -1098,10 +1149,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_55'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_55'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_55:
+        <dt id='test_55'>
+          <a class='testlink' href='#test_55'>
+            test_55:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_55' property='mf:name'>syntax-BINDscope1.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_55' property='mf:name'>syntax-BINDscope1.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_55' typeof='mf:PositiveSyntaxTest11'>
@@ -1118,10 +1170,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_56'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_56'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_56:
+        <dt id='test_56'>
+          <a class='testlink' href='#test_56'>
+            test_56:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_56' property='mf:name'>syntax-BINDscope2.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_56' property='mf:name'>syntax-BINDscope2.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_56' typeof='mf:PositiveSyntaxTest11'>
@@ -1138,10 +1191,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_57'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_57'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_57:
+        <dt id='test_57'>
+          <a class='testlink' href='#test_57'>
+            test_57:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_57' property='mf:name'>syntax-BINDscope3.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_57' property='mf:name'>syntax-BINDscope3.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_57' typeof='mf:PositiveSyntaxTest11'>
@@ -1158,10 +1212,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_58'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_58'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_58:
+        <dt id='test_58'>
+          <a class='testlink' href='#test_58'>
+            test_58:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_58' property='mf:name'>syntax-BINDscope4.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_58' property='mf:name'>syntax-BINDscope4.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_58' typeof='mf:PositiveSyntaxTest11'>
@@ -1178,10 +1233,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_59'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_59'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_59:
+        <dt id='test_59'>
+          <a class='testlink' href='#test_59'>
+            test_59:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_59' property='mf:name'>syntax-BINDscope5.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_59' property='mf:name'>syntax-BINDscope5.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_59' typeof='mf:PositiveSyntaxTest11'>
@@ -1198,10 +1254,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_60'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_60'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_60:
+        <dt id='test_60'>
+          <a class='testlink' href='#test_60'>
+            test_60:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_60' property='mf:name'>syntax-BINDscope6.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_60' property='mf:name'>syntax-BINDscope6.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_60' typeof='mf:NegativeSyntaxTest11'>
@@ -1218,10 +1275,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_61a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_61a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_61a:
+        <dt id='test_61a'>
+          <a class='testlink' href='#test_61a'>
+            test_61a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_61a' property='mf:name'>syntax-BINDscope7.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_61a' property='mf:name'>syntax-BINDscope7.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_61a' typeof='mf:NegativeSyntaxTest11'>
@@ -1238,10 +1296,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_62a'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_62a'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_62a:
+        <dt id='test_62a'>
+          <a class='testlink' href='#test_62a'>
+            test_62a:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_62a' property='mf:name'>syntax-BINDscope8.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_62a' property='mf:name'>syntax-BINDscope8.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_62a' typeof='mf:NegativeSyntaxTest11'>
@@ -1258,10 +1317,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_63'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_63'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_63:
+        <dt id='test_63'>
+          <a class='testlink' href='#test_63'>
+            test_63:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_63' property='mf:name'>syntax-propertyPaths-01.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_63' property='mf:name'>syntax-propertyPaths-01.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_63' typeof='mf:PositiveSyntaxTest11'>
@@ -1278,10 +1338,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_64'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_64'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_64:
+        <dt id='test_64'>
+          <a class='testlink' href='#test_64'>
+            test_64:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_64' property='mf:name'>syntax-SELECTscope1.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_64' property='mf:name'>syntax-SELECTscope1.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_64' typeof='mf:PositiveSyntaxTest11'>
@@ -1298,10 +1359,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_65'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_65'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_65:
+        <dt id='test_65'>
+          <a class='testlink' href='#test_65'>
+            test_65:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_65' property='mf:name'>syntax-SELECTscope2</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_65' property='mf:name'>syntax-SELECTscope2</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_65' typeof='mf:NegativeSyntaxTest11'>
@@ -1318,10 +1380,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_66'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_66'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_66:
+        <dt id='test_66'>
+          <a class='testlink' href='#test_66'>
+            test_66:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_66' property='mf:name'>syntax-SELECTscope3.rq</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_66' property='mf:name'>syntax-SELECTscope3.rq</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_66' typeof='mf:PositiveSyntaxTest11'>
@@ -1338,10 +1401,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_01:
+        <dt id='test_pn_01'>
+          <a class='testlink' href='#test_pn_01'>
+            test_pn_01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_01' property='mf:name'>syn-pname-01</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_01' property='mf:name'>syn-pname-01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_01' typeof='mf:PositiveSyntaxTest11'>
@@ -1358,10 +1422,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_02:
+        <dt id='test_pn_02'>
+          <a class='testlink' href='#test_pn_02'>
+            test_pn_02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_02' property='mf:name'>syn-pname-02</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_02' property='mf:name'>syn-pname-02</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_02' typeof='mf:PositiveSyntaxTest11'>
@@ -1378,10 +1443,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_03:
+        <dt id='test_pn_03'>
+          <a class='testlink' href='#test_pn_03'>
+            test_pn_03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_03' property='mf:name'>syn-pname-03</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_03' property='mf:name'>syn-pname-03</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_03' typeof='mf:PositiveSyntaxTest11'>
@@ -1398,10 +1464,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_04:
+        <dt id='test_pn_04'>
+          <a class='testlink' href='#test_pn_04'>
+            test_pn_04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_04' property='mf:name'>syn-pname-04</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_04' property='mf:name'>syn-pname-04</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_04' typeof='mf:PositiveSyntaxTest11'>
@@ -1418,10 +1485,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_05:
+        <dt id='test_pn_05'>
+          <a class='testlink' href='#test_pn_05'>
+            test_pn_05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_05' property='mf:name'>syn-pname-05</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_05' property='mf:name'>syn-pname-05</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_05' typeof='mf:PositiveSyntaxTest11'>
@@ -1438,10 +1506,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_06:
+        <dt id='test_pn_06'>
+          <a class='testlink' href='#test_pn_06'>
+            test_pn_06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_06' property='mf:name'>syn-pname-06</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_06' property='mf:name'>syn-pname-06</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_06' typeof='mf:PositiveSyntaxTest11'>
@@ -1458,10 +1527,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_07:
+        <dt id='test_pn_07'>
+          <a class='testlink' href='#test_pn_07'>
+            test_pn_07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_07' property='mf:name'>syn-pname-07</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_07' property='mf:name'>syn-pname-07</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_07' typeof='mf:PositiveSyntaxTest11'>
@@ -1478,10 +1548,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_08:
+        <dt id='test_pn_08'>
+          <a class='testlink' href='#test_pn_08'>
+            test_pn_08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_08' property='mf:name'>syn-pname-08</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_08' property='mf:name'>syn-pname-08</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_08' typeof='mf:PositiveSyntaxTest11'>
@@ -1498,10 +1569,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_09'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_09'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_09:
+        <dt id='test_pn_09'>
+          <a class='testlink' href='#test_pn_09'>
+            test_pn_09:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_09' property='mf:name'>syn-pname-09</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_09' property='mf:name'>syn-pname-09</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_09' typeof='mf:PositiveSyntaxTest11'>
@@ -1518,10 +1590,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_01:
+        <dt id='test_pn_bad_01'>
+          <a class='testlink' href='#test_pn_bad_01'>
+            test_pn_bad_01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_01' property='mf:name'>syn-bad-pname-01</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_01' property='mf:name'>syn-bad-pname-01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_01' typeof='mf:NegativeSyntaxTest11'>
@@ -1538,10 +1611,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_02:
+        <dt id='test_pn_bad_02'>
+          <a class='testlink' href='#test_pn_bad_02'>
+            test_pn_bad_02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_02' property='mf:name'>syn-bad-pname-02</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_02' property='mf:name'>syn-bad-pname-02</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_02' typeof='mf:NegativeSyntaxTest11'>
@@ -1558,10 +1632,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_03:
+        <dt id='test_pn_bad_03'>
+          <a class='testlink' href='#test_pn_bad_03'>
+            test_pn_bad_03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_03' property='mf:name'>syn-bad-pname-03</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_03' property='mf:name'>syn-bad-pname-03</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_03' typeof='mf:NegativeSyntaxTest11'>
@@ -1578,10 +1653,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_04:
+        <dt id='test_pn_bad_04'>
+          <a class='testlink' href='#test_pn_bad_04'>
+            test_pn_bad_04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_04' property='mf:name'>syn-bad-pname-04</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_04' property='mf:name'>syn-bad-pname-04</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_04' typeof='mf:NegativeSyntaxTest11'>
@@ -1598,10 +1674,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_05:
+        <dt id='test_pn_bad_05'>
+          <a class='testlink' href='#test_pn_bad_05'>
+            test_pn_bad_05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_05' property='mf:name'>syn-bad-pname-05</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_05' property='mf:name'>syn-bad-pname-05</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_05' typeof='mf:NegativeSyntaxTest11'>
@@ -1618,10 +1695,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_06:
+        <dt id='test_pn_bad_06'>
+          <a class='testlink' href='#test_pn_bad_06'>
+            test_pn_bad_06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_06' property='mf:name'>syn-bad-pname-06</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_06' property='mf:name'>syn-bad-pname-06</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_06' typeof='mf:NegativeSyntaxTest11'>
@@ -1638,10 +1716,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_07'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_07'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_07:
+        <dt id='test_pn_bad_07'>
+          <a class='testlink' href='#test_pn_bad_07'>
+            test_pn_bad_07:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_07' property='mf:name'>syn-bad-pname-07</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_07' property='mf:name'>syn-bad-pname-07</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_07' typeof='mf:NegativeSyntaxTest11'>
@@ -1658,10 +1737,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_08'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_08'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_08:
+        <dt id='test_pn_bad_08'>
+          <a class='testlink' href='#test_pn_bad_08'>
+            test_pn_bad_08:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_08' property='mf:name'>syn-bad-pname-08</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_08' property='mf:name'>syn-bad-pname-08</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_08' typeof='mf:NegativeSyntaxTest11'>
@@ -1678,10 +1758,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_09'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_09'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_09:
+        <dt id='test_pn_bad_09'>
+          <a class='testlink' href='#test_pn_bad_09'>
+            test_pn_bad_09:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_09' property='mf:name'>syn-bad-pname-09</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_09' property='mf:name'>syn-bad-pname-09</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_09' typeof='mf:NegativeSyntaxTest11'>
@@ -1698,10 +1779,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_10'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_10'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_10:
+        <dt id='test_pn_bad_10'>
+          <a class='testlink' href='#test_pn_bad_10'>
+            test_pn_bad_10:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_10' property='mf:name'>syn-bad-pname-10</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_10' property='mf:name'>syn-bad-pname-10</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_10' typeof='mf:NegativeSyntaxTest11'>
@@ -1718,10 +1800,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_11:
+        <dt id='test_pn_bad_11'>
+          <a class='testlink' href='#test_pn_bad_11'>
+            test_pn_bad_11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_11' property='mf:name'>syn-bad-pname-11</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_11' property='mf:name'>syn-bad-pname-11</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_11' typeof='mf:NegativeSyntaxTest11'>
@@ -1738,10 +1821,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_12'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_12'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_12:
+        <dt id='test_pn_bad_12'>
+          <a class='testlink' href='#test_pn_bad_12'>
+            test_pn_bad_12:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_12' property='mf:name'>syn-bad-pname-12</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_12' property='mf:name'>syn-bad-pname-12</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_12' typeof='mf:NegativeSyntaxTest11'>
@@ -1758,10 +1842,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_13'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_13'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_13:
+        <dt id='test_pn_bad_13'>
+          <a class='testlink' href='#test_pn_bad_13'>
+            test_pn_bad_13:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_13' property='mf:name'>syn-bad-pname-13</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_13' property='mf:name'>syn-bad-pname-13</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pn_bad_13' typeof='mf:NegativeSyntaxTest11'>
@@ -1778,10 +1863,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pp_coll'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pp_coll'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pp_coll:
+        <dt id='test_pp_coll'>
+          <a class='testlink' href='#test_pp_coll'>
+            test_pp_coll:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pp_coll' property='mf:name'>syn-pp-in-collection</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pp_coll' property='mf:name'>syn-pp-in-collection</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_pp_coll' typeof='mf:PositiveSyntaxTest11'>
@@ -1798,10 +1884,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_01:
+        <dt id='test_codepoint_escape_01'>
+          <a class='testlink' href='#test_codepoint_escape_01'>
+            test_codepoint_escape_01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_01' property='mf:name'>\U unicode codepoint escaping in literal</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_01' property='mf:name'>\U unicode codepoint escaping in literal</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_01' typeof='mf:PositiveSyntaxTest11'>
@@ -1818,10 +1905,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_02'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_02'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_02:
+        <dt id='test_codepoint_escape_bad_02'>
+          <a class='testlink' href='#test_codepoint_escape_bad_02'>
+            test_codepoint_escape_bad_02:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_02' property='mf:name'>Invalid multi-pass codepoint escaping (\u then \U)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_02' property='mf:name'>Invalid multi-pass codepoint escaping (\u then \U)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_02' typeof='mf:NegativeSyntaxTest11'>
@@ -1838,10 +1926,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_03'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_03'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_03:
+        <dt id='test_codepoint_escape_bad_03'>
+          <a class='testlink' href='#test_codepoint_escape_bad_03'>
+            test_codepoint_escape_bad_03:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_03' property='mf:name'>Invalid multi-pass codepoint escaping (\U then \u)</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_03' property='mf:name'>Invalid multi-pass codepoint escaping (\U then \u)</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_escape_bad_03' typeof='mf:NegativeSyntaxTest11'>
@@ -1858,10 +1947,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_04'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_04'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_04:
+        <dt id='test_codepoint_boundaries_04'>
+          <a class='testlink' href='#test_codepoint_boundaries_04'>
+            test_codepoint_boundaries_04:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_04' property='mf:name'>utf8 literal using codepoints at notable unicode boundaries</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_04' property='mf:name'>utf8 literal using codepoints at notable unicode boundaries</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_04' typeof='mf:PositiveSyntaxTest11'>
@@ -1878,10 +1968,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_escaped_05'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_escaped_05'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_escaped_05:
+        <dt id='test_codepoint_boundaries_escaped_05'>
+          <a class='testlink' href='#test_codepoint_boundaries_escaped_05'>
+            test_codepoint_boundaries_escaped_05:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_escaped_05' property='mf:name'>\U and \u unicode codepoint escaping in literal using codepoints at notable unicode boundaries</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_escaped_05' property='mf:name'>\U and \u unicode codepoint escaping in literal using codepoints at notable unicode boundaries</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_boundaries_escaped_05' typeof='mf:PositiveSyntaxTest11'>
@@ -1898,10 +1989,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_invalid_escaped_bad_06'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_invalid_escaped_bad_06'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_invalid_escaped_bad_06:
+        <dt id='test_codepoint_invalid_escaped_bad_06'>
+          <a class='testlink' href='#test_codepoint_invalid_escaped_bad_06'>
+            test_codepoint_invalid_escaped_bad_06:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_invalid_escaped_bad_06' property='mf:name'>\u unicode codepoint escaping in literal using partial surrogate pair</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_invalid_escaped_bad_06' property='mf:name'>\u unicode codepoint escaping in literal using partial surrogate pair</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_codepoint_invalid_escaped_bad_06' typeof='mf:NegativeSyntaxTest11'>
@@ -1918,10 +2010,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_few'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_few'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_few:
+        <dt id='test_bad_values_too_few'>
+          <a class='testlink' href='#test_bad_values_too_few'>
+            test_bad_values_too_few:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_few' property='mf:name'>Too few values in a VALUE clause compared to the number of variables</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_few' property='mf:name'>Too few values in a VALUE clause compared to the number of variables</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_few' typeof='mf:NegativeSyntaxTest11'>
@@ -1938,10 +2031,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_many'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_many'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_many:
+        <dt id='test_bad_values_too_many'>
+          <a class='testlink' href='#test_bad_values_too_many'>
+            test_bad_values_too_many:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_many' property='mf:name'>Too many values in a VALUE clause compared to the number of variables</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_many' property='mf:name'>Too many values in a VALUE clause compared to the number of variables</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-query/manifest#test_bad_values_too_many' typeof='mf:NegativeSyntaxTest11'>

--- a/sparql/sparql11/syntax-update-1/index.html
+++ b/sparql/sparql11/syntax-update-1/index.html
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Syntax tests Syntax SPARQL Update
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_1'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_1'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_1:
+        <dt id='test_1'>
+          <a class='testlink' href='#test_1'>
+            test_1:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_1' property='mf:name'>syntax-update-01.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_1' property='mf:name'>syntax-update-01.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_1' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -98,10 +99,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_2'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_2'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_2:
+        <dt id='test_2'>
+          <a class='testlink' href='#test_2'>
+            test_2:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_2' property='mf:name'>syntax-update-02.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_2' property='mf:name'>syntax-update-02.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_2' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -118,10 +120,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_3'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_3'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_3:
+        <dt id='test_3'>
+          <a class='testlink' href='#test_3'>
+            test_3:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_3' property='mf:name'>syntax-update-03.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_3' property='mf:name'>syntax-update-03.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_3' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -138,10 +141,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_4'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_4'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_4:
+        <dt id='test_4'>
+          <a class='testlink' href='#test_4'>
+            test_4:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_4' property='mf:name'>syntax-update-04.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_4' property='mf:name'>syntax-update-04.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_4' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -158,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_5'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_5'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_5:
+        <dt id='test_5'>
+          <a class='testlink' href='#test_5'>
+            test_5:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_5' property='mf:name'>syntax-update-05.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_5' property='mf:name'>syntax-update-05.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_5' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -178,10 +183,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_6'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_6'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_6:
+        <dt id='test_6'>
+          <a class='testlink' href='#test_6'>
+            test_6:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_6' property='mf:name'>syntax-update-06.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_6' property='mf:name'>syntax-update-06.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_6' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -198,10 +204,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_7'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_7'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_7:
+        <dt id='test_7'>
+          <a class='testlink' href='#test_7'>
+            test_7:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_7' property='mf:name'>syntax-update-07.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_7' property='mf:name'>syntax-update-07.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_7' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -218,10 +225,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_8'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_8'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_8:
+        <dt id='test_8'>
+          <a class='testlink' href='#test_8'>
+            test_8:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_8' property='mf:name'>syntax-update-08.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_8' property='mf:name'>syntax-update-08.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_8' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -238,10 +246,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_9'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_9'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_9:
+        <dt id='test_9'>
+          <a class='testlink' href='#test_9'>
+            test_9:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_9' property='mf:name'>syntax-update-09.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_9' property='mf:name'>syntax-update-09.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_9' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -258,10 +267,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_10'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_10'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_10:
+        <dt id='test_10'>
+          <a class='testlink' href='#test_10'>
+            test_10:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_10' property='mf:name'>syntax-update-10.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_10' property='mf:name'>syntax-update-10.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_10' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -278,10 +288,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_11'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_11'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_11:
+        <dt id='test_11'>
+          <a class='testlink' href='#test_11'>
+            test_11:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_11' property='mf:name'>syntax-update-11.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_11' property='mf:name'>syntax-update-11.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_11' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -298,10 +309,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_12'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_12'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_12:
+        <dt id='test_12'>
+          <a class='testlink' href='#test_12'>
+            test_12:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_12' property='mf:name'>syntax-update-12.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_12' property='mf:name'>syntax-update-12.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_12' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -318,10 +330,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_13'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_13'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_13:
+        <dt id='test_13'>
+          <a class='testlink' href='#test_13'>
+            test_13:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_13' property='mf:name'>syntax-update-13.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_13' property='mf:name'>syntax-update-13.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_13' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -338,10 +351,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_14'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_14'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_14:
+        <dt id='test_14'>
+          <a class='testlink' href='#test_14'>
+            test_14:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_14' property='mf:name'>syntax-update-14.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_14' property='mf:name'>syntax-update-14.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_14' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -358,10 +372,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_15'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_15'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_15:
+        <dt id='test_15'>
+          <a class='testlink' href='#test_15'>
+            test_15:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_15' property='mf:name'>syntax-update-15.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_15' property='mf:name'>syntax-update-15.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_15' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -378,10 +393,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_16'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_16'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_16:
+        <dt id='test_16'>
+          <a class='testlink' href='#test_16'>
+            test_16:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_16' property='mf:name'>syntax-update-16.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_16' property='mf:name'>syntax-update-16.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_16' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -398,10 +414,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_17'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_17'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_17:
+        <dt id='test_17'>
+          <a class='testlink' href='#test_17'>
+            test_17:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_17' property='mf:name'>syntax-update-17.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_17' property='mf:name'>syntax-update-17.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_17' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -418,10 +435,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_18'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_18'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_18:
+        <dt id='test_18'>
+          <a class='testlink' href='#test_18'>
+            test_18:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_18' property='mf:name'>syntax-update-18.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_18' property='mf:name'>syntax-update-18.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_18' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -438,10 +456,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_19'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_19'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_19:
+        <dt id='test_19'>
+          <a class='testlink' href='#test_19'>
+            test_19:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_19' property='mf:name'>syntax-update-19.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_19' property='mf:name'>syntax-update-19.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_19' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -458,10 +477,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_20'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_20'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_20:
+        <dt id='test_20'>
+          <a class='testlink' href='#test_20'>
+            test_20:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_20' property='mf:name'>syntax-update-20.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_20' property='mf:name'>syntax-update-20.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_20' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -478,10 +498,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_21'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_21'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_21:
+        <dt id='test_21'>
+          <a class='testlink' href='#test_21'>
+            test_21:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_21' property='mf:name'>syntax-update-21.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_21' property='mf:name'>syntax-update-21.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_21' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -498,10 +519,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_22'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_22'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_22:
+        <dt id='test_22'>
+          <a class='testlink' href='#test_22'>
+            test_22:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_22' property='mf:name'>syntax-update-22.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_22' property='mf:name'>syntax-update-22.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_22' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -518,10 +540,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_23'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_23'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_23:
+        <dt id='test_23'>
+          <a class='testlink' href='#test_23'>
+            test_23:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_23' property='mf:name'>syntax-update-23.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_23' property='mf:name'>syntax-update-23.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_23' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -538,10 +561,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_24'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_24'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_24:
+        <dt id='test_24'>
+          <a class='testlink' href='#test_24'>
+            test_24:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_24' property='mf:name'>syntax-update-24.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_24' property='mf:name'>syntax-update-24.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_24' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -558,10 +582,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_25'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_25'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_25:
+        <dt id='test_25'>
+          <a class='testlink' href='#test_25'>
+            test_25:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_25' property='mf:name'>syntax-update-25.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_25' property='mf:name'>syntax-update-25.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_25' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -578,10 +603,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_26'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_26'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_26:
+        <dt id='test_26'>
+          <a class='testlink' href='#test_26'>
+            test_26:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_26' property='mf:name'>syntax-update-26.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_26' property='mf:name'>syntax-update-26.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_26' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -598,10 +624,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_27'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_27'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_27:
+        <dt id='test_27'>
+          <a class='testlink' href='#test_27'>
+            test_27:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_27' property='mf:name'>syntax-update-27.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_27' property='mf:name'>syntax-update-27.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_27' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -618,10 +645,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_28'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_28'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_28:
+        <dt id='test_28'>
+          <a class='testlink' href='#test_28'>
+            test_28:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_28' property='mf:name'>syntax-update-28.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_28' property='mf:name'>syntax-update-28.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_28' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -638,10 +666,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_29'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_29'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_29:
+        <dt id='test_29'>
+          <a class='testlink' href='#test_29'>
+            test_29:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_29' property='mf:name'>syntax-update-29.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_29' property='mf:name'>syntax-update-29.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_29' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -658,10 +687,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_30'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_30'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_30:
+        <dt id='test_30'>
+          <a class='testlink' href='#test_30'>
+            test_30:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_30' property='mf:name'>syntax-update-30.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_30' property='mf:name'>syntax-update-30.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_30' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -678,10 +708,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_31'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_31'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_31:
+        <dt id='test_31'>
+          <a class='testlink' href='#test_31'>
+            test_31:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_31' property='mf:name'>syntax-update-31.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_31' property='mf:name'>syntax-update-31.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_31' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -698,10 +729,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_32'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_32'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_32:
+        <dt id='test_32'>
+          <a class='testlink' href='#test_32'>
+            test_32:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_32' property='mf:name'>syntax-update-32.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_32' property='mf:name'>syntax-update-32.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_32' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -718,10 +750,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_33'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_33'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_33:
+        <dt id='test_33'>
+          <a class='testlink' href='#test_33'>
+            test_33:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_33' property='mf:name'>syntax-update-33.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_33' property='mf:name'>syntax-update-33.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_33' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -738,10 +771,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_34'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_34'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_34:
+        <dt id='test_34'>
+          <a class='testlink' href='#test_34'>
+            test_34:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_34' property='mf:name'>syntax-update-34.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_34' property='mf:name'>syntax-update-34.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_34' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -758,10 +792,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_35'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_35'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_35:
+        <dt id='test_35'>
+          <a class='testlink' href='#test_35'>
+            test_35:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_35' property='mf:name'>syntax-update-35.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_35' property='mf:name'>syntax-update-35.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_35' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -778,10 +813,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_36'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_36'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_36:
+        <dt id='test_36'>
+          <a class='testlink' href='#test_36'>
+            test_36:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_36' property='mf:name'>syntax-update-36.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_36' property='mf:name'>syntax-update-36.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_36' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -798,10 +834,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_37'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_37'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_37:
+        <dt id='test_37'>
+          <a class='testlink' href='#test_37'>
+            test_37:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_37' property='mf:name'>syntax-update-37.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_37' property='mf:name'>syntax-update-37.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_37' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -818,10 +855,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_38'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_38'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_38:
+        <dt id='test_38'>
+          <a class='testlink' href='#test_38'>
+            test_38:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_38' property='mf:name'>syntax-update-38.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_38' property='mf:name'>syntax-update-38.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_38' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -838,10 +876,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_39'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_39'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_39:
+        <dt id='test_39'>
+          <a class='testlink' href='#test_39'>
+            test_39:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_39' property='mf:name'>syntax-update-39.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_39' property='mf:name'>syntax-update-39.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_39' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -858,10 +897,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_40'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_40'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_40:
+        <dt id='test_40'>
+          <a class='testlink' href='#test_40'>
+            test_40:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_40' property='mf:name'>syntax-update-40.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_40' property='mf:name'>syntax-update-40.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_40' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -878,10 +918,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_41'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_41'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_41:
+        <dt id='test_41'>
+          <a class='testlink' href='#test_41'>
+            test_41:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_41' property='mf:name'>syntax-update-bad-01.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_41' property='mf:name'>syntax-update-bad-01.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_41' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -898,10 +939,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_42'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_42'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_42:
+        <dt id='test_42'>
+          <a class='testlink' href='#test_42'>
+            test_42:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_42' property='mf:name'>syntax-update-bad-02.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_42' property='mf:name'>syntax-update-bad-02.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_42' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -918,10 +960,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_43'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_43'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_43:
+        <dt id='test_43'>
+          <a class='testlink' href='#test_43'>
+            test_43:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_43' property='mf:name'>syntax-update-bad-03.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_43' property='mf:name'>syntax-update-bad-03.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_43' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -938,10 +981,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_44'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_44'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_44:
+        <dt id='test_44'>
+          <a class='testlink' href='#test_44'>
+            test_44:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_44' property='mf:name'>syntax-update-bad-04.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_44' property='mf:name'>syntax-update-bad-04.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_44' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -958,10 +1002,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_45'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_45'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_45:
+        <dt id='test_45'>
+          <a class='testlink' href='#test_45'>
+            test_45:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_45' property='mf:name'>syntax-update-bad-05.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_45' property='mf:name'>syntax-update-bad-05.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_45' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -978,10 +1023,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_46'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_46'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_46:
+        <dt id='test_46'>
+          <a class='testlink' href='#test_46'>
+            test_46:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_46' property='mf:name'>syntax-update-bad-06.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_46' property='mf:name'>syntax-update-bad-06.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_46' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -998,10 +1044,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_47'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_47'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_47:
+        <dt id='test_47'>
+          <a class='testlink' href='#test_47'>
+            test_47:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_47' property='mf:name'>syntax-update-bad-07.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_47' property='mf:name'>syntax-update-bad-07.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_47' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -1018,10 +1065,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_48'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_48'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_48:
+        <dt id='test_48'>
+          <a class='testlink' href='#test_48'>
+            test_48:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_48' property='mf:name'>syntax-update-bad-08.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_48' property='mf:name'>syntax-update-bad-08.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_48' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -1038,10 +1086,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_49'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_49'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_49:
+        <dt id='test_49'>
+          <a class='testlink' href='#test_49'>
+            test_49:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_49' property='mf:name'>syntax-update-bad-09.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_49' property='mf:name'>syntax-update-bad-09.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_49' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -1058,10 +1107,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_50'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_50'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_50:
+        <dt id='test_50'>
+          <a class='testlink' href='#test_50'>
+            test_50:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_50' property='mf:name'>syntax-update-bad-10.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_50' property='mf:name'>syntax-update-bad-10.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_50' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -1078,10 +1128,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_51'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_51'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_51:
+        <dt id='test_51'>
+          <a class='testlink' href='#test_51'>
+            test_51:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_51' property='mf:name'>syntax-update-bad-11.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_51' property='mf:name'>syntax-update-bad-11.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_51' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -1098,10 +1149,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_52'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_52'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_52:
+        <dt id='test_52'>
+          <a class='testlink' href='#test_52'>
+            test_52:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_52' property='mf:name'>syntax-update-bad-12.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_52' property='mf:name'>syntax-update-bad-12.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_52' typeof='mf:NegativeUpdateSyntaxTest11'>
@@ -1118,10 +1170,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_53'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_53'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_53:
+        <dt id='test_53'>
+          <a class='testlink' href='#test_53'>
+            test_53:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_53' property='mf:name'>syntax-update-53.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_53' property='mf:name'>syntax-update-53.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_53' typeof='mf:PositiveUpdateSyntaxTest11'>
@@ -1138,10 +1191,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_54'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_54'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_54:
+        <dt id='test_54'>
+          <a class='testlink' href='#test_54'>
+            test_54:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_54' property='mf:name'>syntax-update-54.ru</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_54' property='mf:name'>syntax-update-54.ru</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-1/manifest#test_54' typeof='mf:NegativeUpdateSyntaxTest11'>

--- a/sparql/sparql11/syntax-update-2/index.html
+++ b/sparql/sparql11/syntax-update-2/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         Syntax tests Syntax SPARQL Update
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-2/manifest#syntax-update-other-01'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-2/manifest#syntax-update-other-01'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-2/manifest#syntax-update-other-01:
+        <dt id='syntax-update-other-01'>
+          <a class='testlink' href='#syntax-update-other-01'>
+            syntax-update-other-01:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-2/manifest#syntax-update-other-01' property='mf:name'>syntax-update-other-01</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-2/manifest#syntax-update-other-01' property='mf:name'>syntax-update-other-01</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/syntax-update-2/manifest#syntax-update-other-01' typeof='mf:PositiveUpdateSyntaxTest11'>

--- a/sparql/sparql11/template.haml
+++ b/sparql/sparql11/template.haml
@@ -61,7 +61,7 @@
       %p{property: "rdfs:comment"}
         = Array(man['comment']).join(' ').gsub(/\s+/m, ' ').strip.gsub(/(MUST|SHOULD|MAY)/, '<em class="rfc2119">\\1</em>')
       :markdown
-        This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.
+        This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.
 
         ### Contributing Tests
         The test manifests and entries are built automatically from [manifest.ttl](manifest.ttl) using a Rake task. Tests may be contributed via pull request to [https://github.com/w3c/rdf-tests](https://github.com/w3c/rdf-tests) with suitable changes to the [manifest.ttl](manifest.ttl) and referenced files.

--- a/sparql/sparql11/template.haml
+++ b/sparql/sparql11/template.haml
@@ -89,9 +89,10 @@
           Test Descriptions
         %dl.test-description
           - man['entries'].each do |test|
-            %dt{id: test['@id']}
-              %a.testlink{href: "##{test['@id']}"}
-                = "#{test['@id']}:"
+            %dt{id: test['@id'].split('#').last}
+              %a.testlink{href: "##{test['@id'].split('#').last}"}
+                = "#{test['@id'].split('#').last}:"
+              %span{about: test['@id'], property: "mf:name"}<~test['name']
               %span{about: test['@id'], property: "mf:name"}<~test['name']
             %dd{property: "mf:entry", inlist: true, resource: test['@id'], typeof: test['@type']}
               %div{property: "rdfs:comment"}

--- a/sparql/sparql11/update-silent/index.html
+++ b/sparql/sparql11/update-silent/index.html
@@ -50,7 +50,7 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='' typeof='mf:Manifest'>
+  <body resource='./' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -64,7 +64,7 @@
       <p property='rdfs:comment'>
         The test cases in this manifest comprise cases of erroneous operations which should fail, but succeed because of the keyword SILENT
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.0 test suite.</p>
+      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -78,10 +78,11 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-silent:
+        <dt id='load-silent'>
+          <a class='testlink' href='#load-silent'>
+            load-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-silent' property='mf:name'>LOAD SILENT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-silent' property='mf:name'>LOAD SILENT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-silent' typeof='mf:UpdateEvaluationTest'>
@@ -105,10 +106,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-into-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-into-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-into-silent:
+        <dt id='load-into-silent'>
+          <a class='testlink' href='#load-into-silent'>
+            load-into-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-into-silent' property='mf:name'>LOAD SILENT INTO</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-into-silent' property='mf:name'>LOAD SILENT INTO</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#load-into-silent' typeof='mf:UpdateEvaluationTest'>
@@ -132,10 +134,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-silent:
+        <dt id='clear-silent'>
+          <a class='testlink' href='#clear-silent'>
+            clear-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-silent' property='mf:name'>CLEAR SILENT GRAPH iri</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-silent' property='mf:name'>CLEAR SILENT GRAPH iri</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-silent' typeof='mf:UpdateEvaluationTest'>
@@ -159,10 +162,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-default-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-default-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-default-silent:
+        <dt id='clear-default-silent'>
+          <a class='testlink' href='#clear-default-silent'>
+            clear-default-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-default-silent' property='mf:name'>CLEAR SILENT DEFAULT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-default-silent' property='mf:name'>CLEAR SILENT DEFAULT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#clear-default-silent' typeof='mf:UpdateEvaluationTest'>
@@ -186,10 +190,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#create-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#create-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#create-silent:
+        <dt id='create-silent'>
+          <a class='testlink' href='#create-silent'>
+            create-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#create-silent' property='mf:name'>CREATE SILENT iri</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#create-silent' property='mf:name'>CREATE SILENT iri</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#create-silent' typeof='mf:UpdateEvaluationTest'>
@@ -213,10 +218,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-silent:
+        <dt id='drop-silent'>
+          <a class='testlink' href='#drop-silent'>
+            drop-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-silent' property='mf:name'>DROP SILENT GRAPH iri</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-silent' property='mf:name'>DROP SILENT GRAPH iri</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-silent' typeof='mf:UpdateEvaluationTest'>
@@ -240,10 +246,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-default-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-default-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-default-silent:
+        <dt id='drop-default-silent'>
+          <a class='testlink' href='#drop-default-silent'>
+            drop-default-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-default-silent' property='mf:name'>DROP SILENT DEFAULT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-default-silent' property='mf:name'>DROP SILENT DEFAULT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#drop-default-silent' typeof='mf:UpdateEvaluationTest'>
@@ -267,10 +274,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-silent:
+        <dt id='copy-silent'>
+          <a class='testlink' href='#copy-silent'>
+            copy-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-silent' property='mf:name'>COPY SILENT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-silent' property='mf:name'>COPY SILENT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-silent' typeof='mf:UpdateEvaluationTest'>
@@ -294,10 +302,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-to-default-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-to-default-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-to-default-silent:
+        <dt id='copy-to-default-silent'>
+          <a class='testlink' href='#copy-to-default-silent'>
+            copy-to-default-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-to-default-silent' property='mf:name'>COPY SILENT TO DEFAULT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-to-default-silent' property='mf:name'>COPY SILENT TO DEFAULT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#copy-to-default-silent' typeof='mf:UpdateEvaluationTest'>
@@ -321,10 +330,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-silent:
+        <dt id='move-silent'>
+          <a class='testlink' href='#move-silent'>
+            move-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-silent' property='mf:name'>MOVE SILENT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-silent' property='mf:name'>MOVE SILENT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-silent' typeof='mf:UpdateEvaluationTest'>
@@ -348,10 +358,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-to-default-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-to-default-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-to-default-silent:
+        <dt id='move-to-default-silent'>
+          <a class='testlink' href='#move-to-default-silent'>
+            move-to-default-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-to-default-silent' property='mf:name'>MOVE SILENT TO DEFAULT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-to-default-silent' property='mf:name'>MOVE SILENT TO DEFAULT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#move-to-default-silent' typeof='mf:UpdateEvaluationTest'>
@@ -375,10 +386,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-silent:
+        <dt id='add-silent'>
+          <a class='testlink' href='#add-silent'>
+            add-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-silent' property='mf:name'>ADD SILENT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-silent' property='mf:name'>ADD SILENT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-silent' typeof='mf:UpdateEvaluationTest'>
@@ -402,10 +414,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-to-default-silent'>
-          <a class='testlink' href='#http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-to-default-silent'>
-            http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-to-default-silent:
+        <dt id='add-to-default-silent'>
+          <a class='testlink' href='#add-to-default-silent'>
+            add-to-default-silent:
           </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-to-default-silent' property='mf:name'>ADD SILENT TO DEFAULT</span>
           <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-to-default-silent' property='mf:name'>ADD SILENT TO DEFAULT</span>
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/update-silent/manifest#add-to-default-silent' typeof='mf:UpdateEvaluationTest'>

--- a/sparql/sparql12/grouping/index.html
+++ b/sparql/sparql12/grouping/index.html
@@ -30,7 +30,7 @@
       footer {text-align: center;}
     </style>
     <title>
-      SPARQL 1.1 Federation Extensions
+      Grouping
     </title>
     <style>
       em.rfc2119 {
@@ -50,20 +50,20 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='manifest-sparql11-fed.ttl' typeof='mf:Manifest'>
+  <body resource='../grouping#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
       </a>
     </p>
-    <h1 property='rdfs:label'>SPARQL 1.1 Federation Extensions</h1>
+    <h1 property='rdfs:label'>Grouping</h1>
     <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2010 <a href="http://www.w3.org/"><acronym title="World Wide Web Consortium">W3C</acronym></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="http://www.ercim.org/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
     <hr title='Separator for header'>
     <div>
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
       </p>
-      <p>This page describes W3C SPARQL Working Group's SPARQL1.1 test suite.</p>
+      <p>This page describes SPARQL 1.2 test suite of the W3C RDF-star Working Group.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
       <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
       <h3 id="distribution">Distribution</h3>
@@ -74,16 +74,36 @@
     </div>
     <div>
       <h2>
-        Referenced Manifests
+        Test Descriptions
       </h2>
-      <ul>
-        <li>
-          <a href='service/index.html' inlist='true' property='mf:include'>service/</a>
-        </li>
-        <li>
-          <a href='syntax-fed/index.html' inlist='true' property='mf:include'>syntax-fed/</a>
-        </li>
-      </ul>
+      <dl class='test-description'>
+        <dt id='group01'>
+          <a class='testlink' href='#group01'>
+            group01:
+          </a>
+          <span about='../grouping#group01' property='mf:name'>Group-1</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='../grouping#group01' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+            <p>Grouping with literals</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail' property='mf:action' resource=''>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='group01.srx' property='mf:result'>group01.srx</a>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
     </div>
     <footer>
       <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright ©</a> 2015 <a href="http://www.w3.org/">W3C</a>® (<a href="http://www.csail.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C® <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>

--- a/sparql/sparql12/grouping/manifest.ttl
+++ b/sparql/sparql12/grouping/manifest.ttl
@@ -1,11 +1,11 @@
 @prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix :       <http://www.w3.org/2009/sparql/docs/tests/data-sparql11/grouping/manifest#> .
-@prefix rdfs:	<http://www.w3.org/2000/01/rdf-schema#> .
+@prefix :       <https://w3c.github.io/rdf-tests/sparql/sparql12/grouping#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
 @prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
 
-<>  rdf:type mf:Manifest ;
+:manifest  rdf:type mf:Manifest ;
     rdfs:label "Grouping" ;
     mf:entries
     ( 

--- a/sparql/sparql12/index.html
+++ b/sparql/sparql12/index.html
@@ -1,181 +1,90 @@
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang='en' prefix='dawgt:   http://www.w3.org/2001/sw/DataAccess/tests/test-dawg# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# mfx:    http://jena.hpl.hp.com/2005/05/test-manifest-extra# qt:     http://www.w3.org/2001/sw/DataAccess/tests/test-query# sd:      http://www.w3.org/ns/sparql-service-description# ut:     http://www.w3.org/2009/sparql/tests/test-update#'>
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+    <meta content='width=device-width, initial-scale=1.0' name='viewport'>
+    <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' type='text/css'>
     <style>
-*{margin:0;padding:0;}
-body {
-	font: 12px arial, helvetica,arial,freesans,clean,sans-serif;
-	color:black;
-	line-height:1.4em;
-	background-color: #F8F8F8;
-	padding: 0em 2em;
-}
-
-table {
-	font-size:inherit;
-	font:100%;
-	margin:1em;
-}
-
-p {
-	margin-bottom: 1em;
-}
-
-td {  
-  padding-left: 0.3em;
-}
-
-th {  
-  font-weight: bold;  
-  text-align: center;  
-  background-color: NavyBlue !important; 
-  font-size: 110%;
-  background: hsl(180, 30%, 50%); 
-  color: #fff;
-}
-
-th a:link {
-  color: #fff;
-}
-
-th a:visited {
-  color: #aaa;
-}
-
-tr:nth-child(even) { background-color: hsl(180, 30%, 93%) }
-
-table th{border-bottom:1px solid #bbb;padding:.2em 1em;}
-table td{border-bottom:1px solid #ddd;padding:.2em 1em;}
-
-
-select,option{padding:0 .25em;}
-optgroup{margin-top:.5em;}
-
-pre,code{font:12px Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;}
-pre {
-	margin:1em 0;
-	background-color:#eee;
-	border:1px solid #ddd;
-	padding:5px;
-	line-height:1.5em;
-	color:#444;
-	overflow:auto;
-	-webkit-box-shadow:rgba(0,0,0,0.07) 0 1px 2px inset;
-	-webkit-border-radius:3px;
-	-moz-border-radius:3px;border-radius:3px;
-}
-pre code {
-	padding:0;
-	font-size:10px;
-	background-color:#eee;
-	border:none;
-}
-code {
-	background-color:#f8f8ff;
-	color:#444;
-	padding:0 .2em;
-	border:1px solid #dedede;
-}
-
-img{border:0;max-width:100%;}
-abbr{border-bottom:none;}
-
-a{color:#4183c4;}
-
-a:link, a:active {
-  background: transparent;
-  text-decoration:none;
-}
-
-a:visited {
-  color: #529;
-  background: transparent;
-}
-
-a:hover{background-color: yellow; color: #00e;}
-
-a code,a:link code,a:visited code{color:#4183c4;}
-
-a:link img, a:visited img {
-   border-style: none
-}
-
-h1, h2, h3, h4, h5, h6
-{
-	margin-bottom: 0.5em;
-	margin-top: 1em;
-	padding-bottom: 0.15em;
-	border-bottom: 1px solid #ccc;
-	background: transparent;
-	color: #005a9c;
-	font-weight: normal;
-}
-
-h1
-{
-	border-bottom: none;
-	background: transparent;
-	/* color: #000; */
-}
-
-h4, h5, h6 {border: none;}
-
-
-hr{border:1px solid #ddd;}
-
-ul{margin:1em 0 1em 2em;}
-ol{margin:1em 0 1em 2em;}
-ul li,ol li{
-	margin-bottom:.1em;
-}
-ul ul,ul ol,ol ol,ol ul{margin-top:0;margin-bottom:0;}
-
-ul.toc {
-  list-style: disc;
-  list-style: none;
-}
-
-blockquote{margin:1em 0;border-left:5px solid #ddd;padding-left:.6em;color:#555;}
-dt{font-weight:bold;margin-left:1em;}
-dd{margin-left:2em;margin-bottom:1em;}
-sup {
-    font-size: 0.83em;
-    vertical-align: super;
-    line-height: 0;
-}
-* {
-	-webkit-print-color-adjust: exact;
-}
-
-em.rfc2119 { 
-  text-transform: lowercase;
-  font-variant:   small-caps;
-  font-style:     normal;
-  color:          #900;
-}
-
-@media print {
-	table, pre {
-		page-break-inside: avoid;
-	}
-	pre {
-		word-wrap: break-word;
-	}
-}
+      body: {bacground-image: none;}
+      dl.editor>dd {
+        margin: 0 0 0 40px;
+      }
+      dl.test-detail {
+        padding: 0.5em;
+      }
+      dl.test-detail>dt {
+        float: left;
+        clear: left;
+        text-align: right;
+        font-weight: bold;
+        color: green;
+      }
+      dl.test-detail>dt:after {content: ": "}
+      dl.test-detail>dd {
+        margin: 0 0 0 110px;
+        padding: 0 0 0.5em 0;
+      }
+      dl.test-description>dt {margin-top: 2em;}
+      dd {margin-left: 0;}
+      dd code {display: inline;}
+      footer {text-align: center;}
     </style>
-    <title>SPARQL 1.2 Tests</title>
+    <title>
+      SPARQL 1.2 tests
+    </title>
+    <style>
+      em.rfc2119 {
+        text-transform: lowercase;
+        font-variant:   small-caps;
+        font-style:     normal;
+        color:          #900;
+      }
+      a.testlink {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.testlink:hover {
+        text-decoration: underline;
+      }
+      .warning {color: orange;}
+      .error {color: red;}
+    </style>
   </head>
-  <body>
-
-      <h1 id="sparql-12">SPARQL 1.2 Tests</h1>
-
-      <p>rdf-test area reserved for SPARQL 1.2.
-        This will be based on the work of the 
-        <a href="https://www.w3.org/2022/08/rdf-star-wg-charter/"
-           >RDF-star Working Group</a>.
+  <body resource='../sparql12#manifest' typeof='mf:Manifest'>
+    <p>
+      <a href='http://www.w3.org/'>
+        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
+      </a>
+    </p>
+    <h1 property='rdfs:label'>SPARQL 1.2 tests</h1>
+    <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2010 <a href="http://www.w3.org/"><acronym title="World Wide Web Consortium">W3C</acronym></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="http://www.ercim.org/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+    <hr title='Separator for header'>
+    <div>
+      <h2 id='abstract'>Abstract</h2>
+      <p property='rdfs:comment'>
+        <p>These test suites are a product of the <a href="">W3C RDF-star Working Group</a> as well as the RDF-star Interest Group within the W3C RDF-DEV Community Group, and has been maintained by the <a href="https://www.w3.org/community/rdf-tests/">RDF Test Curation Community Group</a> at <a href="https://github.com/w3c/rdf-tests/tree/main/sparql/sparql12/">https://github.com/w3c/rdf-tests/tree/main/sparql/sparql12</a>. Conformance with SPARQL 1.2 specifications can be determined via successfully running the tests for relevant specifications along with the relevant SPARQL 1.1 tests.</p>
       </p>
-    
+      <p>This page describes SPARQL 1.2 test suite of the W3C RDF-star Working Group.</p>
+      <h3 id="contributing-tests">Contributing Tests</h3>
+      <p>The test manifests and entries are built automatically from <a href="manifest.ttl">manifest.ttl</a> using a Rake task. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-tests">https://github.com/w3c/rdf-tests</a> with suitable changes to the <a href="manifest.ttl">manifest.ttl</a> and referenced files.</p>
+      <h3 id="distribution">Distribution</h3>
+      <p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
+      <h3 id="disclaimer">Disclaimer</h3>
+      <p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+        COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+    </div>
+    <div>
+      <h2>
+        Referenced Manifests
+      </h2>
+      <ul>
+        <li>
+          <a href='grouping/index.html' inlist='true' property='mf:include'>grouping/</a>
+        </li>
+      </ul>
+    </div>
+    <footer>
+      <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright ©</a> 2015 <a href="http://www.w3.org/">W3C</a>® (<a href="http://www.csail.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C® <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+    </footer>
   </body>
 </html>

--- a/sparql/sparql12/manifest.ttl
+++ b/sparql/sparql12/manifest.ttl
@@ -5,7 +5,7 @@ PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
-PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/sparql/sparql12#>
 PREFIX dct:    <http://purl.org/dc/terms/>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
 PREFIX foaf:   <http://xmlns.com/foaf/0.1/>

--- a/sparql/sparql12/template.haml
+++ b/sparql/sparql12/template.haml
@@ -90,9 +90,9 @@
           Test Descriptions
         %dl.test-description
           - man['entries'].each do |test|
-            %dt{id: test['@id']}
-              %a.testlink{href: "##{test['@id']}"}
-                = "#{test['@id']}:"
+            %dt{id: test['@id'].split('#').last}
+              %a.testlink{href: "##{test['@id'].split('#').last}"}
+                = "#{test['@id'].split('#').last}:"
               %span{about: test['@id'], property: "mf:name"}<~test['name']
             %dd{property: "mf:entry", inlist: true, resource: test['@id'], typeof: test['@type']}
               %div{property: "rdfs:comment"}

--- a/sparql/sparql12/template.haml
+++ b/sparql/sparql12/template.haml
@@ -29,7 +29,7 @@
       dd code {display: inline;}
       footer {text-align: center;}
     %title
-      = man['label']
+      = man['label'].is_a?(Hash) ? man['label']['@value'] : man['label']
     :css
       em.rfc2119 { 
         text-transform: lowercase;
@@ -51,7 +51,7 @@
     %p
       %a{href: "http://www.w3.org/"}
         %img{src: "http://www.w3.org/Icons/w3c_home", alt: "W3C", height: 48, width: 72}
-    %h1{property: "rdfs:label"}<= man['label']
+    %h1{property: "rdfs:label"}<= man['label'].is_a?(Hash) ? man['label']['@value'] : man['label']
     :markdown
       [Copyright](http://www.w3.org/Consortium/Legal/ipr-notice#Copyright) © 2010 [<acronym title="World Wide Web Consortium">W3C</acronym>](http://www.w3.org/)<sup>®</sup> ([<acronym title="Massachusetts Institute of Technology">MIT</acronym>](http://www.csail.mit.edu/), [<acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym>](http://www.ercim.org/), [Keio](http://www.keio.ac.jp/)), All Rights Reserved. W3C [liability](http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer), [trademark](http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks), and [document use](http://www.w3.org/Consortium/Legal/copyright-documents) rules apply.
     %hr{title: "Separator for header"}
@@ -59,7 +59,8 @@
     %div
       %h2{id: "abstract"}="Abstract"
       %p{property: "rdfs:comment"}
-        = Array(man['comment']).join(' ').gsub(/\s+/m, ' ').strip.gsub(/(MUST|SHOULD|MAY)/, '<em class="rfc2119">\\1</em>')
+        :markdown
+          #{Array(man['comment']).join(' ').gsub(/\s+/m, ' ').strip.gsub(/(MUST|SHOULD|MAY)/, '<em class="rfc2119">\\1</em>')}
       :markdown
         This page describes SPARQL 1.2 test suite of the W3C RDF-star Working Group.
 


### PR DESCRIPTION
* Account for language in label for SPARQL 1.2 manifest and name SPARQL 1.1 tests as being 1.1. not 1.0.
* Shorten test identifiers in generated index.html for SPARQL manifests.
