### PR TITLE
Cover xsd:dateTime equality and ordering

### DIFF
--- a/sparql/sparql10/expr-equals/data-eq-dateTime.ttl
+++ b/sparql/sparql10/expr-equals/data-eq-dateTime.ttl
@@ -1,0 +1,14 @@
+@prefix    :        <http://example.org/things#> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+
+:xi1 :pl "1"^^xsd:integer ; :pr "2008-04-01T00:00:00Z"^^xsd:dateTime .
+:xb1 :pl "true"^^xsd:boolean ; :pr "2008-04-01T00:00:00Z"^^xsd:dateTime .
+:xs1 :pl "2008-04-01T00:00:00Z" ; :pr "2008-04-01T00:00:00Z"^^xsd:dateTime .
+
+:d1 :pl "2008-04-01T00:00:00Z"^^xsd:dateTime ; :pr "2008-04-01T00:00:00Z"^^xsd:dateTime . # true
+:d2 :pl "2002-04-02T12:00:00"^^xsd:dateTime ; :pr "2002-04-02T12:00:00"^^xsd:dateTime . # true
+:d3 :pl "2002-04-02T23:00:00-04:00"^^xsd:dateTime ; :pr "2002-04-03T02:00:00-01:00"^^xsd:dateTime . # true
+:d4 :pl "2002-04-02T23:00:00"^^xsd:dateTime ; :pr "2002-04-02T23:00:00+06:00"^^xsd:dateTime . # false
+:d5 :pl "1999-12-31T24:00:00"^^xsd:dateTime ; :pr "2000-01-01T00:00:00"^^xsd:dateTime . # true
+:d6 :pl "2005-04-04T24:00:00"^^xsd:dateTime ; :pr "2005-04-04T00:00:00"^^xsd:dateTime . # false
+:d7 :pl "2008-04-01T00:00:00.00Z"^^xsd:dateTime ; :pr "2008-04-01T00:00:00Z"^^xsd:dateTime . # true

--- a/sparql/sparql10/expr-equals/index.html
+++ b/sparql/sparql10/expr-equals/index.html
@@ -456,6 +456,33 @@
             </dd>
           </dl>
         </dd>
+        <dt id='eq-dateTime'>
+          <a class='testlink' href='#eq-dateTime'>
+            eq-dateTime:
+          </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-dateTime' property='mf:name'>Equality with dateTime</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-dateTime' property='mf:name'>Equality with dateTime</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-equals/manifest#eq-dateTime' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+            <p>= with dateTime</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail'>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='result-eq-dateTime.ttl' property='mf:result'>result-eq-dateTime.ttl</a>
+            </dd>
+          </dl>
+        </dd>
       </dl>
     </div>
     <footer>

--- a/sparql/sparql10/expr-equals/manifest.ttl
+++ b/sparql/sparql10/expr-equals/manifest.ttl
@@ -12,7 +12,7 @@
     ( 
         :eq-1 :eq-2 :eq-3 :eq-4 :eq-5 :eq-2-1 :eq-2-2
         :eq-graph-1 :eq-graph-2 :eq-graph-3 :eq-graph-4 :eq-graph-5
-        :eq-float :eq-bool
+        :eq-float :eq-bool :eq-dateTime
     ).
 
 :eq-1 a mf:QueryEvaluationTest ;
@@ -157,4 +157,11 @@
               qt:data   <data-eq-bool.ttl>  ] ;
          mf:result  <result-eq-bool.ttl>
       .
-
+:eq-dateTime a mf:QueryEvaluationTest ;
+        rdfs:comment "= with dateTime" ;
+         mf:name    "Equality with dateTime" ;
+         mf:action
+            [ qt:query  <query-eq-dateTime.rq> ;
+              qt:data   <data-eq-dateTime.ttl>  ] ;
+         mf:result  <result-eq-dateTime.ttl>
+      .

--- a/sparql/sparql10/expr-equals/query-eq-dateTime.rq
+++ b/sparql/sparql10/expr-equals/query-eq-dateTime.rq
@@ -1,0 +1,7 @@
+PREFIX  xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX  : <http://example.org/things#>
+SELECT  ?x
+WHERE
+    { ?x :pr ?vr ; :pl ?vl .
+      FILTER ( ?vr = ?vl )  .
+    }

--- a/sparql/sparql10/expr-equals/result-eq-dateTime.ttl
+++ b/sparql/sparql10/expr-equals/result-eq-dateTime.ttl
@@ -1,0 +1,32 @@
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix rs:      <http://www.w3.org/2001/sw/DataAccess/tests/result-set#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix :        <http://example.org/things#> .
+
+[]    rdf:type    rs:ResultSet ;
+      rs:resultVariable  "x" ;
+      rs:solution
+                  [ rs:binding  [ rs:value    :d1 ;
+                                  rs:variable  "x"
+                                ]
+                  ] ;
+      rs:solution
+                  [ rs:binding  [ rs:value    :d2 ;
+                                  rs:variable  "x"
+                                ]
+                  ] ;
+      rs:solution
+                  [ rs:binding  [ rs:value    :d3 ;
+                                  rs:variable  "x"
+                                ]
+                  ] ;
+      rs:solution
+                  [ rs:binding  [ rs:value    :d5 ;
+                                  rs:variable  "x"
+                                ]
+                  ] ;
+      rs:solution
+                  [ rs:binding  [ rs:value    :d7 ;
+                                  rs:variable  "x"
+                                ]
+                  ] .

--- a/sparql/sparql10/expr-ops/data-dateTime.ttl
+++ b/sparql/sparql10/expr-ops/data-dateTime.ttl
@@ -1,0 +1,13 @@
+@prefix : <http://example.org/> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+
+:tzasc :p1 "2008-10-01T00:00:00Z"^^xsd:dateTime ; :p2 "2008-10-03T00:00:00Z"^^xsd:dateTime .
+:tzdesc :p1 "2008-10-03T00:00:00Z"^^xsd:dateTime ; :p2 "2008-10-01T00:00:00Z"^^xsd:dateTime .
+:tzeq :p1 "2008-10-01T00:00:00Z"^^xsd:dateTime ; :p2 "2008-10-01T00:00:00Z"^^xsd:dateTime .
+:ntzasc :p1 "2008-10-01T00:00:00"^^xsd:dateTime ; :p2 "2008-10-03T00:00:00"^^xsd:dateTime .
+:ntzdesc :p1 "2008-10-03T00:00:00"^^xsd:dateTime ; :p2 "2008-10-01T00:00:00"^^xsd:dateTime .
+:ntzeq :p1 "2008-10-01T00:00:00"^^xsd:dateTime ; :p2 "2008-10-01T00:00:00"^^xsd:dateTime .
+:tzntzasc :p1 "2008-10-01T00:00:00Z"^^xsd:dateTime ; :p2 "2008-10-03T00:00:00"^^xsd:dateTime .
+:tzntzdesc :p1 "2008-10-03T00:00:00Z"^^xsd:dateTime ; :p2 "2008-10-01T00:00:00"^^xsd:dateTime .
+:ntztzasc :p1 "2008-10-01T00:00:00"^^xsd:dateTime ; :p2 "2008-10-03T00:00:00Z"^^xsd:dateTime .
+:ntztzdesc :p1 "2008-10-03T00:00:00"^^xsd:dateTime ; :p2 "2008-10-01T00:00:00Z"^^xsd:dateTime .

--- a/sparql/sparql10/expr-ops/index.html
+++ b/sparql/sparql10/expr-ops/index.html
@@ -269,6 +269,116 @@
             </dd>
           </dl>
         </dd>
+        <dt id='dateTime-le-2'>
+          <a class='testlink' href='#dateTime-le-2'>
+            dateTime-le-2:
+          </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-le-2' property='mf:name'>DateTime Less-than or equals</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-le-2' property='mf:name'>DateTime Less-than or equals</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-le-2' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+            <p>&lt;= in FILTER expressions</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail'>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='result-dateTime-le-2.srx' property='mf:result'>result-dateTime-le-2.srx</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='dateTime-ge-2'>
+          <a class='testlink' href='#dateTime-ge-2'>
+            dateTime-ge-2:
+          </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-ge-2' property='mf:name'>DateTime Greater-than or equals</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-ge-2' property='mf:name'>DateTime Greater-than or equals</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-ge-2' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+            <p>&lt;= in FILTER expressions</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail'>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='result-dateTime-ge-2.srx' property='mf:result'>result-dateTime-ge-2.srx</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='dateTime-lt-2'>
+          <a class='testlink' href='#dateTime-lt-2'>
+            dateTime-lt-2:
+          </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-lt-2' property='mf:name'>DateTime Less-than</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-lt-2' property='mf:name'>DateTime Less-than</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-lt-2' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+            <p>&lt; in FILTER expressions</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail'>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='result-dateTime-lt-2.srx' property='mf:result'>result-dateTime-lt-2.srx</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='dateTime-gt-2'>
+          <a class='testlink' href='#dateTime-gt-2'>
+            dateTime-gt-2:
+          </a>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-gt-2' property='mf:name'>DateTime Greater-than</span>
+          <span about='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-gt-2' property='mf:name'>DateTime Greater-than</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2001/sw/DataAccess/tests/data-r2/expr-ops/manifest#dateTime-gt-2' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+            <blockquote>
+              <p>in FILTER expressions</p>
+            </blockquote>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail'>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='result-dateTime-gt-2.srx' property='mf:result'>result-dateTime-gt-2.srx</a>
+            </dd>
+          </dl>
+        </dd>
       </dl>
     </div>
     <footer>

--- a/sparql/sparql10/expr-ops/manifest.ttl
+++ b/sparql/sparql10/expr-ops/manifest.ttl
@@ -11,6 +11,10 @@
     mf:entries
     ( 
         :ge-1 :le-1 :mul-1 :plus-1 :minus-1 :unplus-1 :unminus-1
+        :dateTime-le-2
+        :dateTime-ge-2
+        :dateTime-lt-2
+        :dateTime-gt-2
     ).
 
 
@@ -85,4 +89,40 @@
             [ qt:query  <query-le-1.rq> ;
               qt:data   <data.ttl> ] ;
          mf:result  <result-le-1.srx>
+      .
+
+:dateTime-le-2 a mf:QueryEvaluationTest ;
+         mf:name    "DateTime Less-than or equals" ;
+         rdfs:comment "<= in FILTER expressions" ;
+         mf:action
+            [ qt:query  <query-le-2.rq> ;
+              qt:data   <data-dateTime.ttl> ] ;
+         mf:result  <result-dateTime-le-2.srx>
+      .
+
+:dateTime-ge-2 a mf:QueryEvaluationTest ;
+         mf:name    "DateTime Greater-than or equals" ;
+         rdfs:comment "<= in FILTER expressions" ;
+         mf:action
+            [ qt:query  <query-ge-2.rq> ;
+              qt:data   <data-dateTime.ttl> ] ;
+         mf:result  <result-dateTime-ge-2.srx>
+      .
+
+:dateTime-lt-2 a mf:QueryEvaluationTest ;
+         mf:name    "DateTime Less-than" ;
+         rdfs:comment "< in FILTER expressions" ;
+         mf:action
+            [ qt:query  <query-lt-2.rq> ;
+              qt:data   <data-dateTime.ttl> ] ;
+         mf:result  <result-dateTime-lt-2.srx>
+      .
+
+:dateTime-gt-2 a mf:QueryEvaluationTest ;
+         mf:name    "DateTime Greater-than" ;
+         rdfs:comment "> in FILTER expressions" ;
+         mf:action
+            [ qt:query  <query-gt-2.rq> ;
+              qt:data   <data-dateTime.ttl> ] ;
+         mf:result  <result-dateTime-gt-2.srx>
       .

--- a/sparql/sparql10/expr-ops/query-ge-2.rq
+++ b/sparql/sparql10/expr-ops/query-ge-2.rq
@@ -1,0 +1,5 @@
+PREFIX : <http://example.org/>
+SELECT ?s WHERE {
+    ?s :p1 ?o1 ; :p2 ?o2 .
+    FILTER(?o1 >= ?o2)
+}

--- a/sparql/sparql10/expr-ops/query-gt-2.rq
+++ b/sparql/sparql10/expr-ops/query-gt-2.rq
@@ -1,0 +1,5 @@
+PREFIX : <http://example.org/>
+SELECT ?s WHERE {
+    ?s :p1 ?o1 ; :p2 ?o2 .
+    FILTER(?o1 > ?o2)
+}

--- a/sparql/sparql10/expr-ops/query-le-2.rq
+++ b/sparql/sparql10/expr-ops/query-le-2.rq
@@ -1,0 +1,5 @@
+PREFIX : <http://example.org/>
+SELECT ?s WHERE {
+    ?s :p1 ?o1 ; :p2 ?o2 .
+    FILTER(?o1 <= ?o2)
+}

--- a/sparql/sparql10/expr-ops/query-lt-2.rq
+++ b/sparql/sparql10/expr-ops/query-lt-2.rq
@@ -1,0 +1,5 @@
+PREFIX : <http://example.org/>
+SELECT ?s WHERE {
+    ?s :p1 ?o1 ; :p2 ?o2 .
+    FILTER(?o1 < ?o2)
+}

--- a/sparql/sparql10/expr-ops/result-dateTime-ge-2.srx
+++ b/sparql/sparql10/expr-ops/result-dateTime-ge-2.srx
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+    <head>
+        <variable name="s"/>
+    </head>
+    <results>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/ntzeq</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/ntzdesc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/tzeq</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/tzdesc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/tzntzdesc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/ntztzdesc</uri>
+            </binding>
+        </result>
+    </results>
+</sparql>

--- a/sparql/sparql10/expr-ops/result-dateTime-gt-2.srx
+++ b/sparql/sparql10/expr-ops/result-dateTime-gt-2.srx
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+    <head>
+        <variable name="s"/>
+    </head>
+    <results>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/ntzdesc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/tzdesc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/tzntzdesc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/ntztzdesc</uri>
+            </binding>
+        </result>
+    </results>
+</sparql>

--- a/sparql/sparql10/expr-ops/result-dateTime-le-2.srx
+++ b/sparql/sparql10/expr-ops/result-dateTime-le-2.srx
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+    <head>
+        <variable name="s"/>
+    </head>
+    <results>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/ntzeq</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/ntzasc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/tzeq</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/tzasc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/tzntzasc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/ntztzasc</uri>
+            </binding>
+        </result>
+    </results>
+</sparql>

--- a/sparql/sparql10/expr-ops/result-dateTime-lt-2.srx
+++ b/sparql/sparql10/expr-ops/result-dateTime-lt-2.srx
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+    <head>
+        <variable name="s"/>
+    </head>
+    <results>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/ntzasc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/tzasc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/tzntzasc</uri>
+            </binding>
+        </result>
+        <result>
+            <binding name="s">
+                <uri>http://example.org/ntztzasc</uri>
+            </binding>
+        </result>
+    </results>
+</sparql>


### PR DESCRIPTION
Test are crafted such that they pass if there is a default timezone or if there isn't

However it assumes that at least the comparisons defined in [XSD datatypes 1.1 Seven-property Model](https://www.w3.org/TR/xmlschema11-2/#theSevenPropertyModel) are working i.e. that two date-times, one with timezone and one without timezone are comparable if the comparison output is the same when using both +14:00 and -14:00 timezones.