### PR TITLE
Use Turtle test runners for Turtle tests

### DIFF
--- a/rdf/rdf11/rdf-turtle/manifest.ttl
+++ b/rdf/rdf11/rdf-turtle/manifest.ttl
@@ -1773,13 +1773,13 @@
    mf:action    <turtle-syntax-bad-base-03.ttl> ;
    .
 
-<#turtle-syntax-bad-bnode-01> rdf:type rdft:TestNTriplesNegativeSyntax ;
+<#turtle-syntax-bad-bnode-01> rdf:type rdft:TestTurtleNegativeSyntax ;
    mf:name      "turtle-syntax-bad-bnode-01" ;
    rdfs:comment "Colon in bnode label not allowed (negative test)" ;
    mf:action    <turtle-syntax-bad-bnode-01.ttl> ;
    .
 
-<#turtle-syntax-bad-bnode-02> rdf:type rdft:TestNTriplesNegativeSyntax ;
+<#turtle-syntax-bad-bnode-02> rdf:type rdft:TestTurtleNegativeSyntax ;
    mf:name      "turtle-syntax-bad-bnode-02" ;
    rdfs:comment "Colon in bnode label not allowed (negative test)" ;
    mf:action    <turtle-syntax-bad-bnode-02.ttl> ;

--- a/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
@@ -368,22 +368,22 @@ trs:nt-ttl12-bad-05 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:action    <nt-ttl12-bad-syntax-05.ttl> ;
     .
 
-trs:nt-ttl12-bad-06 rdf:type rdft:TestNTriplesNegativeSyntax ;
+trs:nt-ttl12-bad-06 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "N-Triples 1.2 as Turtle 1.2 - Bad - reified triple as predicate" ;
     mf:action    <nt-ttl12-bad-syntax-06.ttl> ;
     .
 
-trs:nt-ttl12-bad-07 rdf:type rdft:TestNTriplesNegativeSyntax ;
+trs:nt-ttl12-bad-07 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "N-Triples 1.2 as Turtle 1.2 - Bad - reified triple, literal subject" ;
     mf:action    <nt-ttl12-bad-syntax-07.ttl> ;
     .
 
-trs:nt-ttl12-bad-08 rdf:type rdft:TestNTriplesNegativeSyntax ;
+trs:nt-ttl12-bad-08 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "N-Triples 1.2 as Turtle 1.2 - Bad - reified triple, literal predicate" ;
     mf:action    <nt-ttl12-bad-syntax-08.ttl> ;
     .
 
-trs:nt-ttl12-bad-09 rdf:type rdft:TestNTriplesNegativeSyntax ;
+trs:nt-ttl12-bad-09 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "N-Triples 1.2 as Turtle 1.2 - Bad - reified triple, blank node predicate" ;
     mf:action    <nt-ttl12-bad-syntax-09.ttl> ;
     .


### PR DESCRIPTION
There are a number of tests for Turtle 1.1 and 1.2 syntax that use an N-Triples test runner instead of a Turtle test runner:

- in rdf/rdf11/rdf-turtle/manifest.ttl:
   - `turtle-syntax-bad-bnode-01`
   - `turtle-syntax-bad-bnode-02`
- in rdf/rdf12/rdf-turtle/syntax/manifest.ttl:
    - `N-Triples 1.2 as Turtle 1.2 - Bad - reified triple as predicate`
    - `N-Triples 1.2 as Turtle 1.2 - Bad - reified triple, literal subject`
    - `N-Triples 1.2 as Turtle 1.2 - Bad - reified triple, literal predicate`
    - `N-Triples 1.2 as Turtle 1.2 - Bad - reified triple, blank node predicate`

Is there any particular reason to use an N-Triples test runner for these tests?

If not, this PR changes the above tests to a Turtle test runner.