### PR TITLE
Dockerfile and bash script to generate HTML files locally

### DIFF
--- a/local-gen/.gitignore
+++ b/local-gen/.gitignore
@@ -1,0 +1,2 @@
+Gemfile
+Gemfile.lock

--- a/local-gen/Dockerfile
+++ b/local-gen/Dockerfile
@@ -1,0 +1,11 @@
+# used by ./generate-files.sh
+
+FROM ruby:3.4.3
+RUN apt-get update -qq && apt-get install -y build-essential
+RUN mkdir /app
+WORKDIR /app
+COPY Gemfile /app/Gemfile
+COPY Gemfile.lock /app/Gemfile.lock
+RUN bundle install
+VOLUME /app
+ENTRYPOINT ["bundle", "exec", "rake"]

--- a/local-gen/generate-files.sh
+++ b/local-gen/generate-files.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+#
+# Script that generates the HTML manifests and reports based on the TTL files,
+# as performed by the github action.
+#
+# DO NOT commit the generated files to the repository.
+
+set -e
+
+IMAGE=rdf-test-automations
+
+cd "$(dirname "$0")"
+cp ../Gemfile ../Gemfile.lock . # 'docker build' refuses to access parent dir
+docker image rm -f $IMAGE
+docker build -t $IMAGE .
+docker run -v $PWD/..:/app --rm $IMAGE "$@"
+


### PR DESCRIPTION
NB: generation of HTML files are normally managed by github actions. This script is provided for the sole purpose of testing the generation, but the generated files must not be committed to the repository.

maybe this should not be merged to the public repo,
but at least some of the maintainers may find it useful to get it in their working copy.
