### PR TITLE
Indirect Graph Identification Graph IRI is absolute

### DIFF
--- a/sparql/sparql11/http-rdf-update/index.html
+++ b/sparql/sparql11/http-rdf-update/index.html
@@ -131,7 +131,7 @@ Content-Type: text/turtle; charset=utf-8
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_put__initial_state' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
             <h4 id="request">Request</h4>
-            <pre><code>GET $GRAPHSTORE$?graph=$GRAPHSTORE$/person/1.ttl HTTP/1.1
+            <pre><code>GET $GRAPHSTORE$?graph=http://$HOST$/$GRAPHSTORE$/person/1.ttl HTTP/1.1
 Host: $HOST$
 Accept: text/turtle
 </code></pre>

--- a/sparql/sparql11/http-rdf-update/manifest.ttl
+++ b/sparql/sparql11/http-rdf-update/manifest.ttl
@@ -238,7 +238,7 @@ gsp:get_of_put__initial_state a mf:GraphStoreProtocolTest;
     rdfs:comment """
 #### Request
 
-    GET $GRAPHSTORE$?graph=$GRAPHSTORE$/person/1.ttl HTTP/1.1
+    GET $GRAPHSTORE$?graph=http://$HOST$/$GRAPHSTORE$/person/1.ttl HTTP/1.1
     Host: $HOST$
     Accept: text/turtle
 


### PR DESCRIPTION
If [Graph Store Protocol Indirect Graph Identification](https://www.w3.org/TR/2013/REC-sparql11-http-rdf-update-20130321/#indirect-graph-identification) is used, then the query string must be an absolute IRI. The Graph Store Protocol test `GET of PUT - Initial state` had a relative IRI which is now fixed.