### PR TITLE
Change reified triple to triple term

### DIFF
--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-syntax-basic-08.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-syntax-basic-08.ttl
@@ -1,4 +1,4 @@
 PREFIX : <http://example/>
 
 :s1 :p true .
-<<(:s1 :p true)>> .
+:s2 :p <<(:s1 :p true)>> .


### PR DESCRIPTION
According to [the description of the test](https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax/#turtle12-8), this should be a triple term, not a reified triple...