### PR TITLE
Fix GSP `POST - existing graph` and `GET of POST - existing graph` test mixup/omission

### DIFF
--- a/sparql/sparql11/http-rdf-update/index.html
+++ b/sparql/sparql11/http-rdf-update/index.html
@@ -439,6 +439,18 @@ Host: $HOST$
         </dt>
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#post__existing_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
+            <h4 id="request">Request</h4>
+            <pre><code>POST $GRAPHSTORE$/person/1.ttl HTTP/1.1
+Host: $HOST$
+Content-Type: text/turtle; charset=utf-8
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; foaf:name "Jane Doe"
+</code></pre>
+            <h4 id="response">Response</h4>
+            <pre><code>200 OK
+</code></pre>
           </div>
           <dl class='test-detail'>
             <dt>type</dt>
@@ -460,16 +472,23 @@ Host: $HOST$
         <dd inlist='true' property='mf:entry' resource='http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#get_of_post__existing_graph' typeof='mf:GraphStoreProtocolTest'>
           <div property='rdfs:comment'>
             <h4 id="request">Request</h4>
-            <pre><code>POST $GRAPHSTORE$/person/1.ttl HTTP/1.1
+            <pre><code>GET $GRAPHSTORE$/person/1.ttl HTTP/1.1
 Host: $HOST$
-Content-Type: text/turtle; charset=utf-8
-
-@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
-
-&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; foaf:name "Jane Doe"
+Accept: text/turtle
 </code></pre>
             <h4 id="response">Response</h4>
             <pre><code>200 OK
+Content-Type: text/turtle; charset=utf-8
+Content-Length: ...
+
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
+@prefix v: &lt;http://www.w3.org/2006/vcard/ns#&gt; .
+
+&lt;http://$HOST$/$GRAPHSTORE$/person/1&gt; a foaf:Person;
+   foaf:businessCard [
+        a v:VCard;
+        v:fn "John Doe"
+   ] .
 </code></pre>
           </div>
           <dl class='test-detail'>

--- a/sparql/sparql11/http-rdf-update/manifest.ttl
+++ b/sparql/sparql11/http-rdf-update/manifest.ttl
@@ -135,17 +135,24 @@ gsp:get_of_post__existing_graph a mf:GraphStoreProtocolTest;
     rdfs:comment """
 #### Request
 
-    POST $GRAPHSTORE$/person/1.ttl HTTP/1.1
+    GET $GRAPHSTORE$/person/1.ttl HTTP/1.1
     Host: $HOST$
-    Content-Type: text/turtle; charset=utf-8
-
-    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-
-    <http://$HOST$/$GRAPHSTORE$/person/1> foaf:name "Jane Doe"
+    Accept: text/turtle
 
 #### Response
 
     200 OK
+    Content-Type: text/turtle; charset=utf-8
+    Content-Length: ...
+
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+
+    <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
+       foaf:businessCard [
+            a v:VCard;
+            v:fn "John Doe"
+       ] .
     """ .
 
 gsp:get_of_post__multipart_formdata a mf:GraphStoreProtocolTest;
@@ -319,7 +326,22 @@ gsp:post__create__new_graph a mf:GraphStoreProtocolTest;
 gsp:post__existing_graph a mf:GraphStoreProtocolTest;
     dawg:approval dawg:Approved;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "POST - existing graph" .
+    mf:name "POST - existing graph" ;
+    rdfs:comment """
+#### Request
+
+    POST $GRAPHSTORE$/person/1.ttl HTTP/1.1
+    Host: $HOST$
+    Content-Type: text/turtle; charset=utf-8
+
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+    <http://$HOST$/$GRAPHSTORE$/person/1> foaf:name "Jane Doe"
+
+#### Response
+
+    200 OK
+    """ .
 
 gsp:post__multipart_formdata a mf:GraphStoreProtocolTest;
     dawg:approval dawg:Approved;


### PR DESCRIPTION
Fix the description of the tests `POST - existing graph` and `GET of POST - existing graph` in the manifest.

- `POST - existing graph` had no comment describing the test case.
- `GET of POST - existing graph` contained the test case for `POST - existing graph`.

The specifications from <https://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/>, but are also what I'd expect from the test names. As far as I can tell both tests have been [approved in 2012](https://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3), but I don't know why they got lost/mixed up.