### PR TITLE
Covers AVG behavior with empty groups

### DIFF
--- a/sparql/sparql11/aggregates/agg-avg-03.rq
+++ b/sparql/sparql11/aggregates/agg-avg-03.rq
@@ -1,0 +1,2 @@
+SELECT (AVG(?o) AS ?avg)
+WHERE { ?s ?p ?o }

--- a/sparql/sparql11/aggregates/agg-avg-03.srx
+++ b/sparql/sparql11/aggregates/agg-avg-03.srx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="avg"/>
+  </head>
+  <results>
+    <result>
+      <binding name="avg">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">0</literal>
+      </binding>
+    </result>
+  </results>
+</sparql>

--- a/sparql/sparql11/aggregates/manifest.ttl
+++ b/sparql/sparql11/aggregates/manifest.ttl
@@ -30,6 +30,7 @@
     :agg-sum-02
     :agg-avg-01
     :agg-avg-02
+    :agg-avg-03
     :agg-min-01
     :agg-min-02
     :agg-max-01
@@ -233,6 +234,14 @@
          [ qt:query  <agg-avg-02.rq> ;
            qt:data   <agg-numeric2.ttl> ] ;
     mf:result  <agg-avg-02.srx>
+    .
+
+:agg-avg-03 rdf:type mf:QueryEvaluationTest ;
+    mf:name    "AVG with empty group (value defined to be 0)" ;
+	mf:feature sparql:avg ;
+    mf:action
+         [ qt:query  <agg-avg-03.rq> ] ;
+    mf:result  <agg-avg-03.srx>
     .
 
 :agg-min-01 rdf:type mf:QueryEvaluationTest ;


### PR DESCRIPTION
SPARQL 1.1: "If Count(S) = 0, then Avg(S) = "0"^^xsd:integer."