### PR TITLE
Ensures SPARQL 1.2 follows RDF 1.1

### DIFF
--- a/sparql/sparql12/manifest.ttl
+++ b/sparql/sparql12/manifest.ttl
@@ -36,4 +36,5 @@ trs:manifest  rdf:type mf:Manifest ;
     <syntax-triple-terms-negative/manifest.ttl>
     <syntax-triple-terms-positive/manifest.ttl>
     <lang-basedir/manifest.ttl>
+    <rdf11/manifest.ttl>
   ) .

--- a/sparql/sparql12/rdf11/index.html
+++ b/sparql/sparql12/rdf11/index.html
@@ -30,7 +30,7 @@
       footer {text-align: center;}
     </style>
     <title>
-      SPARQL 1.2 tests
+      RDF 1.1 literals handling
     </title>
     <style>
       em.rfc2119 {
@@ -50,19 +50,18 @@
       .error {color: red;}
     </style>
   </head>
-  <body resource='../sparql12#manifest' typeof='mf:Manifest'>
+  <body resource='../grouping#manifest' typeof='mf:Manifest'>
     <p>
       <a href='http://www.w3.org/'>
         <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
       </a>
     </p>
-    <h1 property='rdfs:label'>SPARQL 1.2 tests</h1>
+    <h1 property='rdfs:label'>RDF 1.1 literals handling</h1>
     <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2010 <a href="http://www.w3.org/"><acronym title="World Wide Web Consortium">W3C</acronym></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="http://www.ercim.org/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
     <hr title='Separator for header'>
     <div>
       <h2 id='abstract'>Abstract</h2>
       <p property='rdfs:comment'>
-        <p>These test suites are a product of the <a href="">W3C RDF-star Working Group</a> as well as the RDF-star Interest Group within the W3C RDF-DEV Community Group, and has been maintained by the <a href="https://www.w3.org/community/rdf-tests/">RDF Test Curation Community Group</a> at <a href="https://github.com/w3c/rdf-tests/tree/main/sparql/sparql12/">https://github.com/w3c/rdf-tests/tree/main/sparql/sparql12</a>. Conformance with SPARQL 1.2 specifications can be determined via successfully running the tests for relevant specifications along with the relevant SPARQL 1.1 tests.</p>
       </p>
       <p>This page describes SPARQL 1.2 test suite of the W3C RDF-star Working Group.</p>
       <h3 id="contributing-tests">Contributing Tests</h3>
@@ -75,25 +74,88 @@
     </div>
     <div>
       <h2>
-        Referenced Manifests
+        Test Descriptions
       </h2>
-      <ul>
-        <li>
-          <a href='grouping/index.html' inlist='true' property='mf:include'>grouping/</a>
-        </li>
-        <li>
-          <a href='lang-basedir/index.html' inlist='true' property='mf:include'>lang-basedir/</a>
-        </li>
-        <li>
-          <a href='rdf11/index.html' inlist='true' property='mf:include'>rdf11/</a>
-        </li>
-        <li>
-          <a href='syntax-triple-terms-negative/index.html' inlist='true' property='mf:include'>syntax-triple-terms-negative/</a>
-        </li>
-        <li>
-          <a href='syntax-triple-terms-positive/index.html' inlist='true' property='mf:include'>syntax-triple-terms-positive/</a>
-        </li>
-      </ul>
+      <dl class='test-description'>
+        <dt id='langstring-datatype'>
+          <a class='testlink' href='#langstring-datatype'>
+            langstring-datatype:
+          </a>
+          <span about='../grouping#langstring-datatype' property='mf:name'>DATATYPE on rdf:langString</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='../grouping#langstring-datatype' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+            <p>plain literals with a language tag have a rdf:langString datatype</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail' property='mf:action' resource=''>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='langstring-datatype.srj' property='mf:result'>langstring-datatype.srj</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='plain-string-datatype'>
+          <a class='testlink' href='#plain-string-datatype'>
+            plain-string-datatype:
+          </a>
+          <span about='../grouping#plain-string-datatype' property='mf:name'>DATATYPE on plain string literal</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='../grouping#plain-string-datatype' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+            <p>plain literals without a language tag have the xsd:string datatype</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail' property='mf:action' resource=''>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='plain-string-datatype.srj' property='mf:result'>plain-string-datatype.srj</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='plain-string-same'>
+          <a class='testlink' href='#plain-string-same'>
+            plain-string-same:
+          </a>
+          <span about='../grouping#plain-string-same' property='mf:name'>xsd:string and plain literals are the same</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='../grouping#plain-string-same' typeof='mf:QueryEvaluationTest'>
+          <div property='rdfs:comment'>
+            <p>xsd:string literals are the same as literals without datatypes</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:QueryEvaluationTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <dl class='test-detail' property='mf:action' resource=''>
+              </dl>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='plain-string-same.srj' property='mf:result'>plain-string-same.srj</a>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
     </div>
     <footer>
       <p><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright ©</a> 2015 <a href="http://www.w3.org/">W3C</a>® (<a href="http://www.csail.mit.edu/">MIT</a>, <a href="http://www.ercim.org/">ERCIM</a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C® <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>

--- a/sparql/sparql12/rdf11/langstring-datatype.rq
+++ b/sparql/sparql12/rdf11/langstring-datatype.rq
@@ -1,0 +1,1 @@
+SELECT (DATATYPE("foo"@en) AS ?dt) WHERE {}

--- a/sparql/sparql12/rdf11/langstring-datatype.srj
+++ b/sparql/sparql12/rdf11/langstring-datatype.srj
@@ -1,0 +1,12 @@
+{
+  "head": {
+    "vars": [ "dt" ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "dt": { "type": "uri", "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" }
+      }
+    ]
+  }
+}

--- a/sparql/sparql12/rdf11/manifest.ttl
+++ b/sparql/sparql12/rdf11/manifest.ttl
@@ -1,0 +1,37 @@
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix :       <https://w3c.github.io/rdf-tests/sparql/sparql12/grouping#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
+@prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
+
+:manifest  rdf:type mf:Manifest ;
+    rdfs:label "RDF 1.1 literals handling" ;
+    mf:entries
+    (
+    :langstring-datatype
+    :plain-string-datatype
+    :plain-string-same
+    ) .
+
+
+:langstring-datatype rdf:type mf:QueryEvaluationTest ;
+    mf:name "DATATYPE on rdf:langString";
+    rdfs:comment    "plain literals with a language tag have a rdf:langString datatype" ;
+    dawgt:approval dawgt:Proposed ;
+    mf:action [ qt:query  <langstring-datatype.rq> ] ;
+    mf:result  <langstring-datatype.srj> .
+
+:plain-string-datatype rdf:type mf:QueryEvaluationTest ;
+    mf:name "DATATYPE on plain string literal";
+    rdfs:comment    "plain literals without a language tag have the xsd:string datatype" ;
+    dawgt:approval dawgt:Proposed ;
+    mf:action [ qt:query  <plain-string-datatype.rq> ] ;
+    mf:result  <plain-string-datatype.srj> .
+
+:plain-string-same rdf:type mf:QueryEvaluationTest ;
+    mf:name "xsd:string and plain literals are the same";
+    rdfs:comment    "xsd:string literals are the same as literals without datatypes" ;
+    dawgt:approval dawgt:Proposed ;
+    mf:action [ qt:query  <plain-string-same.rq> ] ;
+    mf:result  <plain-string-same.srj> .

--- a/sparql/sparql12/rdf11/plain-string-datatype.rq
+++ b/sparql/sparql12/rdf11/plain-string-datatype.rq
@@ -1,0 +1,1 @@
+SELECT (DATATYPE("foo") AS ?dt) WHERE {}

--- a/sparql/sparql12/rdf11/plain-string-datatype.srj
+++ b/sparql/sparql12/rdf11/plain-string-datatype.srj
@@ -1,0 +1,12 @@
+{
+  "head": {
+    "vars": [ "dt" ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "dt": { "type": "uri", "value": "http://www.w3.org/2001/XMLSchema#string" }
+      }
+    ]
+  }
+}

--- a/sparql/sparql12/rdf11/plain-string-same.rq
+++ b/sparql/sparql12/rdf11/plain-string-same.rq
@@ -1,0 +1,2 @@
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+ASK { FILTER(sameTerm("foo", "foo"^^xsd:string)) }

--- a/sparql/sparql12/rdf11/plain-string-same.srj
+++ b/sparql/sparql12/rdf11/plain-string-same.srj
@@ -1,0 +1,4 @@
+{
+  "head": {},
+  "boolean": true
+}


### PR DESCRIPTION
- the datatype of literals with language tags is rdf:langString
- the datatype of plain literals with language tags is xsd:string
- plain literals without language tags and literals with xsd:string datatype are the same