### PR TITLE
Delete old duplicate TriG 1.2 object reification test case

### DIFF
--- a/rdf/rdf12/rdf-trig/eval/manifest.ttl
+++ b/rdf/rdf12/rdf-trig/eval/manifest.ttl
@@ -101,12 +101,6 @@ trs:trig12-rt-08 rdf:type rdft:TestTrigEval ;
    mf:result    <trig12-eval-rt-08.nq> ;
    .
 
-trs:trig12-4 rdf:type rdft:TestTrigEval ;
-   mf:name      "TriG 1.2 - object reification with identifier" ;
-   mf:action    <trig12-eval-04.trig> ;
-   mf:result    <trig12-eval-04.nq> ;
-   .
-
 trs:trig12-bnode-1 rdf:type rdft:TestTrigEval ;
    mf:name      "TriG 1.2 - blank node label" ;
    mf:action    <trig12-eval-bnode-1.trig> ;


### PR DESCRIPTION
Not a big deal or really an issue - just removed test case for object reification with identifier since it is most likely a duplicate of the one at line 74. It is also not mentioned in the entries list above. Probably accidentally left there during a refactor.

Discovered while writing a test runner which did not use RDF/SPARQL but instead parse the manifest files directly with custom logic.