### PR TITLE
Fix a wrong expected SPARQL protocol test result

### DIFF
--- a/sparql/sparql11/protocol/index.html
+++ b/sparql/sparql11/protocol/index.html
@@ -308,7 +308,7 @@ User-agent: sparql-client/0.1
 Content-Type: application/sparql-query
 Content-Length: XXX
 
-ASK FROM &lt;http://kasei.us/2009/09/sparql/data/data1.rdf&gt; { &lt;data1.rdf&gt; ?p ?o }
+ASK FROM &lt;http://kasei.us/2009/09/sparql/data/data1.rdf&gt; { &lt;http://kasei.us/2009/09/sparql/data/data1.rdf&gt; ?p ?o }
 </code></pre>
             <h4 id="response">Response</h4>
             <pre><code>2xx or 3xx response

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -192,7 +192,7 @@
     Content-Type: application/sparql-query
     Content-Length: XXX
 
-    ASK FROM <http://kasei.us/2009/09/sparql/data/data1.rdf> { <data1.rdf> ?p ?o }
+    ASK FROM <http://kasei.us/2009/09/sparql/data/data1.rdf> { <http://kasei.us/2009/09/sparql/data/data1.rdf> ?p ?o }
     
 #### Response
 


### PR DESCRIPTION
The test case "query specifying dataset in both query string and protocol; test for use of protocol-specified dataset" 
reads as follows originally:
```
#### Request

    POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
    Host: www.example
    User-agent: sparql-client/0.1
    Content-Type: application/sparql-query
    Content-Length: XXX

    ASK FROM <http://kasei.us/2009/09/sparql/data/data1.rdf> { <data1.rdf> ?p ?o }
    
#### Response

    2xx or 3xx response
    Content-Type: application/sparql-results+xml or application/sparql-results+json

    true
 ```
As far as I understand, the expected result of `true` is wrong, because
* The protocol specifies (via `default-graph-uri`) the default graph `...data2.rdf`
* The query specifies (via FROM) the default graph `data1.rdf`
* SPARQL 1.1 Protocol as well as the name of the test specify, that in this case, the dataset specification ofthe protocol (so data2.rdf) should be used, which only contains theIRI `<...data2.rdf>`
* Therefore the expected result should be `false`

Additionally, the IRI in the query body doesn't use an absolute IRI and there is no base declaration, I have also added the full IRI for thi PR.

An alternative way to fix this would be to leave the expected result at "true" and change the query s.t. it asks for `data2.rdf` in the WHERE clause.

Please let me know what you think, and (possibly if so) were I am mistaken.
Best regards