### PR TITLE
Exclude non-triple-term comparisons from op-4

### DIFF
--- a/sparql/sparql12/eval-triple-terms/op-4.rq
+++ b/sparql/sparql12/eval-triple-terms/op-4.rq
@@ -3,6 +3,7 @@ PREFIX :       <http://example/>
 SELECT * {
   ?x :left ?left .
   ?x :right ?right .
+  FILTER ( isTRIPLE(?left) && isTRIPLE(?right) )
   FILTER ( ?left <= ?right )
   FILTER ( ?right >= ?left )
 }

--- a/sparql/sparql12/eval-triple-terms/op-4.srj
+++ b/sparql/sparql12/eval-triple-terms/op-4.srj
@@ -285,34 +285,6 @@
                     },
                     "type": "triple"
                 }
-            },
-            {
-                "x": {
-                    "value": "http://example/x9",
-                    "type": "uri"
-                },
-                "left": {
-                    "value": "http://example/irireifier",
-                    "type": "uri"
-                },
-                "right": {
-                    "value": "http://example/irireifier",
-                    "type": "uri"
-                }
-            },
-            {
-                "x": {
-                    "value": "http://example/x10",
-                    "type": "uri"
-                },
-                "left": {
-                    "value": "bc_0_b0_bnodereifier",
-                    "type": "bnode"
-                },
-                "right": {
-                    "value": "bc_0_b0_bnodereifier",
-                    "type": "bnode"
-                }
             }
         ]
     }


### PR DESCRIPTION
As discussed in #168, <= and >= are not defined on IRIs and blank nodes in the SPARQL operator table.
As such, this spec test should not rely on their existence, even though some implementations may have support for them through operator extensions.