### PR TITLE
Add syntax tests for codepoint escaping.

### DIFF
--- a/sparql/sparql12/manifest.ttl
+++ b/sparql/sparql12/manifest.ttl
@@ -33,6 +33,7 @@ trs:manifest  rdf:type mf:Manifest ;
   """;
   mf:include (
     <grouping/manifest.ttl>
+    <syntax-escaping/manifest.ttl>
     <syntax-triple-terms-negative/manifest.ttl>
     <syntax-triple-terms-positive/manifest.ttl>
   ) .

--- a/sparql/sparql12/syntax-escaping/codepoint-esc-01.rq
+++ b/sparql/sparql12/syntax-escaping/codepoint-esc-01.rq
@@ -1,0 +1,7 @@
+SELECT * WHERE {
+	?s ?p "\\u000Z"
+}
+
+# \u000Z is an invalid escape sequence. It should either: be left as-is
+# as it does not match the escape syntax of `\u HEX HEX HEX HEX`; or
+# seen as a syntax error.

--- a/sparql/sparql12/syntax-escaping/codepoint-esc-02.rq
+++ b/sparql/sparql12/syntax-escaping/codepoint-esc-02.rq
@@ -1,0 +1,8 @@
+PREFIX ns: <http://example.org/>
+SELECT * WHERE {
+	?s ?p ns:id\u005c=123
+}
+
+# the escape here produces '\' REVERSE SOLIDUS (U+5C)
+# its unescaping must lead to a Prefixed Name ns:id\=123 using an escaped
+# equals sign (U+3D), representing the IRI <http://example.org/id=123>.

--- a/sparql/sparql12/syntax-escaping/codepoint-esc-03.rq
+++ b/sparql/sparql12/syntax-escaping/codepoint-esc-03.rq
@@ -1,0 +1,5 @@
+SELECT * WHERE {
+	?s ?p "\\u0041"
+}
+# Legal codepoint escape of LATIN CAPITAL LETTER A (U+41), resulting in an
+# invalid backslash escape \A.

--- a/sparql/sparql12/syntax-escaping/codepoint-esc-04.rq
+++ b/sparql/sparql12/syntax-escaping/codepoint-esc-04.rq
@@ -1,0 +1,5 @@
+SELECT * WHERE {
+	?s ?p "\\u0074"
+}
+# Legal codepoint escape of LATIN SMALL LETTER T (U+74), resulting in a
+# valid backslash escape \t for CHARACTER TABULATION (U+9).

--- a/sparql/sparql12/syntax-escaping/codepoint-esc-05.rq
+++ b/sparql/sparql12/syntax-escaping/codepoint-esc-05.rq
@@ -1,0 +1,5 @@
+SELECT * WHERE {
+	?s ?p "\u005C\u005Cn"
+}
+# Two legal codepoint escapes of REVERSE SOLIDUS (U+5C), resulting in a
+# valid backslash escape \\ for REVERSE SOLIDUS (U+5C) followed by 'n'.

--- a/sparql/sparql12/syntax-escaping/codepoint-esc-06.rq
+++ b/sparql/sparql12/syntax-escaping/codepoint-esc-06.rq
@@ -1,0 +1,8 @@
+PREFIX og: <http://ogp.me/ns#>
+SELECT * WHERE {
+	?page og:audio\u00253Atitle ?title
+}
+
+# the escape here produces '%' PERCENT SIGN (U+25)
+# its unescaping must lead to a Prefixed Name og:audio%3Atitle which includes
+# the percent-encoding %3A (COLON).

--- a/sparql/sparql12/syntax-escaping/codepoint-esc-07.rq
+++ b/sparql/sparql12/syntax-escaping/codepoint-esc-07.rq
@@ -1,0 +1,7 @@
+SELECT\u0020*\U00000009WHERE {
+	?s ?p "value"
+}
+
+# the escapes here produce whitespace -- SPACESPACE (U+20) and
+# CHARACTER TABULATION (U+9) -- surrounding the `*` token in the
+# SELECT projection.

--- a/sparql/sparql12/syntax-escaping/codepoint-esc-08.rq
+++ b/sparql/sparql12/syntax-escaping/codepoint-esc-08.rq
@@ -1,0 +1,6 @@
+SELECT * WHERE {
+	?s ?p \u0022value"
+}
+
+# the escape here produces QUOTATION MARK (U+22)
+# its unescaping must lead to the literal 'value'.

--- a/sparql/sparql12/syntax-escaping/codepoint-esc-09.rq
+++ b/sparql/sparql12/syntax-escaping/codepoint-esc-09.rq
@@ -1,0 +1,3 @@
+\u0041\u0053\u004B\u0020\u007B\u007D
+
+# The query `ASK {}` entirely encoded using codepoint escapes.

--- a/sparql/sparql12/syntax-escaping/codepoint-esc-10.rq
+++ b/sparql/sparql12/syntax-escaping/codepoint-esc-10.rq
@@ -1,0 +1,11 @@
+SELECT * WHERE {
+	?s ?p "\\u000\u241e"
+}
+
+# \u000\ is an invalid escape sequence, while \u241e is a valid sequence.
+# The interpretation here depends on whether the entire six-character sequence `\u000\`
+# is consumed during parsing/tokenizing and left as-is (or raised as an error),
+# or whether the final character is recognized as the first character of a valid
+# codepoint escape sequence. If the latter, the unescaping should result in a
+# six-codepoint literal whose five-character prefix is "\u000", followed by
+# SYMBOL FOR RECORD SEPARATOR (U+241E).

--- a/sparql/sparql12/syntax-escaping/manifest.ttl
+++ b/sparql/sparql12/syntax-escaping/manifest.ttl
@@ -1,0 +1,81 @@
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix :       <https://w3c.github.io/rdf-tests/sparql/sparql12/escaping#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
+@prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
+
+:manifest  rdf:type mf:Manifest ;
+    rdfs:label "SPARQL Codepoint-Escaping Tests" ;
+    mf:entries
+    ( 
+    :codepoint-esc-01
+    :codepoint-esc-02
+    :codepoint-esc-03
+    :codepoint-esc-04
+    :codepoint-esc-05
+    :codepoint-esc-06
+    :codepoint-esc-07
+    :codepoint-esc-08
+    :codepoint-esc-09
+    :codepoint-esc-10
+    ) .
+
+
+:codepoint-esc-01 rdf:type   mf:PositiveSyntaxTest ; # TODO: depends on decision on handling of invalid escapes
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "codepoint-esc-01.rq" ;
+   rdfs:comment   "invalid codepoint escape (requires handling codepoint escaping before backslash escaping)" ;
+   mf:action      <codepoint-esc-01.rq> .
+
+:codepoint-esc-02 rdf:type   mf:PositiveSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "codepoint-esc-02.rq" ;
+   rdfs:comment   "codepoint escape for the backslash of a PN_LOCAL_ESC in the PN_LOCAL part of a PrefixedName" ;
+   mf:action      <codepoint-esc-02.rq> .
+
+:codepoint-esc-03 rdf:type   mf:NegativeSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "codepoint-esc-03.rq" ;
+   rdfs:comment   "codepoint escape that results in an invalid backslash escape (requires handling codepoint escaping before backslash escaping)" ;
+   mf:action      <codepoint-esc-03.rq> .
+
+:codepoint-esc-04 rdf:type   mf:PositiveSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "codepoint-esc-04.rq" ;
+   rdfs:comment   "codepoint escape that results in a valid backslash escape" ;
+   mf:action      <codepoint-esc-04.rq> .
+
+:codepoint-esc-05 rdf:type   mf:PositiveSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "codepoint-esc-05.rq" ;
+   mf:action      <codepoint-esc-05.rq> .
+
+:codepoint-esc-06 rdf:type   mf:PositiveSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "codepoint-esc-06.rq" ;
+   rdfs:comment   "codepoint escape for the percent sign in the PL_LOCAL part of a PrefixedName" ;
+   mf:action      <codepoint-esc-06.rq> .
+
+:codepoint-esc-07 rdf:type   mf:PositiveSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "codepoint-esc-07.rq" ;
+   rdfs:comment   "codepoint escape for whitespace separating the projection tokens: SELECT * WHERE" ;
+   mf:action      <codepoint-esc-07.rq> .
+
+:codepoint-esc-08 rdf:type   mf:PositiveSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "codepoint-esc-08.rq" ;
+   rdfs:comment   "codepoint escape for the starting double-quote of a literal" ;
+   mf:action      <codepoint-esc-08.rq> .
+
+:codepoint-esc-09 rdf:type   mf:PositiveSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "codepoint-esc-09.rq" ;
+   mf:action      <codepoint-esc-09.rq> .
+
+:codepoint-esc-10 rdf:type   mf:PositiveSyntaxTest ; # TODO: depends on decision on handling of invalid escapes
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "codepoint-esc-10.rq" ;
+   rdfs:comment   "overlapping codepoint escapes" ;
+   mf:action      <codepoint-esc-10.rq> .


### PR DESCRIPTION
Adds new tests for some interesting cases of unicode codepoint escaping, addressing w3c/sparql-query#164. Two tests (codepoint-esc-01 and codepoint-esc-10) are marked in the manifest with `TODO` markers as being dependent on decisions on how systems should handle invalid escape sequences. I believe the others are accurately test the existing spec text of SPARQL 1.1.

I think many of these cases should also be turned into evaluation tests, to ensure the unescaping is being performed correctly, but I'll leave that for another PR (or a subsequent update to this PR).