### PR TITLE
adds NoCanonicalizationOfNumerics requirement to group01

### DIFF
--- a/sparql/sparql12/grouping/manifest.ttl
+++ b/sparql/sparql12/grouping/manifest.ttl
@@ -21,4 +21,5 @@
          [ qt:query  <group01.rq> ;
            qt:data   <group-data-1.ttl> ] ;
     mf:result  <group01.srx>
+    mf:requires mf:NoCanonicalizationOfNumerics
     .


### PR DESCRIPTION
Adds the newly introduced `mf:NoCanonicalizationOfNumerics` requirement (see PR #123) to the `group01` test in the SPARQL 1.2 test suite, as suggested by @kasei in https://github.com/w3c/rdf-tests/pull/122#issuecomment-1834651276