### PR TITLE
Restore rdf12/rdf-semantics/malformed-literal.ttl; remove unused malformed-literal* TTL files.

### DIFF
--- a/rdf/rdf12/rdf-semantics/malformed-literal-2a.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-2a.ttl
@@ -1,5 +1,0 @@
-prefix : <http://example.com/ns#>
-prefix xsd: <http://www.w3.org/2001/XMLSchema#>
-
-:a1 :p1 <<( :a :b "c"^^xsd:integer )>>.
-:a2 :p2 <<( :d :b "c"^^xsd:integer )>>.

--- a/rdf/rdf12/rdf-semantics/malformed-literal-3r.ttl
+++ b/rdf/rdf12/rdf-semantics/malformed-literal-3r.ttl
@@ -1,5 +1,0 @@
-prefix : <http://example.com/ns#>
-prefix xsd: <http://www.w3.org/2001/XMLSchema#>
-
-:a1 :p1 <<( :a :b _:x )>>.
-:a2 :p2 <<( :d :b _:x )>>.


### PR DESCRIPTION
Closes #213
Closes w3c/rdf-semantics#180

This PR restores the file `malformed-literal.ttl`.

The other missing files mentioned in #213 

Commit d6a0455e30 took two tests out of the manifest file because they were not in the "emtries" section and the commens said they were withdrawn.

Commit 95220cff6c removed some files which intended to clear-up for those two tests but also removed `malformed-literal.ttl` which is still in-use.

`rdf/rdf12/rdf-semantics/malformed-literal-2a.ttl` and `rdf/rdf12/rdf-semantics/malformed-literal-3r.ttl` are not mentioned in the current manifest so it looks like there are not needed.

This PR is an alternative to #279.