### PR TITLE
Add missing prefixes for Graph Store Protocol Test

### DIFF
--- a/sparql/sparql11/http-rdf-update/index.html
+++ b/sparql/sparql11/http-rdf-update/index.html
@@ -140,6 +140,9 @@ Accept: text/turtle
 Content-Type: text/turtle; charset=utf-8
 Content-Length: ...
 
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
 &lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;
    foaf:businessCard [
         a v:VCard;

--- a/sparql/sparql11/http-rdf-update/manifest.ttl
+++ b/sparql/sparql11/http-rdf-update/manifest.ttl
@@ -248,6 +248,9 @@ gsp:get_of_put__initial_state a mf:GraphStoreProtocolTest;
     Content-Type: text/turtle; charset=utf-8
     Content-Length: ...
 
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+
     <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
        foaf:businessCard [
             a v:VCard;


### PR DESCRIPTION
The expected response for the Graph Store Protocol test `GET of PUT - Initial state` was missing the prefix definitions. This PR adds these.