### PR TITLE
Add correct `xsd:string` types for some tests of SPARQL 1.1

### DIFF
--- a/sparql/sparql11/functions/concat-single.srx
+++ b/sparql/sparql11/functions/concat-single.srx
@@ -5,7 +5,7 @@
 </head>
 <results>
 	<result>
-		<binding name="str"><literal>abc</literal></binding>
+		<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
 	</result>
 </results>
 </sparql>

--- a/sparql/sparql11/functions/concat01.srx
+++ b/sparql/sparql11/functions/concat01.srx
@@ -5,7 +5,7 @@
 </head>
 <results>
 		<result>
-			<binding name="str"><literal>abcDEF</literal></binding>
+			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abcDEF</literal></binding>
 		</result>
 </results>
 </sparql>

--- a/sparql/sparql11/functions/replace01.srx
+++ b/sparql/sparql11/functions/replace01.srx
@@ -23,11 +23,11 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s5</uri></binding>
-			<binding name="new"><literal>abc</literal></binding>
+			<binding name="new"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="new"><literal>def</literal></binding>
+			<binding name="new"><literal datatype="http://www.w3.org/2001/XMLSchema#string">def</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>

--- a/sparql/sparql11/functions/strafter01a.srx
+++ b/sparql/sparql11/functions/strafter01a.srx
@@ -27,7 +27,7 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="suffix"><literal>f</literal></binding>
+			<binding name="suffix"><literal datatype="http://www.w3.org/2001/XMLSchema#string">f</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>

--- a/sparql/sparql11/functions/substring01.srx
+++ b/sparql/sparql11/functions/substring01.srx
@@ -18,8 +18,8 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>
-			<binding name="str"><literal>DEF</literal></binding>
-			<binding name="substr"><literal>D</literal></binding>
+			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">DEF</literal></binding>
+			<binding name="substr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">D</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s3</uri></binding>
@@ -33,8 +33,8 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="str"><literal>abc</literal></binding>
-			<binding name="substr"><literal>a</literal></binding>
+			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
+			<binding name="substr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">a</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s1</uri></binding>

--- a/sparql/sparql11/functions/substring02.srx
+++ b/sparql/sparql11/functions/substring02.srx
@@ -18,8 +18,8 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s7</uri></binding>
-			<binding name="str"><literal>DEF</literal></binding>
-			<binding name="substr"><literal>EF</literal></binding>
+			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">DEF</literal></binding>
+			<binding name="substr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">EF</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s3</uri></binding>
@@ -33,8 +33,8 @@
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s6</uri></binding>
-			<binding name="str"><literal>abc</literal></binding>
-			<binding name="substr"><literal>bc</literal></binding>
+			<binding name="str"><literal datatype="http://www.w3.org/2001/XMLSchema#string">abc</literal></binding>
+			<binding name="substr"><literal datatype="http://www.w3.org/2001/XMLSchema#string">bc</literal></binding>
 		</result>
 		<result>
 			<binding name="s"><uri>http://example.org/s1</uri></binding>


### PR DESCRIPTION
According to the SPARQL 1.1 standard (as specified by explicit examples there), the datatype `xsd:string` is to be preserved for string functions that have this datatype as an input, so a `SUBSTR`, `CONCAT` etc. of inputs with type `xsd:string` should yield results with `xsd:string`. The test suite currently assumes that the `xsd:string` datatype is dropped (strangely not only for the result of the expression, but also when simply exporting the typed input literals as XML.

This PR adjusts some tests (I have not yet fully analyzed all tests) to what I consider to be the more correct behavior. Please give me feedback especially if there is a particular reason why the datatype `xsd:string` is omitted in the expected query results (the SPARQL 1.1 standard explicitly differentiates between simple literals without a datatype, and literals explicitly typed with `xsd:string`, although they behave very similarly.

