### PR TITLE
SPARQL 1.1: Covers GROUP_CONCAT behavior with language tags

### DIFF
--- a/sparql/sparql11/aggregates/agg-groupconcat-4.rq
+++ b/sparql/sparql11/aggregates/agg-groupconcat-4.rq
@@ -1,0 +1,7 @@
+PREFIX : <http://www.example.org/>
+ASK {
+	{SELECT (GROUP_CONCAT(?o) AS ?g) WHERE {
+		VALUES ?o { "1"@en "2"@en }
+	}}
+	FILTER(?g = "1 2"@en || ?g = "2 1"@en)
+}

--- a/sparql/sparql11/aggregates/agg-groupconcat-4.srx
+++ b/sparql/sparql11/aggregates/agg-groupconcat-4.srx
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head/>
+  <boolean>true</boolean>
+</sparql>

--- a/sparql/sparql11/aggregates/agg-groupconcat-5.rq
+++ b/sparql/sparql11/aggregates/agg-groupconcat-5.rq
@@ -1,0 +1,7 @@
+PREFIX : <http://www.example.org/>
+ASK {
+	{SELECT (GROUP_CONCAT(?o) AS ?g) WHERE {
+		VALUES ?o { "1"@en "2"@fr }
+	}}
+	FILTER(?g = "1 2" || ?g = "2 1")
+}

--- a/sparql/sparql11/aggregates/agg-groupconcat-5.srx
+++ b/sparql/sparql11/aggregates/agg-groupconcat-5.srx
@@ -1,0 +1,7 @@
+PREFIX : <http://www.example.org/>
+ASK {
+	{SELECT (GROUP_CONCAT(?o) AS ?g) WHERE {
+		VALUES ?o { "1"@en "2"@fr }
+	}}
+	FILTER(?g = "1 2" || ?g = "2 1")
+}

--- a/sparql/sparql11/aggregates/agg-groupconcat-5.srx
+++ b/sparql/sparql11/aggregates/agg-groupconcat-5.srx
@@ -1,7 +1,5 @@
-PREFIX : <http://www.example.org/>
-ASK {
-	{SELECT (GROUP_CONCAT(?o) AS ?g) WHERE {
-		VALUES ?o { "1"@en "2"@fr }
-	}}
-	FILTER(?g = "1 2" || ?g = "2 1")
-}
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+	<head/>
+	<boolean>true</boolean>
+</sparql>

--- a/sparql/sparql11/aggregates/index.html
+++ b/sparql/sparql11/aggregates/index.html
@@ -481,6 +481,58 @@
             </dd>
           </dl>
         </dd>
+        <dt id='agg-groupconcat-04'>
+          <a class='testlink' href='#agg-groupconcat-04'>
+            agg-groupconcat-04:
+          </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-04' property='mf:name'>GROUP_CONCAT with same language tag</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-04' property='mf:name'>GROUP_CONCAT with same language tag</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-04' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail' property='mf:action' resource=''>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='agg-groupconcat-4.srx' property='mf:result'>agg-groupconcat-4.srx</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='agg-groupconcat-05'>
+          <a class='testlink' href='#agg-groupconcat-05'>
+            agg-groupconcat-05:
+          </a>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-05' property='mf:name'>GROUP_CONCAT with different language tags</span>
+          <span about='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-05' property='mf:name'>GROUP_CONCAT with different language tags</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-groupconcat-05' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail' property='mf:action' resource=''>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='agg-groupconcat-5.srx' property='mf:result'>agg-groupconcat-5.srx</a>
+            </dd>
+          </dl>
+        </dd>
         <dt id='agg-sum-01'>
           <a class='testlink' href='#agg-sum-01'>
             agg-sum-01:

--- a/sparql/sparql11/aggregates/manifest.ttl
+++ b/sparql/sparql11/aggregates/manifest.ttl
@@ -26,6 +26,8 @@
     :agg-groupconcat-01
     :agg-groupconcat-02
     :agg-groupconcat-03
+    :agg-groupconcat-04
+    :agg-groupconcat-05
     :agg-sum-01
     :agg-sum-02
     :agg-avg-01
@@ -211,6 +213,21 @@
          [ qt:query  <agg-groupconcat-3.rq> ;
            qt:data   <agg-groupconcat-1.ttl> ] ;
     mf:result  <agg-groupconcat-3.srx>
+    .
+
+:agg-groupconcat-04 rdf:type mf:QueryEvaluationTest ;
+    mf:name    "GROUP_CONCAT with same language tag" ;
+	mf:feature sparql:group_concat ;
+    mf:action
+         [ qt:query  <agg-groupconcat-4.rq> ] ;
+    mf:result  <agg-groupconcat-4.srx>
+    .
+:agg-groupconcat-05 rdf:type mf:QueryEvaluationTest ;
+    mf:name    "GROUP_CONCAT with different language tags" ;
+	mf:feature sparql:group_concat ;
+    mf:action
+         [ qt:query  <agg-groupconcat-5.rq> ] ;
+    mf:result  <agg-groupconcat-5.srx>
     .
 
 :agg-avg-01 rdf:type mf:QueryEvaluationTest ;


### PR DESCRIPTION
GROUP_CONCAT is defined on top of CONCAT and CONCAT has a well-defined behavior with language tag in RDF 1.1