### PR TITLE
Expand Syntax Tests of Decimal Numbers in Turtle

### DIFF
--- a/rdf/rdf12/rdf-turtle/syntax/index.html
+++ b/rdf/rdf12/rdf-turtle/syntax/index.html
@@ -358,6 +358,46 @@
             </dd>
           </dl>
         </dd>
+        <dt id='turtle12-number-1'>
+          <a class='testlink' href='#turtle12-number-1'>
+            turtle12-number-1:
+          </a>
+          <span about='../syntax#turtle12-number-1' property='mf:name'>Turtle 1.2 - double literal no leading zero</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle12-number-1' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle12-syntax-number-01.ttl' property='mf:action'>turtle12-syntax-number-01.ttl</a>
+            </dd>
+          </dl>
+        </dd>
+        <dt id='turtle12-number-2'>
+          <a class='testlink' href='#turtle12-number-2'>
+            turtle12-number-2:
+          </a>
+          <span about='../syntax#turtle12-number-2' property='mf:name'>Turtle 1.2 - decimal literal no leading zero</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='../syntax#turtle12-number-2' typeof='rdft:TestTurtlePositiveSyntax'>
+          <div property='rdfs:comment'>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>rdft:TestTurtlePositiveSyntax</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='turtle12-syntax-number-02.ttl' property='mf:action'>turtle12-syntax-number-02.ttl</a>
+            </dd>
+          </dl>
+        </dd>
         <dt id='turtle12-bad-1'>
           <a class='testlink' href='#turtle12-bad-1'>
             turtle12-bad-1:

--- a/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
@@ -43,6 +43,9 @@ trs:manifest  rdf:type mf:Manifest ;
         trs:turtle12-bnode-2
         trs:turtle12-bnode-3
 
+        trs:turtle12-number-1
+        trs:turtle12-number-2
+
         trs:turtle12-bad-1
         trs:turtle12-bad-2
         trs:turtle12-bad-3
@@ -181,6 +184,16 @@ trs:turtle12-bnode-2 rdf:type rdft:TestTurtlePositiveSyntax ;
 trs:turtle12-bnode-3 rdf:type rdft:TestTurtlePositiveSyntax ;
    mf:name      "Turtle 1.2 - blank node" ;
    mf:action    <turtle12-syntax-bnode-03.ttl> ;
+   .
+
+trs:turtle12-number-1 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle 1.2 - double literal no leading zero" ;
+   mf:action    <turtle12-syntax-number-01.ttl> ;
+   .
+
+trs:turtle12-number-2 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle 1.2 - decimal literal no leading zero" ;
+   mf:action    <turtle12-syntax-number-02.ttl> ;
    .
 
 ## Bad Syntax

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-syntax-number-01.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-syntax-number-01.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p -.2e3 .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-syntax-number-02.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-syntax-number-02.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+
+:s :p +.7 .


### PR DESCRIPTION
Addresses the issue raised in #193 by adding two test inputs for the syntax of decimal numbers in Turtle.

As suggested, I put the syntax tests into the RDF 1.2 folder, although the syntax are already part of RDF 1.1.