### PR TITLE
Update RDF 1.2 semantics tests for triple terms not quoted triples.

### DIFF
--- a/rdf/rdf12/rdf-semantics/canonical-literal.ttl
+++ b/rdf/rdf12/rdf-semantics/canonical-literal.ttl
@@ -1,4 +1,4 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b "42"^^xsd:integer >> :p1 :o1.
+:a1 :p1 <<( :a :b "42"^^xsd:integer )>>.

--- a/rdf/rdf12/rdf-semantics/index.html
+++ b/rdf/rdf12/rdf-semantics/index.html
@@ -81,15 +81,15 @@
         Test Descriptions
       </h2>
       <dl class='test-description'>
-        <dt id='all-identical-quoted-triples-are-the-same'>
-          <a class='testlink' href='#all-identical-quoted-triples-are-the-same'>
-            all-identical-quoted-triples-are-the-same:
+        <dt id='all-identical-triple-terms-are-the-same'>
+          <a class='testlink' href='#all-identical-triple-terms-are-the-same'>
+            all-identical-triple-terms-are-the-same:
           </a>
-          <span about='../rdf-semantics#all-identical-quoted-triples-are-the-same' property='mf:name'>all-identical-quoted-triples-are-the-same</span>
+          <span about='../rdf-semantics#all-identical-triple-terms-are-the-same' property='mf:name'>all-identical-triple-terms-are-the-same</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#all-identical-quoted-triples-are-the-same' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#all-identical-triple-terms-are-the-same' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Multiple occurences of the same quoted triples are undistinguishable in the abstract model.</p>
+            <p>Multiple occurences of the same triple terms are undistinguishable in the abstract model.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -106,13 +106,13 @@
             </dd>
           </dl>
         </dd>
-        <dt id='quoted-triples-no-spurious'>
-          <a class='testlink' href='#quoted-triples-no-spurious'>
-            quoted-triples-no-spurious:
+        <dt id='triple-terms-no-spurious'>
+          <a class='testlink' href='#triple-terms-no-spurious'>
+            triple-terms-no-spurious:
           </a>
-          <span about='../rdf-semantics#quoted-triples-no-spurious' property='mf:name'>quoted-triples-no-spurious</span>
+          <span about='../rdf-semantics#triple-terms-no-spurious' property='mf:name'>quoted-triples-no-spurious</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#quoted-triples-no-spurious' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#triple-terms-no-spurious' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
             <p>This test ensures that other entailments are not spurious.</p>
           </div>
@@ -131,15 +131,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='bnodes-in-quoted-subject'>
-          <a class='testlink' href='#bnodes-in-quoted-subject'>
-            bnodes-in-quoted-subject:
+        <dt id='bnodes-in-triple-term-subject'>
+          <a class='testlink' href='#bnodes-in-triple-term-subject'>
+            bnodes-in-triple-term-subject:
           </a>
-          <span about='../rdf-semantics#bnodes-in-quoted-subject' property='mf:name'>bnodes-in-quoted-subject</span>
+          <span about='../rdf-semantics#bnodes-in-triple-term-subject' property='mf:name'>bnodes-in-triple-term-subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-quoted-subject' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-triple-term-subject' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Terms inside quoted triples can be replaced by fresh bnodes.</p>
+            <p>Terms inside triple terms can be replaced by fresh bnodes.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -156,15 +156,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='bnodes-in-quoted-object'>
-          <a class='testlink' href='#bnodes-in-quoted-object'>
-            bnodes-in-quoted-object:
+        <dt id='bnodes-in-triple-term-object'>
+          <a class='testlink' href='#bnodes-in-triple-term-object'>
+            bnodes-in-triple-term-object:
           </a>
-          <span about='../rdf-semantics#bnodes-in-quoted-object' property='mf:name'>bnodes-in-quoted-object</span>
+          <span about='../rdf-semantics#bnodes-in-triple-term-object' property='mf:name'>bnodes-in-triple-term-object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-quoted-object' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-triple-term-object' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Terms inside quoted triples can be replaced by fresh bnodes.</p>
+            <p>Terms inside triple terms can be replaced by fresh bnodes.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -181,15 +181,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='bnodes-in-quoted-subject-and-object'>
-          <a class='testlink' href='#bnodes-in-quoted-subject-and-object'>
-            bnodes-in-quoted-subject-and-object:
+        <dt id='bnodes-in-triple-term-subject-and-object'>
+          <a class='testlink' href='#bnodes-in-triple-term-subject-and-object'>
+            bnodes-in-triple-term-subject-and-object:
           </a>
-          <span about='../rdf-semantics#bnodes-in-quoted-subject-and-object' property='mf:name'>bnodes-in-quoted-subject-and-object</span>
+          <span about='../rdf-semantics#bnodes-in-triple-term-subject-and-object' property='mf:name'>bnodes-in-triple-term-subject-and-object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-quoted-subject-and-object' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-triple-term-subject-and-object' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Terms inside quoted triples can be replaced by fresh bnodes.</p>
+            <p>Terms inside triple terms can be replaced by fresh bnodes.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -206,15 +206,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='bnodes-in-quoted-subject-and-object-fail'>
-          <a class='testlink' href='#bnodes-in-quoted-subject-and-object-fail'>
-            bnodes-in-quoted-subject-and-object-fail:
+        <dt id='bnodes-in-triple-term-subject-and-object-fail'>
+          <a class='testlink' href='#bnodes-in-triple-term-subject-and-object-fail'>
+            bnodes-in-triple-term-subject-and-object-fail:
           </a>
-          <span about='../rdf-semantics#bnodes-in-quoted-subject-and-object-fail' property='mf:name'>bnodes-in-quoted-subject-and-object-fail</span>
+          <span about='../rdf-semantics#bnodes-in-triple-term-subject-and-object-fail' property='mf:name'>bnodes-in-triple-term-subject-and-object-fail</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-quoted-subject-and-object-fail' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#bnodes-in-triple-term-subject-and-object-fail' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>The same bnode can not match different quoted terms.</p>
+            <p>The same bnode can not match different triple terms.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -231,15 +231,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='same-bnode-same-quoted-term'>
-          <a class='testlink' href='#same-bnode-same-quoted-term'>
-            same-bnode-same-quoted-term:
+        <dt id='same-bnode-same-triple-term'>
+          <a class='testlink' href='#same-bnode-same-triple-term'>
+            same-bnode-same-triple-term:
           </a>
-          <span about='../rdf-semantics#same-bnode-same-quoted-term' property='mf:name'>same-bnode-same-quoted-term</span>
+          <span about='../rdf-semantics#same-bnode-same-triple-term' property='mf:name'>same-bnode-same-quoted-term</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#same-bnode-same-quoted-term' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#same-bnode-same-triple-term' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Identical quoted term can be replaced by the same fresh bnode multiple times.</p>
+            <p>Identical triple term can be replaced by the same fresh bnode multiple times.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -256,15 +256,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='different-bnodes-same-quoted-term'>
-          <a class='testlink' href='#different-bnodes-same-quoted-term'>
-            different-bnodes-same-quoted-term:
+        <dt id='different-bnodes-same-triple-term'>
+          <a class='testlink' href='#different-bnodes-same-triple-term'>
+            different-bnodes-same-triple-term:
           </a>
-          <span about='../rdf-semantics#different-bnodes-same-quoted-term' property='mf:name'>different-bnodes-same-quoted-term</span>
+          <span about='../rdf-semantics#different-bnodes-same-triple-term' property='mf:name'>different-bnodes-same-triple-term</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#different-bnodes-same-quoted-term' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#different-bnodes-same-triple-term' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Different bnodes can match identical quoted terms.</p>
+            <p>Different bnodes can match identical triple terms.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -281,15 +281,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='constrained-bnodes-in-quoted-subject'>
-          <a class='testlink' href='#constrained-bnodes-in-quoted-subject'>
-            constrained-bnodes-in-quoted-subject:
+        <dt id='constrained-bnodes-in-triple-term-subject'>
+          <a class='testlink' href='#constrained-bnodes-in-triple-term-subject'>
+            constrained-bnodes-in-triple-term-subject:
           </a>
-          <span about='../rdf-semantics#constrained-bnodes-in-quoted-subject' property='mf:name'>constrained-bnodes-in-quoted-subject</span>
+          <span about='../rdf-semantics#constrained-bnodes-in-triple-term-subject' property='mf:name'>constrained-bnodes-in-triple-term-subject</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-in-quoted-subject' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-in-triple-term-subject' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Terms inside and outside quoted triples can be replaced by fresh bnodes</p>
+            <p>Terms inside and outside triple terms can be replaced by fresh bnodes</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -306,15 +306,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='constrained-bnodes-in-quoted-object'>
-          <a class='testlink' href='#constrained-bnodes-in-quoted-object'>
-            constrained-bnodes-in-quoted-object:
+        <dt id='constrained-bnodes-in-triple-term-object'>
+          <a class='testlink' href='#constrained-bnodes-in-triple-term-object'>
+            constrained-bnodes-in-triple-term-object:
           </a>
-          <span about='../rdf-semantics#constrained-bnodes-in-quoted-object' property='mf:name'>constrained-bnodes-in-quoted-object</span>
+          <span about='../rdf-semantics#constrained-bnodes-in-triple-term-object' property='mf:name'>constrained-bnodes-in-triple-term-object</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-in-quoted-object' typeof='mf:PositiveEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-in-triple-term-object' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Terms inside and outside quoted triples can be replaced by fresh bnodes.</p>
+            <p>Terms inside and outside triple terms can be replaced by fresh bnodes.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -331,15 +331,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='constrained-bnodes-in-quoted-fail'>
-          <a class='testlink' href='#constrained-bnodes-in-quoted-fail'>
-            constrained-bnodes-in-quoted-fail:
+        <dt id='constrained-bnodes-in-triple-term-fail'>
+          <a class='testlink' href='#constrained-bnodes-in-triple-term-fail'>
+            constrained-bnodes-in-triple-term-fail:
           </a>
-          <span about='../rdf-semantics#constrained-bnodes-in-quoted-fail' property='mf:name'>constrained-bnodes-in-quoted-fail</span>
+          <span about='../rdf-semantics#constrained-bnodes-in-triple-term-fail' property='mf:name'>constrained-bnodes-in-triple-term-fail</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-in-quoted-fail' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-in-triple-term-fail' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Quoted bnode identifiers share the same scope as non-quoted ones. A bnode that occurs both inside quoted triples and inside asserted triples must satisfy all occurrences at the same time.</p>
+            <p>Quoted bnode identifiers share the same scope as non-quoted ones. A bnode that occurs both inside triple terms and inside asserted triples must satisfy all occurrences at the same time.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -364,7 +364,7 @@
         </dt>
         <dd inlist='true' property='mf:entry' resource='../rdf-semantics#constrained-bnodes-on-literal' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Literals inside and outside quoted triples can be replaced by fresh bnodes.</p>
+            <p>Literals inside and outside triple terms can be replaced by fresh bnodes.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -410,7 +410,7 @@
         </dt>
         <dd inlist='true' property='mf:entry' resource='../rdf-semantics#malformed-literal' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Malformed literals are allowed when quoted.</p>
+            <p>Malformed literals are allowed when in triple terms.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -431,7 +431,7 @@
         </dt>
         <dd inlist='true' property='mf:entry' resource='../rdf-semantics#malformed-literal-accepted' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Malformed literals are allowed when quoted.</p>
+            <p>Malformed literals are allowed when in triple terms.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -456,7 +456,7 @@
         </dt>
         <dd inlist='true' property='mf:entry' resource='../rdf-semantics#malformed-literal-no-spurious' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Quoted malformed literals do not lead to spurious entailment.</p>
+            <p>Malformed literals within triple terms do not lead to spurious entailment.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -531,7 +531,7 @@
         </dt>
         <dd inlist='true' property='mf:entry' resource='../rdf-semantics#opaque-literal' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Quoted literals are opaque, even when their datatype is recognized.</p>
+            <p>Literals within triple terms are opaque, even when their datatype is recognized.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -581,7 +581,7 @@
         </dt>
         <dd inlist='true' property='mf:entry' resource='../rdf-semantics#opaque-language-string' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Quoted literals (including language strings) are opaque, even when their datatype is recognized.</p>
+            <p>Literals within reifying terms (including language strings) are opaque, even when their datatype is recognized.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -631,7 +631,7 @@
         </dt>
         <dd inlist='true' property='mf:entry' resource='../rdf-semantics#opaque-iri' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Quoted IRIs are opaque.</p>
+            <p>Triple term IRIs are opaque.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -648,15 +648,15 @@
             </dd>
           </dl>
         </dd>
-        <dt id='quoted-not-asserted'>
-          <a class='testlink' href='#quoted-not-asserted'>
-            quoted-not-asserted:
+        <dt id='triple-term-not-asserted'>
+          <a class='testlink' href='#triple-term-not-asserted'>
+            triple-term-not-asserted:
           </a>
-          <span about='../rdf-semantics#quoted-not-asserted' property='mf:name'>quoted-not-asserted</span>
+          <span about='../rdf-semantics#triple-term-not-asserted' property='mf:name'>triple-term-not-asserted</span>
         </dt>
-        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#quoted-not-asserted' typeof='mf:NegativeEntailmentTest'>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#triple-term-not-asserted' typeof='mf:NegativeEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Quoted triples are not asserted.</p>
+            <p>Triple terms are not asserted.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -706,7 +706,7 @@
         </dt>
         <dd inlist='true' property='mf:entry' resource='../rdf-semantics#annotation' typeof='mf:PositiveEntailmentTest'>
           <div property='rdfs:comment'>
-            <p>Annotation are about the annotated triple.</p>
+            <p>Annotation are about the reifying triple.</p>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>

--- a/rdf/rdf12/rdf-semantics/lowercase-language-string.ttl
+++ b/rdf/rdf12/rdf-semantics/lowercase-language-string.ttl
@@ -1,4 +1,4 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b "hello"@en-us >> :p1 :o1.
+:a1 :p1 <<( :a :b "hello"@en-us )>>.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-2a.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-2a.ttl
@@ -1,5 +1,5 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b "c"^^xsd:integer >> :p1 :o1.
-<< :d :b "c"^^xsd:integer >> :p2 :o2.
+:a1 :p1 <<( :a :b "c"^^xsd:integer )>>.
+:a2 :p2 <<( :d :b "c"^^xsd:integer )>>.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-2r.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-2r.ttl
@@ -1,5 +1,5 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b _:x >> :p1 :o1.
-<< :d :b _:x >> :p2 :o2.
+:a1 :p1 <<( :a :b _:x )>>.
+:a2 :p2 <<( :d :b _:x )>>.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-3a.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-3a.ttl
@@ -1,5 +1,5 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b "c"^^xsd:integer >> :p1 :o1.
-<< :d :b "d"^^xsd:integer >> :p2 :o2.
+:a1 :p1 <<( :a :b "c"^^xsd:integer )>>.
+:a2 :p2 <<( :d :b "d"^^xsd:integer )>>.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-3r.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-3r.ttl
@@ -1,5 +1,5 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b _:x >> :p1 :o1.
-<< :d :b _:x >> :p2 :o2.
+:a1 :p1 <<( :a :b _:x )>>.
+:a2 :p2 <<( :d :b _:x )>>.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-other.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-other.ttl
@@ -1,4 +1,4 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b "d"^^xsd:integer >> :p1 :o1.
+:a1 :p1 <<( :a :b "c"^^xsd:integer )>>..

--- a/rdf/rdf12/rdf-semantics/malformed-literal.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal.ttl
@@ -1,4 +1,4 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b "c"^^xsd:integer >> :p1 :o1.
+:a1 :p1 <<( :a :b "c"^^xsd:integer )>>..

--- a/rdf/rdf12/rdf-semantics/manifest.ttl
+++ b/rdf/rdf12/rdf-semantics/manifest.ttl
@@ -37,17 +37,17 @@ trs:manifest a mf:Manifest;
   """;
   rdfs:seeAlso <README>;
   mf:entries (
-    trs:all-identical-quoted-triples-are-the-same
-    trs:quoted-triples-no-spurious
-    trs:bnodes-in-quoted-subject
-    trs:bnodes-in-quoted-object
-    trs:bnodes-in-quoted-subject-and-object
-    trs:bnodes-in-quoted-subject-and-object-fail
-    trs:same-bnode-same-quoted-term
-    trs:different-bnodes-same-quoted-term
-    trs:constrained-bnodes-in-quoted-subject
-    trs:constrained-bnodes-in-quoted-object
-    trs:constrained-bnodes-in-quoted-fail
+    trs:all-identical-triple-terms-are-the-same
+    trs:triple-terms-no-spurious
+    trs:bnodes-in-triple-term-subject
+    trs:bnodes-in-triple-term-object
+    trs:bnodes-in-triple-term-subject-and-object
+    trs:bnodes-in-triple-term-subject-and-object-fail
+    trs:same-bnode-same-triple-term
+    trs:different-bnodes-same-triple-term
+    trs:constrained-bnodes-in-triple-term-subject
+    trs:constrained-bnodes-in-triple-term-object
+    trs:constrained-bnodes-in-triple-term-fail
     trs:constrained-bnodes-on-literal
     trs:malformed-literal-control
     trs:malformed-literal
@@ -60,7 +60,7 @@ trs:manifest a mf:Manifest;
     trs:opaque-language-string
     trs:opaque-iri-control
     trs:opaque-iri
-    trs:quoted-not-asserted
+    trs:triple-term-not-asserted
     trs:annotated-asserted
     trs:annotation
     trs:annotation-unfolded
@@ -81,11 +81,11 @@ trs:manifest a mf:Manifest;
     trs:double-infinity
   ) .
 
-trs:all-identical-quoted-triples-are-the-same a mf:PositiveEntailmentTest;
-  rdfs:comment "Multiple occurences of the same quoted triples are undistinguishable in the abstract model.";
+trs:all-identical-triple-terms-are-the-same a mf:PositiveEntailmentTest;
+  rdfs:comment "Multiple occurences of the same triple terms are undistinguishable in the abstract model.";
   mf:action <test001a.ttl>;
   mf:entailmentRegime "simple";
-  mf:name "all-identical-quoted-triples-are-the-same";
+  mf:name "all-identical-triple-terms-are-the-same";
   mf:recognizedDatatypes ();
   mf:result <test001r.ttl>;
   mf:unrecognizedDatatypes ();
@@ -102,7 +102,7 @@ trs:annotated-asserted a mf:PositiveEntailmentTest;
   test:approval test:NotClassified .
 
 trs:annotation a mf:PositiveEntailmentTest;
-  rdfs:comment "Annotation are about the annotated triple.";
+  rdfs:comment "Annotation are about the reifying triple.";
   mf:action <test007a.ttl>;
   mf:entailmentRegime "simple";
   mf:name "annotation";
@@ -121,78 +121,78 @@ trs:annotation-unfolded a mf:PositiveEntailmentTest;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:bnodes-in-quoted-object a mf:PositiveEntailmentTest;
-  rdfs:comment "Terms inside quoted triples can be replaced by fresh bnodes.";
+trs:bnodes-in-triple-term-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms inside triple terms can be replaced by fresh bnodes.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
-  mf:name "bnodes-in-quoted-object";
+  mf:name "bnodes-in-triple-term-object";
   mf:recognizedDatatypes ();
   mf:result <test002or.ttl>;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:bnodes-in-quoted-subject a mf:PositiveEntailmentTest;
-  rdfs:comment "Terms inside quoted triples can be replaced by fresh bnodes.";
+trs:bnodes-in-triple-term-subject a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms inside triple terms can be replaced by fresh bnodes.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
-  mf:name "bnodes-in-quoted-subject";
+  mf:name "bnodes-in-triple-term-subject";
   mf:recognizedDatatypes ();
   mf:result <test002sr.ttl>;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:bnodes-in-quoted-subject-and-object a mf:PositiveEntailmentTest;
-  rdfs:comment "Terms inside quoted triples can be replaced by fresh bnodes.";
+trs:bnodes-in-triple-term-subject-and-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms inside triple terms can be replaced by fresh bnodes.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
-  mf:name "bnodes-in-quoted-subject-and-object";
+  mf:name "bnodes-in-triple-term-subject-and-object";
   mf:recognizedDatatypes ();
   mf:result <test002sor.ttl>;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:bnodes-in-quoted-subject-and-object-fail a mf:NegativeEntailmentTest;
-  rdfs:comment "The same bnode can not match different quoted terms.";
+trs:bnodes-in-triple-term-subject-and-object-fail a mf:NegativeEntailmentTest;
+  rdfs:comment "The same bnode can not match different triple terms.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
-  mf:name "bnodes-in-quoted-subject-and-object-fail";
+  mf:name "bnodes-in-triple-term-subject-and-object-fail";
   mf:recognizedDatatypes ();
   mf:result <test002sbr.ttl>;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:constrained-bnodes-in-quoted-fail a mf:NegativeEntailmentTest;
-  rdfs:comment "Quoted bnode identifiers share the same scope as non-quoted ones. A bnode that occurs both inside quoted triples and inside asserted triples must satisfy all occurrences at the same time.";
+trs:constrained-bnodes-in-triple-term-fail a mf:NegativeEntailmentTest;
+  rdfs:comment "Quoted bnode identifiers share the same scope as non-quoted ones. A bnode that occurs both inside triple terms and inside asserted triples must satisfy all occurrences at the same time.";
   mf:action <test004a.ttl>;
   mf:entailmentRegime "simple";
-  mf:name "constrained-bnodes-in-quoted-fail";
+  mf:name "constrained-bnodes-in-triple-term-fail";
   mf:recognizedDatatypes ();
   mf:result <test004fr.ttl>;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:constrained-bnodes-in-quoted-object a mf:PositiveEntailmentTest;
-  rdfs:comment "Terms inside and outside quoted triples can be replaced by fresh bnodes.";
+trs:constrained-bnodes-in-triple-term-object a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms inside and outside triple terms can be replaced by fresh bnodes.";
   mf:action <test004a.ttl>;
   mf:entailmentRegime "simple";
-  mf:name "constrained-bnodes-in-quoted-object";
+  mf:name "constrained-bnodes-in-triple-term-object";
   mf:recognizedDatatypes ();
   mf:result <test004or.ttl>;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:constrained-bnodes-in-quoted-subject a mf:PositiveEntailmentTest;
-  rdfs:comment "Terms inside and outside quoted triples can be replaced by fresh bnodes";
+trs:constrained-bnodes-in-triple-term-subject a mf:PositiveEntailmentTest;
+  rdfs:comment "Terms inside and outside triple terms can be replaced by fresh bnodes";
   mf:action <test004a.ttl>;
   mf:entailmentRegime "simple";
-  mf:name "constrained-bnodes-in-quoted-subject";
+  mf:name "constrained-bnodes-in-triple-term-subject";
   mf:recognizedDatatypes ();
   mf:result <test004sr.ttl>;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
 trs:constrained-bnodes-on-literal a mf:PositiveEntailmentTest;
-  rdfs:comment "Literals inside and outside quoted triples can be replaced by fresh bnodes.";
+  rdfs:comment "Literals inside and outside triple terms can be replaced by fresh bnodes.";
   mf:action <test006a.ttl>;
   mf:entailmentRegime "simple";
   mf:name "constrained-bnodes-on-literal";
@@ -201,27 +201,27 @@ trs:constrained-bnodes-on-literal a mf:PositiveEntailmentTest;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:different-bnodes-same-quoted-term a mf:PositiveEntailmentTest;
-  rdfs:comment "Different bnodes can match identical quoted terms.";
+trs:different-bnodes-same-triple-term a mf:PositiveEntailmentTest;
+  rdfs:comment "Different bnodes can match identical triple terms.";
   mf:action <test003a.ttl>;
   mf:entailmentRegime "simple";
-  mf:name "different-bnodes-same-quoted-term";
+  mf:name "different-bnodes-same-triple-term";
   mf:recognizedDatatypes ();
   mf:result <test002sor.ttl>;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:quoted-not-asserted a mf:NegativeEntailmentTest;
-  rdfs:comment "Quoted triples are not asserted.";
+trs:triple-term-not-asserted a mf:NegativeEntailmentTest;
+  rdfs:comment "Triple terms are not asserted.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
-  mf:name "quoted-not-asserted";
+  mf:name "triple-term-not-asserted";
   mf:recognizedDatatypes ();
   mf:result <test002pgr.ttl>;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:quoted-triples-no-spurious a mf:NegativeEntailmentTest;
+trs:triple-terms-no-spurious a mf:NegativeEntailmentTest;
   rdfs:comment "This test ensures that other entailments are not spurious.";
   mf:action <test002a.ttl>;
   mf:entailmentRegime "simple";
@@ -232,7 +232,7 @@ trs:quoted-triples-no-spurious a mf:NegativeEntailmentTest;
   test:approval test:NotClassified .
 
 trs:malformed-literal a mf:NegativeEntailmentTest;
-  rdfs:comment "Malformed literals are allowed when quoted.";
+  rdfs:comment "Malformed literals are allowed when in triple terms.";
   mf:action <malformed-literal.ttl>;
   mf:entailmentRegime "RDF";
   mf:name "malformed-literal";
@@ -242,7 +242,7 @@ trs:malformed-literal a mf:NegativeEntailmentTest;
   test:approval test:NotClassified .
 
 trs:malformed-literal-accepted a mf:PositiveEntailmentTest;
-  rdfs:comment "Malformed literals are allowed when quoted.";
+  rdfs:comment "Malformed literals are allowed when in triple terms.";
   mf:action <malformed-literal.ttl>;
   mf:entailmentRegime "RDF";
   mf:name "malformed-literal-accepted";
@@ -302,7 +302,7 @@ trs:malformed-literal-control a mf:PositiveEntailmentTest;
   test:approval test:NotClassified .
 
 trs:malformed-literal-no-spurious a mf:NegativeEntailmentTest;
-  rdfs:comment "Quoted malformed literals do not lead to spurious entailment.";
+  rdfs:comment "Malformed literals within triple terms do not lead to spurious entailment.";
   mf:action <malformed-literal.ttl>;
   mf:entailmentRegime "RDF";
   mf:name "malformed-literal-no-spurious";
@@ -312,7 +312,7 @@ trs:malformed-literal-no-spurious a mf:NegativeEntailmentTest;
   test:approval test:NotClassified .
 
 trs:opaque-iri a mf:NegativeEntailmentTest;
-  rdfs:comment "Quoted IRIs are opaque.";
+  rdfs:comment "Triple term IRIs are opaque.";
   mf:action <superman.ttl>;
   mf:entailmentRegime "RDFS-Plus";
   mf:name "opaque-iri";
@@ -332,7 +332,7 @@ trs:opaque-iri-control a mf:PositiveEntailmentTest;
   test:approval test:NotClassified .
 
 trs:opaque-language-string a mf:NegativeEntailmentTest;
-  rdfs:comment "Quoted literals (including language strings) are opaque, even when their datatype is recognized.";
+  rdfs:comment "Literals within reifying terms (including language strings) are opaque, even when their datatype is recognized.";
   mf:action <lowercase-language-string.ttl>;
   mf:entailmentRegime "RDF";
   mf:name "opaque-language-string";
@@ -352,7 +352,7 @@ trs:opaque-language-string-control a mf:PositiveEntailmentTest;
   test:approval test:NotClassified .
 
 trs:opaque-literal a mf:NegativeEntailmentTest;
-  rdfs:comment "Quoted literals are opaque, even when their datatype is recognized.";
+  rdfs:comment "Literals within triple terms are opaque, even when their datatype is recognized.";
   mf:action <non-canonical-literal.ttl>;
   mf:entailmentRegime "RDF";
   mf:name "opaque-literal";
@@ -371,8 +371,8 @@ trs:opaque-literal-control a mf:PositiveEntailmentTest;
   mf:unrecognizedDatatypes ();
   test:approval test:NotClassified .
 
-trs:same-bnode-same-quoted-term a mf:PositiveEntailmentTest;
-  rdfs:comment "Identical quoted term can be replaced by the same fresh bnode multiple times.";
+trs:same-bnode-same-triple-term a mf:PositiveEntailmentTest;
+  rdfs:comment "Identical triple term can be replaced by the same fresh bnode multiple times.";
   mf:action <test003a.ttl>;
   mf:entailmentRegime "simple";
   mf:name "same-bnode-same-quoted-term";
@@ -382,7 +382,7 @@ trs:same-bnode-same-quoted-term a mf:PositiveEntailmentTest;
   test:approval test:NotClassified .
 
 trs:triple-in-object a mf:PositiveEntailmentTest;
-  rdfs:comment "Quoted triples can appear in object position (withdrawn, as it belongs to concrete syntax test-suites).";
+  rdfs:comment "Triple terms can appear in object position (withdrawn, as it belongs to concrete syntax test-suites).";
   mf:action <test000o.ttl>;
   mf:entailmentRegime "simple";
   mf:name "triple-in-object";

--- a/rdf/rdf12/rdf-semantics/non-canonical-literal.ttl
+++ b/rdf/rdf12/rdf-semantics/non-canonical-literal.ttl
@@ -1,4 +1,4 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b "042"^^xsd:integer >> :p1 :o1.
+:a1 :p1 <<( :a :b "042"^^xsd:integer )>>.

--- a/rdf/rdf12/rdf-semantics/superman.ttl
+++ b/rdf/rdf12/rdf-semantics/superman.ttl
@@ -1,5 +1,5 @@
 prefix : <http://example.com/ns#>
 prefix owl: <http://www.w3.org/2002/07/owl#>
 
-<< :superman :can :fly >> :reportedBy :clark.
+:clark :reports <<( :superman :can :fly )>>.
 :clark owl:sameAs :superman.

--- a/rdf/rdf12/rdf-semantics/superman_undesired_entailment.ttl
+++ b/rdf/rdf12/rdf-semantics/superman_undesired_entailment.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< :clark :can :fly >> :reportedBy :clark.
+:clark :reports <<( :clark :can :fly )>>.

--- a/rdf/rdf12/rdf-semantics/test000o.ttl
+++ b/rdf/rdf12/rdf-semantics/test000o.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-:s1 :p1 << :x :y :z >>.
+:s1 :p1 <<( :x :y :z )>>.

--- a/rdf/rdf12/rdf-semantics/test000s.ttl
+++ b/rdf/rdf12/rdf-semantics/test000s.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b :c >> :p1 :o1.
+<<( :a :b :c )>> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test001a.ttl
+++ b/rdf/rdf12/rdf-semantics/test001a.ttl
@@ -1,4 +1,4 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b :c >> :p1 :o1.
-<< :a :b :c >> :p2 :o2.
+:a1 :p1 <<( :a :b :c )>> ,
+:a1 :p1 <<( :a :b :c )>> .

--- a/rdf/rdf12/rdf-semantics/test001r.ttl
+++ b/rdf/rdf12/rdf-semantics/test001r.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b :c >> :p1 :o1; :p2 :o2.
+:a1 :p1 <<( :a :b :c )>> .

--- a/rdf/rdf12/rdf-semantics/test002a.ttl
+++ b/rdf/rdf12/rdf-semantics/test002a.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b :c >> :p1 :o1.
+:a1 :p1 <<( :a :b :c )>> .

--- a/rdf/rdf12/rdf-semantics/test002or.ttl
+++ b/rdf/rdf12/rdf-semantics/test002or.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b _:x >> :p1 :o1.
+:a1 :p1 <<( :a :b _:x )>> .

--- a/rdf/rdf12/rdf-semantics/test002r.ttl
+++ b/rdf/rdf12/rdf-semantics/test002r.ttl
@@ -1,3 +1,0 @@
-prefix : <http://example.com/ns#>
-
-<< :a :b :c >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test002sbr.ttl
+++ b/rdf/rdf12/rdf-semantics/test002sbr.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< _:x :b _:x >> :p1 :o1.
+:a1 :p1 <<( _:x :b _:x )>> .

--- a/rdf/rdf12/rdf-semantics/test002sor.ttl
+++ b/rdf/rdf12/rdf-semantics/test002sor.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< _:x :b _:y >> :p1 :o1.
+:a1 :p1 <<( _:x :b _:y )>> .

--- a/rdf/rdf12/rdf-semantics/test002sr.ttl
+++ b/rdf/rdf12/rdf-semantics/test002sr.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< _:x :b :c >> :p1 :o1.
+:a1 :p1 <<( _:x :b :c )>> .

--- a/rdf/rdf12/rdf-semantics/test003a.ttl
+++ b/rdf/rdf12/rdf-semantics/test003a.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b :a >> :p1 :o1.
+:a1 :p1 <<( :a :b :a )>> .

--- a/rdf/rdf12/rdf-semantics/test003r.ttl
+++ b/rdf/rdf12/rdf-semantics/test003r.ttl
@@ -1,3 +1,0 @@
-prefix : <http://example.com/ns#>
-
-<< :a :b :a >> :p1 :o1.

--- a/rdf/rdf12/rdf-semantics/test004a.ttl
+++ b/rdf/rdf12/rdf-semantics/test004a.ttl
@@ -1,5 +1,5 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b :c >> :p1 :o1.
+:a1 :p1 <<( :a :b :c )>>.
 :a :label "A".
 :c :label "C".

--- a/rdf/rdf12/rdf-semantics/test004fr.ttl
+++ b/rdf/rdf12/rdf-semantics/test004fr.ttl
@@ -1,4 +1,4 @@
 prefix : <http://example.com/ns#>
 
-<< _:x :b :c >> :p1 :o1.
+:a1 :p1 <<( _:x :b :c )>>.
 _:x :label "C".

--- a/rdf/rdf12/rdf-semantics/test004or.ttl
+++ b/rdf/rdf12/rdf-semantics/test004or.ttl
@@ -1,4 +1,4 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b _:x >> :p1 :o1.
+:a1 :p1 <<( :a :b _:x )>>.
 _:x :label "C".

--- a/rdf/rdf12/rdf-semantics/test004sr.ttl
+++ b/rdf/rdf12/rdf-semantics/test004sr.ttl
@@ -1,4 +1,4 @@
 prefix : <http://example.com/ns#>
 
-<< _:x :b :c >> :p1 :o1.
+:a1 :p1 <<( _:x :b :c )>>.
 _:x :label "A".

--- a/rdf/rdf12/rdf-semantics/test005.ttl
+++ b/rdf/rdf12/rdf-semantics/test005.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b :d >> :p1 :o1.
+:a1 :p1 <<( :a :b :d )>> .

--- a/rdf/rdf12/rdf-semantics/test006a.ttl
+++ b/rdf/rdf12/rdf-semantics/test006a.ttl
@@ -1,5 +1,5 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b "42"^^xsd:integer >> :p1 :o1.
+:a1 :p1 <<( :a :b "42"^^xsd:integer )>>.
 :s2 :p2 "42"^^xsd:integer.

--- a/rdf/rdf12/rdf-semantics/test006r.ttl
+++ b/rdf/rdf12/rdf-semantics/test006r.ttl
@@ -1,5 +1,5 @@
 prefix : <http://example.com/ns#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<< :a :b _:x >> :p1 :o1.
+:a1 :p1 <<( :a :b _:x )>>.
 :s2 :p2 _:x.

--- a/rdf/rdf12/rdf-semantics/test007a2.ttl
+++ b/rdf/rdf12/rdf-semantics/test007a2.ttl
@@ -1,4 +1,4 @@
 prefix : <http://example.com/ns#>
 
 :a :b :c.
-<< :a :b :c >> :p1 :o1.
+:a1 :p1 <<( :a :b :c )>>.

--- a/rdf/rdf12/rdf-semantics/test007r2.ttl
+++ b/rdf/rdf12/rdf-semantics/test007r2.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b :c >> :p1 :o1.
+:a1 :p1 <<( :a :b :c )>>.

--- a/rdf/rdf12/rdf-semantics/upercase-language-string.ttl
+++ b/rdf/rdf12/rdf-semantics/upercase-language-string.ttl
@@ -1,3 +1,3 @@
 prefix : <http://example.com/ns#>
 
-<< :a :b "hello"@en-US >> :p1 :o1.
+:a1 :p1 <<( :a :b "hello"@en-US )>>.

--- a/rdf/rdf12/template.haml
+++ b/rdf/rdf12/template.haml
@@ -97,6 +97,7 @@
           Test Descriptions
         %dl.test-description
           - man['entries'].each do |test|
+            - require 'byebug'; byebug unless test['@id']
             - test_id = test['@id'].split('#').last
             %dt{id: test_id}
               %a.testlink{href: "##{test_id}"}


### PR DESCRIPTION
Updates tests which used the old quoted triples, typically in the subject position, to use triple terms in the object position.