### PR TITLE
Consistently format GSP conformance tests expected response status code

### DIFF
--- a/sparql/sparql11/http-rdf-update/index.html
+++ b/sparql/sparql11/http-rdf-update/index.html
@@ -109,7 +109,8 @@ Content-Type: text/turtle; charset=utf-8
     ].
 </code></pre>
             <h4 id="response">Response</h4>
-            <p><code>201 Created</code></p>
+            <pre><code>201 Created
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>

--- a/sparql/sparql11/http-rdf-update/manifest.ttl
+++ b/sparql/sparql11/http-rdf-update/manifest.ttl
@@ -426,7 +426,7 @@ gsp:put__initial_state a mf:GraphStoreProtocolTest;
 
 #### Response
 
-`201 Created`
+    201 Created
     """ .
 
 gsp:put__mismatched_payload a mf:GraphStoreProtocolTest;


### PR DESCRIPTION
Remove the backticks from the expected response status code for the `PUT - initial state` GSP SPARQL 1.1 conformance test to format it the same as all the other tests.