### PR TITLE
Fix RDF/XML xml-canon-test001

### DIFF
--- a/rdf/rdf11/rdf-xml/xml-canon/test001.nt
+++ b/rdf/rdf11/rdf-xml/xml-canon/test001.nt
@@ -13,4 +13,4 @@
 # $Id: test001.nt,v 1.1 2003/08/18 10:09:29 jgrant Exp $
 #
 #####################################################################
-<http://www.example.org/a> <http://example.org/prop> "<br></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
+<http://www.example.org/a> <http://example.org/prop> "<br xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:eg=\"http://example.org/\"></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .


### PR DESCRIPTION
The  xml-canon-test001 did not include the proper xml namespaces.
This new expected output is the same as what the Ruby RDF Distiller produces.