### PR TITLE
More testing of triple terms in RDF/XML

### DIFF
--- a/rdf/rdf12/rdf-xml/eval/manifest.ttl
+++ b/rdf/rdf12/rdf-xml/eval/manifest.ttl
@@ -40,7 +40,8 @@ trs:manifest  rdf:type mf:Manifest ;
         trs:rdf12-xml-tt-05
         trs:rdf12-xml-tt-06
         trs:rdf12-xml-tt-07
-        trs:rdf12-xml-tt-08
+        trs:rdf12-xml-tt-bad-01
+        trs:rdf12-xml-tt-bad-02
 
         trs:rdf12-xml-an-01
         trs:rdf12-xml-an-02
@@ -121,31 +122,37 @@ trs:rdf12-xml-tt-03 rdf:type rdft:TestXMLEval;
 
 trs:rdf12-xml-tt-04 rdf:type rdft:TestXMLEval;
   mf:name     "rdf12-xml-tt-04";
-  mf:comment  "Triple term having a type";
+  mf:comment  "Triple term having a type (rdf:Description)";
   mf:action   <rdf12-xml-tt-04.rdf>;
   mf:result   <rdf12-xml-tt-04.nt> .
 
 trs:rdf12-xml-tt-05 rdf:type rdft:TestXMLEval;
   mf:name     "rdf12-xml-tt-05";
-  mf:comment  "Triple term having BNode object";
+  mf:comment  "Triple term having a type (striped)";
   mf:action   <rdf12-xml-tt-05.rdf>;
   mf:result   <rdf12-xml-tt-05.nt> .
 
 trs:rdf12-xml-tt-06 rdf:type rdft:TestXMLEval;
   mf:name     "rdf12-xml-tt-06";
-  mf:comment  "Recursive triple term";
+  mf:comment  "Triple term having BNode object";
   mf:action   <rdf12-xml-tt-06.rdf>;
   mf:result   <rdf12-xml-tt-06.nt> .
 
-trs:rdf12-xml-tt-07 rdf:type rdft:TestXMLNegativeSyntax;
+trs:rdf12-xml-tt-07 rdf:type rdft:TestXMLEval;
   mf:name     "rdf12-xml-tt-07";
-  mf:comment  "Invalid triple term having no predicate or object";
-  mf:action   <rdf12-xml-tt-07.rdf> .
+  mf:comment  "Recursive triple term";
+  mf:action   <rdf12-xml-tt-07.rdf>;
+  mf:result   <rdf12-xml-tt-07.nt> .
 
-trs:rdf12-xml-tt-08 rdf:type rdft:TestXMLNegativeSyntax;
-  mf:name     "rdf12-xml-tt-08";
+trs:rdf12-xml-tt-bad-01 rdf:type rdft:TestXMLNegativeSyntax;
+  mf:name     "rdf12-xml-tt-bad-01";
+  mf:comment  "Invalid triple term having no predicate or object";
+  mf:action   <rdf12-xml-tt-bad-01.rdf> .
+
+trs:rdf12-xml-tt-bad-02 rdf:type rdft:TestXMLNegativeSyntax;
+  mf:name     "rdf12-xml-tt-bad-02";
   mf:comment  "Invalid triple term having two objects";
-  mf:action   <rdf12-xml-tt-08.rdf> .
+  mf:action   <rdf12-xml-tt-bad-02.rdf> .
 
 # Annotations
 

--- a/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-01.nt
+++ b/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-01.nt
@@ -1,0 +1,1 @@
+<http://example.org/> <http://example.org/stuff/1.0/prop> <<( <http://example.org/stuff/1.0/s> <http://example.org/stuff/1.0/p> <http://example.org/stuff/1.0/o> )>> .

--- a/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-05.nt
+++ b/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-05.nt
@@ -1,1 +1,1 @@
-<http://example.org/> <http://example.org/stuff/1.0/prop> <<(<http://example.org/stuff/1.0/s> <http://example.org/stuff/1.0/p> _:b1)>> .
+<http://example.org/> <http://example.org/stuff/1.0/prop> <<( <http://example/s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/stuff/1.0/t> )>> .

--- a/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-05.rdf
+++ b/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-05.rdf
@@ -5,9 +5,7 @@
             rdf:version="1.2">
   <rdf:Description rdf:about="http://example.org/">
     <ex:prop rdf:parseType="Triple">
-      <rdf:Description rdf:about="http://example.org/stuff/1.0/s">
-        <ex:p rdf:nodeID="b1" />
-      </rdf:Description>
+      <ex:t rdf:about="http://example/s"/>
     </ex:prop>
   </rdf:Description>
 </rdf:RDF>

--- a/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-06.nt
+++ b/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-06.nt
@@ -1,1 +1,1 @@
-<http://example.org/> <http://example.org/stuff/1.0/prop> <<(<http://example.org/stuff/1.0/s> <http://example.org/stuff/1.0/p> <<(<http://example.org/stuff/1.0/s2> <http://example.org/stuff/1.0/p2> <http://example.org/stuff/1.0/o2>)>>)>> .
+<http://example.org/> <http://example.org/stuff/1.0/prop> <<(<http://example.org/stuff/1.0/s> <http://example.org/stuff/1.0/p> _:b1)>> .

--- a/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-06.rdf
+++ b/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-06.rdf
@@ -6,11 +6,7 @@
   <rdf:Description rdf:about="http://example.org/">
     <ex:prop rdf:parseType="Triple">
       <rdf:Description rdf:about="http://example.org/stuff/1.0/s">
-        <ex:p rdf:parseType="Triple">
-          <rdf:Description rdf:about="http://example.org/stuff/1.0/s2">
-            <ex:p2 rdf:resource="http://example.org/stuff/1.0/o2" />
-          </rdf:Description>
-        </ex:p>
+        <ex:p rdf:nodeID="b1" />
       </rdf:Description>
     </ex:prop>
   </rdf:Description>

--- a/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-07.nt
+++ b/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-07.nt
@@ -1,0 +1,1 @@
+<http://example.org/> <http://example.org/stuff/1.0/prop> <<(<http://example.org/stuff/1.0/s> <http://example.org/stuff/1.0/p> <<(<http://example.org/stuff/1.0/s2> <http://example.org/stuff/1.0/p2> <http://example.org/stuff/1.0/o2>)>>)>> .

--- a/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-bad-01.rdf
+++ b/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-bad-01.rdf
@@ -6,8 +6,6 @@
   <rdf:Description rdf:about="http://example.org/">
     <ex:prop rdf:parseType="Triple">
       <rdf:Description rdf:about="http://example.org/stuff/1.0/s">
-        <ex:p rdf:resource="http://example.org/stuff/1.0/o1" />
-        <ex:p rdf:resource="http://example.org/stuff/1.0/o2" />
       </rdf:Description>
     </ex:prop>
   </rdf:Description>

--- a/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-bad-02.rdf
+++ b/rdf/rdf12/rdf-xml/eval/rdf12-xml-tt-bad-02.rdf
@@ -6,11 +6,8 @@
   <rdf:Description rdf:about="http://example.org/">
     <ex:prop rdf:parseType="Triple">
       <rdf:Description rdf:about="http://example.org/stuff/1.0/s">
-        <ex:p rdf:parseType="Triple">
-          <rdf:Description rdf:about="http://example.org/stuff/1.0/s2">
-            <ex:p2 rdf:resource="http://example.org/stuff/1.0/o2" />
-          </rdf:Description>
-        </ex:p>
+        <ex:p rdf:resource="http://example.org/stuff/1.0/o1" />
+        <ex:p rdf:resource="http://example.org/stuff/1.0/o2" />
       </rdf:Description>
     </ex:prop>
   </rdf:Description>


### PR DESCRIPTION
This PR:

1 - adds a test for 
```xml
    <ex:prop rdf:parseType="Triple">
      <ex:t rdf:about="http://example/s"/>
    </ex:prop>
```
where the triple term is given in a way other than `rdf:Description`.

2  - It moves negative syntax tests to `rdf12-xml-tt-bad*`

3 - It updates the results for `rdf12-xml-tt-01`. The results were empty (no triples). I don't understand that.

```xml
<?xml version="1.0"?>
<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
            xmlns:ex="http://example.org/stuff/1.0/"
            xml:base="http://example.org/triples/">
  <rdf:Description rdf:about="http://example.org/">
    <ex:prop rdf:parseType="Triple">
      <rdf:Description rdf:about="http://example.org/stuff/1.0/s">
        <ex:p rdf:resource="http://example.org/stuff/1.0/o" />
      </rdf:Description>
    </ex:prop>
  </rdf:Description>
</rdf:RDF>
```

I get one triple with a triple term: (reformatted because of long lines)

```
<http://example.org/> 
    <http://example.org/stuff/1.0/prop> 
        <<( <http://example.org/stuff/1.0/s> <http://example.org/stuff/1.0/p> <http://example.org/stuff/1.0/o> )>> .
```
