### PR TITLE
Add test for entailment of literal type

### DIFF
--- a/rdf/rdf12/rdf-semantics/index.html
+++ b/rdf/rdf12/rdf-semantics/index.html
@@ -527,6 +527,31 @@
             </dd>
           </dl>
         </dd>
+        <dt id='literal-type'>
+          <a class='testlink' href='#literal-type'>
+            literal-type:
+          </a>
+          <span about='../rdf-semantics#literal-type' property='mf:name'>literal-type</span>
+        </dt>
+        <dd inlist='true' property='mf:entry' resource='../rdf-semantics#literal-type' typeof='mf:PositiveEntailmentTest'>
+          <div property='rdfs:comment'>
+            <p>Literals denote instances of their datatype.</p>
+          </div>
+          <dl class='test-detail'>
+            <dt>type</dt>
+            <dd>mf:PositiveEntailmentTest</dd>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource=''></dd>
+            <dt>action</dt>
+            <dd>
+              <a href='canonical-literal-control.ttl' property='mf:action'>canonical-literal-control.ttl</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='literal-type.ttl' property='mf:result'>literal-type.ttl</a>
+            </dd>
+          </dl>
+        </dd>
         <dt id='malformed-literal-control'>
           <a class='testlink' href='#malformed-literal-control'>
             malformed-literal-control:

--- a/rdf/rdf12/rdf-semantics/literal-type.ttl
+++ b/rdf/rdf12/rdf-semantics/literal-type.ttl
@@ -1,0 +1,7 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX : <http://example.com/ns#>
+
+:a :b _:x .
+_:x rdf:type xsd:integer .

--- a/rdf/rdf12/rdf-semantics/manifest.ttl
+++ b/rdf/rdf12/rdf-semantics/manifest.ttl
@@ -49,6 +49,7 @@ trs:manifest a mf:Manifest;
     trs:constrained-bnodes-in-triple-term-object
     trs:constrained-bnodes-in-triple-term-fail
     trs:constrained-bnodes-on-literal
+    trs:literal-type
     trs:malformed-literal-control
     trs:malformed-literal
     trs:malformed-literal-accepted
@@ -234,6 +235,16 @@ trs:triple-terms-no-spurious a mf:NegativeEntailmentTest;
   mf:result <test005.ttl>;
   mf:unrecognizedDatatypes ();
   rdft:approval rdft:NotClassified .
+
+trs:literal-type a mf:PositiveEntailmentTest;
+  rdfs:comment "Literals denote instances of their datatype.";
+  mf:action <canonical-literal-control.ttl>;
+  mf:entailmentRegime "RDF";
+  mf:name "literal-type";
+  mf:recognizedDatatypes (xsd:integer);
+  mf:result <literal-type.ttl>;
+  mf:unrecognizedDatatypes ();
+  test:approval test:NotClassified .
 
 trs:malformed-literal a mf:PositiveEntailmentTest;
   rdfs:comment "Malformed literals are allowed in triple terms, but cause inconsistency.";


### PR DESCRIPTION
Adds test for second semantic condition of [RDF Interpretations](https://www.w3.org/TR/rdf12-semantics/#rdf_d_interpretations) (based on [example pattern](https://www.w3.org/TR/rdf12-semantics/#rdf_entailment_patterns)).