### PR TITLE
SPARQL 1.0: cover "GRAPH ?g {}" case

### DIFF
--- a/sparql/sparql10/graph/graph-empty.rq
+++ b/sparql/sparql10/graph/graph-empty.rq
@@ -1,0 +1,1 @@
+SELECT * { GRAPH ?g {} }

--- a/sparql/sparql10/graph/graph-empty.ttl
+++ b/sparql/sparql10/graph/graph-empty.ttl
@@ -1,0 +1,13 @@
+@prefix rs:      <http://www.w3.org/2001/sw/DataAccess/tests/result-set#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+[]    rdf:type      rs:ResultSet ;
+      rs:resultVariable  "g" ;
+      rs:solution   [ rs:binding    [ rs:value      <data-g1.ttl> ;
+                                      rs:variable   "g"
+                                    ]
+                    ] ;
+      rs:solution   [ rs:binding    [ rs:value      <data-g2.ttl> ;
+                                      rs:variable   "g"
+                                    ]
+                    ] .

--- a/sparql/sparql10/graph/index.html
+++ b/sparql/sparql10/graph/index.html
@@ -375,6 +375,33 @@
             </dd>
           </dl>
         </dd>
+        <dt id='graph-empty'>
+          <a class='testlink' href='#graph-empty'>
+            graph-empty:
+          </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#graph-empty' property='mf:name'>graph-empty</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#graph-empty' property='mf:name'>graph-empty</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/graph/manifest#graph-empty' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+            <p>Graph with empty BGP: list all named graphs</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail'>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='graph-empty.ttl' property='mf:result'>graph-empty.ttl</a>
+            </dd>
+          </dl>
+        </dd>
       </dl>
     </div>
     <footer>

--- a/sparql/sparql10/graph/manifest.ttl
+++ b/sparql/sparql10/graph/manifest.ttl
@@ -21,6 +21,7 @@
 	:dawg-graph-09
 	:dawg-graph-10b
 	:dawg-graph-11
+	:graph-empty
    ).
 
 :dawg-graph-01  rdf:type mf:QueryEvaluationTest ;
@@ -165,3 +166,14 @@
     mf:result  <graph-11.ttl> ;
     .
 
+:graph-empty  rdf:type mf:QueryEvaluationTest ;
+    mf:name "graph-empty" ;
+    rdfs:comment  "Graph with empty BGP: list all named graphs" ;
+    mf:action
+            [ qt:query        <graph-empty.rq> ;
+              qt:data         <data-g1.ttl> ;
+              qt:graphData    <data-g1.ttl> ;
+              qt:graphData    <data-g2.ttl> ;
+            ] ;
+    mf:result  <graph-empty.ttl> ;
+    .


### PR DESCRIPTION
It should list all named graphs.
We did not have any test of GRAPH with an empty BGP.