### PR TITLE
RDF 1.2: Restore missing semantics test files

### DIFF
--- a/rdf/rdf12/rdf-semantics/malformed-literal-2r.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-2r.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:a1 :p1 <<( :a :b _:x )>>.
+:a2 :p2 <<( :d :b _:x )>>.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-3a.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-3a.ttl
@@ -1,0 +1,5 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:a1 :p1 <<( :a :b "c"^^xsd:integer )>>.
+:a2 :p2 <<( :d :b "d"^^xsd:integer )>>.

--- a/rdf/rdf12/rdf-semantics/malformed-literal.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal.ttl
@@ -1,0 +1,4 @@
+prefix : <http://example.com/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:a1 :p1 <<( :a :b "c"^^xsd:integer )>>.

--- a/rdf/rdf12/rdf-semantics/test000o.ttl
+++ b/rdf/rdf12/rdf-semantics/test000o.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+:s1 :p1 <<( :x :y :z )>>.

--- a/rdf/rdf12/rdf-semantics/test000s.ttl
+++ b/rdf/rdf12/rdf-semantics/test000s.ttl
@@ -1,0 +1,3 @@
+prefix : <http://example.com/ns#>
+
+<<( :a :b :c )>> :p1 :o1.


### PR DESCRIPTION
Restores the following test files in `rdf/rdf12/rdf-semantics/` that were previously removed in `95220cf`:

- [malformed-literal](https://github.com/w3c/rdf-tests/blob/b2e0c1a488b79ca7ce158da95920d37e39938fb8/rdf/rdf12/rdf-semantics/manifest.ttl#L238)
- [malformed-literal-accepted](https://github.com/w3c/rdf-tests/blob/b2e0c1a488b79ca7ce158da95920d37e39938fb8/rdf/rdf12/rdf-semantics/manifest.ttl#L248)
- [malformed-literal-bnode-neg](https://github.com/w3c/rdf-tests/blob/b2e0c1a488b79ca7ce158da95920d37e39938fb8/rdf/rdf12/rdf-semantics/manifest.ttl#L258)
- [malformed-literal-no-spurious](https://github.com/w3c/rdf-tests/blob/b2e0c1a488b79ca7ce158da95920d37e39938fb8/rdf/rdf12/rdf-semantics/manifest.ttl#L278)

Fixes #213