### PR TITLE
Fix inconsistencies in SPARQL 1.2 test manifests

### DIFF
--- a/sparql/sparql12/codepoint-escapes/manifest.ttl
+++ b/sparql/sparql12/codepoint-escapes/manifest.ttl
@@ -1,11 +1,11 @@
 @prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix :       <https://w3c.github.io/rdf-tests/sparql/sparql12/codepoint-escapes#> .
+@prefix :       <https://w3c.github.io/rdf-tests/sparql/sparql12/codepoint-escapes/manifest#> .
 @prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
 @prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
 
-:manifest  rdf:type mf:Manifest ;
+<>  rdf:type mf:Manifest ;
     rdfs:label "SPARQL Codepoint-Escaping Tests" ;
     mf:entries
     ( 

--- a/sparql/sparql12/expression/manifest.ttl
+++ b/sparql/sparql12/expression/manifest.ttl
@@ -5,7 +5,7 @@
 @prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
 @prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
 
-:manifest  rdf:type mf:Manifest ;
+<>  rdf:type mf:Manifest ;
     rdfs:label "Expression" ;
     mf:entries
     ( 

--- a/sparql/sparql12/grouping/manifest.ttl
+++ b/sparql/sparql12/grouping/manifest.ttl
@@ -5,7 +5,7 @@
 @prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
 @prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
 
-:manifest  rdf:type mf:Manifest ;
+<>  rdf:type mf:Manifest ;
     rdfs:label "Grouping" ;
     mf:entries
     ( 

--- a/sparql/sparql12/lang-basedir/manifest.ttl
+++ b/sparql/sparql12/lang-basedir/manifest.ttl
@@ -5,7 +5,7 @@
 @prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
 @prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
 
-:manifest  rdf:type mf:Manifest ;
+<>  rdf:type mf:Manifest ;
     rdfs:label "Language and base direction" ;
     mf:entries
     (

--- a/sparql/sparql12/rdf11/manifest.ttl
+++ b/sparql/sparql12/rdf11/manifest.ttl
@@ -5,7 +5,7 @@
 @prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
 @prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
 
-:manifest  rdf:type mf:Manifest ;
+<>  rdf:type mf:Manifest ;
     rdfs:label "RDF 1.1 literals handling" ;
     mf:entries
     (


### PR DESCRIPTION
This fixes some inconsistencies across SPARQL 1.2 test manifests, which may otherwise cause some test runners to trip over (or ignore) them.