### PR TITLE
Add modeling of Protocol test details to manifest

### DIFF
--- a/sparql/sparql11/protocol/data1.nt
+++ b/sparql/sparql11/protocol/data1.nt
@@ -1,0 +1,1 @@
+<http://kasei.us/2009/09/sparql/data/data1.rdf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Document> .

--- a/sparql/sparql11/protocol/data2.nt
+++ b/sparql/sparql11/protocol/data2.nt
@@ -1,0 +1,1 @@
+<http://kasei.us/2009/09/sparql/data/data2.rdf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Document> .

--- a/sparql/sparql11/protocol/data3.nt
+++ b/sparql/sparql11/protocol/data3.nt
@@ -1,0 +1,1 @@
+<http://kasei.us/2009/09/sparql/data/data3.rdf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Document> .

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -52,7 +52,7 @@
 :query_post_form rdf:type mf:ProtocolTest ;
         mf:name    "query via URL-encoded POST" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -105,7 +105,7 @@
         ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
         ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -143,7 +143,7 @@
         ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
         ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -197,7 +197,7 @@
         ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
         ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -251,7 +251,7 @@
         ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
         ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -290,7 +290,7 @@
         ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
         ut:graphData [ ut:graph <data3.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data3.rdf" ] ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -352,7 +352,7 @@
         ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
         ut:graphData [ ut:graph <data3.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data3.rdf" ] ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -403,7 +403,7 @@
 :query_get rdf:type mf:ProtocolTest ;
         mf:name    "query via GET" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -439,7 +439,7 @@
 :query_content_type_select rdf:type mf:ProtocolTest ;
         mf:name    "query appropriate content type (expect one of: XML, JSON, CSV, TSV)" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -487,7 +487,7 @@
 :query_content_type_ask rdf:type mf:ProtocolTest ;
         mf:name    "query appropriate content type (expect one of: XML, JSON)" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -535,7 +535,7 @@
 :query_content_type_describe rdf:type mf:ProtocolTest ;
         mf:name    "query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -583,7 +583,7 @@
 :query_content_type_construct rdf:type mf:ProtocolTest ;
         mf:name    "query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -631,7 +631,7 @@
 :update_dataset_default_graph rdf:type mf:ProtocolTest ;
         mf:name    "update with protocol-specified default graph" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -756,7 +756,7 @@ followed by
 :update_dataset_default_graphs rdf:type mf:ProtocolTest ;
         mf:name    "update with protocol-specified default graphs" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -893,7 +893,7 @@ followed by
 :update_dataset_named_graphs rdf:type mf:ProtocolTest ;
         mf:name    "update with protocol-specified named graphs" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1034,7 +1034,7 @@ followed by
 :update_dataset_full rdf:type mf:ProtocolTest ;
         mf:name    "update with protocol-specified dataset (both named and default graphs)" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1187,7 +1187,7 @@ followed by
 :update_post_form rdf:type mf:ProtocolTest ;
         mf:name    "update via URL-encoded POST" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1233,7 +1233,7 @@ followed by
 :update_post_direct rdf:type mf:ProtocolTest ;
         mf:name    "update via POST directly" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1279,7 +1279,7 @@ followed by
 :update_base_uri rdf:type mf:ProtocolTest ;
         mf:name    "test for service-defined BASE URI (\"which MAY be the service endpoint\")" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1376,7 +1376,7 @@ followed by
 :query_post_direct rdf:type mf:ProtocolTest ;
         mf:name    "query via POST directly" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1427,7 +1427,7 @@ followed by
 :bad_query_method rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with a method other than GET or POST" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1466,7 +1466,7 @@ followed by
 :bad_multiple_queries rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with more than one query string" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1496,7 +1496,7 @@ followed by
 :bad_query_wrong_media_type rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with a POST with media type that's not url-encoded or application/sparql-query" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1542,7 +1542,7 @@ followed by
 :bad_query_missing_form_type rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with url-encoded body, but without application/x-www-form-urlencoded media type" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1581,7 +1581,7 @@ followed by
 :bad_query_missing_direct_type rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with SPARQL body, but without application/sparql-query media type" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1620,7 +1620,7 @@ followed by
 :bad_query_non_utf8 rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with direct POST, but with a non-UTF8 encoding (UTF-16)" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1668,7 +1668,7 @@ followed by
 :bad_query_syntax rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with invalid query syntax (4XX result)" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1698,7 +1698,7 @@ followed by
 :bad_update_get rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with GET" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1728,7 +1728,7 @@ followed by
 :bad_multiple_updates rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with more than one update string" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1774,7 +1774,7 @@ followed by
 :bad_update_wrong_media_type rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with a POST with media type that's not url-encoded or application/sparql-update" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1820,7 +1820,7 @@ followed by
 :bad_update_missing_form_type rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with url-encoded body, but without application/x-www-form-urlencoded media type" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1859,7 +1859,7 @@ followed by
 :bad_update_non_utf8 rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with direct POST, but with a non-UTF8 encoding" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1907,7 +1907,7 @@ followed by
 :bad_update_syntax rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with invalid update syntax" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
@@ -1953,7 +1953,7 @@ followed by
 :bad_update_dataset_conflict rdf:type mf:ProtocolTest ;
         mf:name    "invoke update with both using-graph-uri/using-named-graph-uri parameter and USING/WITH clause" ;
         mf:action [
-            a ht:Request ;
+            a ht:Connection ;
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -4,8 +4,10 @@
 @prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
 @prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
-@prefix cnt: <http://www.w3.org/2011/content#> .
-@prefix ht: <http://www.w3.org/2011/http#> .
+@prefix cnt:    <http://www.w3.org/2011/content#> .
+@prefix ht:     <http://www.w3.org/2011/http#> .
+@prefix sd:     <http://www.w3.org/ns/sparql-service-description#> .
+@prefix ut:     <http://www.w3.org/2009/sparql/tests/test-update#> .
 
 <>  rdf:type mf:Manifest ;
     rdfs:label "SPARQL Protocol" ;
@@ -100,6 +102,8 @@
 
 :query_dataset_default_graphs_get rdf:type mf:ProtocolTest ;
         mf:name    "GET query with protocol-specified default graph" ;
+        ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
+        ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
         mf:action [
             a ht:Request ;
             ht:connectionAuthority "www.example" ;
@@ -136,6 +140,8 @@
 
 :query_dataset_default_graphs_post rdf:type mf:ProtocolTest ;
         mf:name    "POST query with protocol-specified default graphs" ;
+        ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
+        ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
         mf:action [
             a ht:Request ;
             ht:connectionAuthority "www.example" ;
@@ -188,6 +194,8 @@
 
 :query_dataset_named_graphs_post rdf:type mf:ProtocolTest ;
         mf:name    "POST query with protocol-specified named graphs" ;
+        ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
+        ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
         mf:action [
             a ht:Request ;
             ht:connectionAuthority "www.example" ;
@@ -240,6 +248,8 @@
 
 :query_dataset_named_graphs_get rdf:type mf:ProtocolTest ;
         mf:name    "GET query with protocol-specified named graphs" ;
+        ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
+        ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
         mf:action [
             a ht:Request ;
             ht:connectionAuthority "www.example" ;
@@ -276,6 +286,9 @@
 
 :query_dataset_full rdf:type mf:ProtocolTest ;
         mf:name    "query with protocol-specified dataset (both named and default graphs)" ;
+        ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
+        ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
+        ut:graphData [ ut:graph <data3.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data3.rdf" ] ;
         mf:action [
             a ht:Request ;
             ht:connectionAuthority "www.example" ;
@@ -335,6 +348,9 @@
 
 :query_multiple_dataset rdf:type mf:ProtocolTest ;
         mf:name    "query specifying dataset in both query string and protocol; test for use of protocol-specified dataset" ;
+        ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
+        ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
+        ut:graphData [ ut:graph <data3.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data3.rdf" ] ;
         mf:action [
             a ht:Request ;
             ht:connectionAuthority "www.example" ;

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -4,6 +4,8 @@
 @prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
 @prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
+@prefix cnt: <http://www.w3.org/2011/content#> .
+@prefix ht: <http://www.w3.org/2011/http#> .
 
 <>  rdf:type mf:Manifest ;
     rdfs:label "SPARQL Protocol" ;
@@ -47,6 +49,34 @@
 
 :query_post_form rdf:type mf:ProtocolTest ;
         mf:name    "query via URL-encoded POST" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "query=ASK%20%7B%7D"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/x-www-form-urlencoded"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -70,6 +100,23 @@
 
 :query_dataset_default_graphs_get rdf:type mf:ProtocolTest ;
         mf:name    "GET query with protocol-specified default graph" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?query=ASK%20%7B%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E%20a%20%3Ftype%20.%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E%20a%20%3Ftype%20.%20%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "GET" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -89,6 +136,34 @@
 
 :query_dataset_default_graphs_post rdf:type mf:ProtocolTest ;
         mf:name    "POST query with protocol-specified default graphs" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "ASK { <http://kasei.us/2009/09/sparql/data/data1.rdf> a ?type . <http://kasei.us/2009/09/sparql/data/data2.rdf> a ?type . }"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -113,6 +188,34 @@
 
 :query_dataset_named_graphs_post rdf:type mf:ProtocolTest ;
         mf:name    "POST query with protocol-specified named graphs" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "ASK { GRAPH ?g1 { <http://kasei.us/2009/09/sparql/data/data1.rdf> a ?type } GRAPH ?g2 { <http://kasei.us/2009/09/sparql/data/data2.rdf> a ?type } }"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -137,6 +240,23 @@
 
 :query_dataset_named_graphs_get rdf:type mf:ProtocolTest ;
         mf:name    "GET query with protocol-specified named graphs" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?query=ASK%20%7B%20GRAPH%20%3Fg1%20%7B%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E%20a%20%3Ftype%20%7D%20GRAPH%20%3Fg2%20%7B%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E%20a%20%3Ftype%20%7D%20%7D&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "GET" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -156,6 +276,38 @@
 
 :query_dataset_full rdf:type mf:ProtocolTest ;
         mf:name    "query with protocol-specified dataset (both named and default graphs)" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """ASK {
+  <http://kasei.us/2009/09/sparql/data/data3.rdf> a ?type
+  GRAPH ?g1 { <http://kasei.us/2009/09/sparql/data/data1.rdf> a ?type }
+  GRAPH ?g2 { <http://kasei.us/2009/09/sparql/data/data2.rdf> a ?type }
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -183,6 +335,34 @@
 
 :query_multiple_dataset rdf:type mf:ProtocolTest ;
         mf:name    "query specifying dataset in both query string and protocol; test for use of protocol-specified dataset" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%26named-graph-uri%3Dhttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "ASK FROM <http://kasei.us/2009/09/sparql/data/data3.rdf> { GRAPH ?g1 { <http://kasei.us/2009/09/sparql/data/data1.rdf> a ?type } GRAPH ?g2 { <http://kasei.us/2009/09/sparql/data/data2.rdf> a ?type } }"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -206,6 +386,23 @@
 
 :query_get rdf:type mf:ProtocolTest ;
         mf:name    "query via GET" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?query=ASK%20%7B%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf" ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "GET" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -225,6 +422,33 @@
 
 :query_content_type_select rdf:type mf:ProtocolTest ;
         mf:name    "query appropriate content type (expect one of: XML, JSON, CSV, TSV)" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "SELECT (1 AS ?value) {}"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedFormat "tabular" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -246,6 +470,33 @@
 
 :query_content_type_ask rdf:type mf:ProtocolTest ;
         mf:name    "query appropriate content type (expect one of: XML, JSON)" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "ASK {}"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -267,6 +518,33 @@
 
 :query_content_type_describe rdf:type mf:ProtocolTest ;
         mf:name    "query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "DESCRIBE <http://example.org/>"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedFormat "RDF" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -288,6 +566,33 @@
 
 :query_content_type_construct rdf:type mf:ProtocolTest ;
         mf:name    "query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "CONSTRUCT { <s> <p> 1 } WHERE {}"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedFormat "RDF" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -309,6 +614,74 @@
 
 :update_dataset_default_graph rdf:type mf:ProtocolTest ;
         mf:name    "update with protocol-specified default graph" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+CLEAR ALL ;
+INSERT DATA {
+    GRAPH <http://kasei.us/2009/09/sparql/data/data1.rdf> {
+        <http://kasei.us/2009/09/sparql/data/data1.rdf> a foaf:Document
+    }
+} ;
+INSERT {
+    GRAPH <http://example.org/protocol-update-dataset-test/> {
+        ?s a dc:BibliographicResource
+    }
+}
+WHERE {
+    ?s a foaf:Document
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-update"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+                [
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """ASK {
+    GRAPH <http://example.org/protocol-update-dataset-test/> {
+        <http://kasei.us/2009/09/sparql/data/data1.rdf> a <http://purl.org/dc/terms/BibliographicResource>
+    }
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -366,6 +739,80 @@ followed by
 
 :update_dataset_default_graphs rdf:type mf:ProtocolTest ;
         mf:name    "update with protocol-specified default graphs" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+DROP ALL ;
+INSERT DATA {
+    GRAPH <http://kasei.us/2009/09/sparql/data/data1.rdf> { <http://kasei.us/2009/09/sparql/data/data1.rdf> a foaf:Document }
+    GRAPH <http://kasei.us/2009/09/sparql/data/data2.rdf> { <http://kasei.us/2009/09/sparql/data/data2.rdf> a foaf:Document }
+    GRAPH <http://kasei.us/2009/09/sparql/data/data3.rdf> { <http://kasei.us/2009/09/sparql/data/data3.rdf> a foaf:Document }
+} ;
+INSERT {
+    GRAPH <http://example.org/protocol-update-dataset-graphs-test/> {
+        ?s a dc:BibliographicResource
+    }
+}
+WHERE {
+    ?s a foaf:Document
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-update"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+                [
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """ASK {
+    GRAPH <http://example.org/protocol-update-dataset-graphs-test/> {
+        <http://kasei.us/2009/09/sparql/data/data1.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+        <http://kasei.us/2009/09/sparql/data/data2.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+    }
+    FILTER NOT EXISTS {
+        GRAPH <http://example.org/protocol-update-dataset-graphs-test/> {
+            <http://kasei.us/2009/09/sparql/data/data3.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+        }
+    }
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -429,6 +876,82 @@ followed by
 
 :update_dataset_named_graphs rdf:type mf:ProtocolTest ;
         mf:name    "update with protocol-specified named graphs" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+DROP ALL ;
+INSERT DATA {
+    GRAPH <http://kasei.us/2009/09/sparql/data/data1.rdf> { <http://kasei.us/2009/09/sparql/data/data1.rdf> a foaf:Document }
+    GRAPH <http://kasei.us/2009/09/sparql/data/data2.rdf> { <http://kasei.us/2009/09/sparql/data/data2.rdf> a foaf:Document }
+    GRAPH <http://kasei.us/2009/09/sparql/data/data3.rdf> { <http://kasei.us/2009/09/sparql/data/data3.rdf> a foaf:Document }
+} ;
+INSERT {
+    GRAPH <http://example.org/protocol-update-dataset-named-graphs-test/> {
+        ?s a dc:BibliographicResource
+    }
+}
+WHERE {
+    GRAPH ?g {
+        ?s a foaf:Document
+    }
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-update"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+                [
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """ASK {
+    GRAPH <http://example.org/protocol-update-dataset-named-graphs-test/> {
+        <http://kasei.us/2009/09/sparql/data/data1.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+        <http://kasei.us/2009/09/sparql/data/data2.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+    }
+    FILTER NOT EXISTS {
+        GRAPH <http://example.org/protocol-update-dataset-named-graphs-test/> {
+            <http://kasei.us/2009/09/sparql/data/data3.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+        }
+    }
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -494,6 +1017,88 @@ followed by
 
 :update_dataset_full rdf:type mf:ProtocolTest ;
         mf:name    "update with protocol-specified dataset (both named and default graphs)" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+DROP ALL ;
+INSERT DATA {
+    GRAPH <http://kasei.us/2009/09/sparql/data/data1.rdf> { <http://kasei.us/2009/09/sparql/data/data1.rdf> a foaf:Document }
+    GRAPH <http://kasei.us/2009/09/sparql/data/data2.rdf> { <http://kasei.us/2009/09/sparql/data/data2.rdf> a foaf:Document }
+    GRAPH <http://kasei.us/2009/09/sparql/data/data3.rdf> { <http://kasei.us/2009/09/sparql/data/data3.rdf> a foaf:Document }
+} ;
+INSERT {
+    GRAPH <http://example.org/protocol-update-dataset-full-test/> {
+        ?s <http://example.org/in> ?in
+    }
+}
+WHERE {
+    {
+        GRAPH ?g { ?s a foaf:Document }
+        BIND(?g AS ?in)
+    }
+    UNION
+    {
+        ?s a foaf:Document .
+        BIND(\"default\" AS ?in)
+    }
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-update"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+                [
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """ASK {
+    GRAPH <http://example.org/protocol-update-dataset-full-test/> {
+        <http://kasei.us/2009/09/sparql/data/data1.rdf> <http://example.org/in> \"default\" .
+        <http://kasei.us/2009/09/sparql/data/data2.rdf> <http://example.org/in> <http://kasei.us/2009/09/sparql/data/data2.rdf> .
+    }
+    FILTER NOT EXISTS {
+        GRAPH <http://example.org/protocol-update-dataset-full-test/> {
+            <http://kasei.us/2009/09/sparql/data/data3.rdf> ?p ?o
+        }
+    }
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -565,6 +1170,32 @@ followed by
 
 :update_post_form rdf:type mf:ProtocolTest ;
         mf:name    "update via URL-encoded POST" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "update=CLEAR+ALL"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/x-www-form-urlencoded"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -585,6 +1216,32 @@ followed by
 
 :update_post_direct rdf:type mf:ProtocolTest ;
         mf:name    "update via POST directly" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "CLEAR ALL"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-update"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -605,6 +1262,60 @@ followed by
 
 :update_base_uri rdf:type mf:ProtocolTest ;
         mf:name    "test for service-defined BASE URI (\"which MAY be the service endpoint\")" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """CLEAR GRAPH <http://example.org/protocol-base-test/> ;
+INSERT DATA { GRAPH <http://example.org/protocol-base-test/> { <http://example.org/s> <http://example.org/p> <test> } }"""
+                ] ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "content-type" ;
+                        ht:fieldValue "application/sparql-update"
+                    ]
+                ) ;
+                ht:httpVersion "1.1" ;
+                ht:methodName "POST" ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:absolutePath "/sparql/" ;
+                ht:body [
+                    a cnt:ContentAsText ;
+                    cnt:characterEncoding "UTF-8" ;
+                    cnt:chars """SELECT ?o WHERE {
+    GRAPH <http://example.org/protocol-base-test/> {
+        <http://example.org/s> <http://example.org/p> ?o
+    }
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectation """one result with `?o` bound to an IRI that is _not_ `<test>`""" ;
+                        mf:expectedFormat "tabular" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -648,6 +1359,34 @@ followed by
 
 :query_post_direct rdf:type mf:ProtocolTest ;
         mf:name    "query via POST directly" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "ASK {}"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedBoolean true ;
+                        mf:expectedFormat "boolean" ;
+                        mf:expectedStatus ht:StatusCode2xx, ht:StatusCode3xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -671,6 +1410,27 @@ followed by
 
 :bad_query_method rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with a method other than GET or POST" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?query=ASK%20%7B%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf" ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/x-www-form-urlencoded"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "PUT" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -689,6 +1449,21 @@ followed by
 
 :bad_multiple_queries rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with more than one query string" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?query=ASK%20%7B%7D&query=SELECT%20%2A%20%7B%7D" ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "GET" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -704,6 +1479,32 @@ followed by
 
 :bad_query_wrong_media_type rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with a POST with media type that's not url-encoded or application/sparql-query" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "ASK {}"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "text/plain"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -724,6 +1525,26 @@ followed by
 
 :bad_query_missing_form_type rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with url-encoded body, but without application/x-www-form-urlencoded media type" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "query=ASK%20%7B%7D"
+                    ] ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -743,6 +1564,26 @@ followed by
 
 :bad_query_missing_direct_type rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with SPARQL body, but without application/sparql-query media type" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "ASK {}"
+                    ] ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -762,6 +1603,32 @@ followed by
 
 :bad_query_non_utf8 rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with direct POST, but with a non-UTF8 encoding (UTF-16)" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-16" ;
+                        cnt:chars "ASK {}"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-query; charset=UTF-16"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 (Content body encoded in utf-16, with a preceding BOM.)
 
@@ -784,6 +1651,21 @@ followed by
 
 :bad_query_syntax rdf:type mf:ProtocolTest ;
         mf:name    "invoke query operation with invalid query syntax (4XX result)" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?query=ASK%20%7B" ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "GET" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -799,6 +1681,21 @@ followed by
 
 :bad_update_get rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with GET" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?update=CLEAR%20ALL" ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "GET" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -814,6 +1711,32 @@ followed by
 
 :bad_multiple_updates rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with more than one update string" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "update=CLEAR%20NAMED&update=CLEAR%20DEFAULT"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/x-www-form-urlencoded"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -834,6 +1757,32 @@ followed by
 
 :bad_update_wrong_media_type rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with a POST with media type that's not url-encoded or application/sparql-update" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "CLEAR NAMED"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "text/plain"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -854,6 +1803,26 @@ followed by
 
 :bad_update_missing_form_type rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with url-encoded body, but without application/x-www-form-urlencoded media type" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "update=CLEAR%20NAMED"
+                    ] ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -873,6 +1842,32 @@ followed by
 
 :bad_update_non_utf8 rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with direct POST, but with a non-UTF8 encoding" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-16" ;
+                        cnt:chars "CLEAR NAMED"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-update; charset=UTF-16"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 (Content body encoded in utf-16, with a preceding BOM.)
 
@@ -895,6 +1890,32 @@ followed by
 
 :bad_update_syntax rdf:type mf:ProtocolTest ;
         mf:name    "invoke update operation with invalid update syntax" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars "update=CLEAR%20XYZ"
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/x-www-form-urlencoded"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     
@@ -915,6 +1936,38 @@ followed by
 
 :bad_update_dataset_conflict rdf:type mf:ProtocolTest ;
         mf:name    "invoke update with both using-graph-uri/using-named-graph-uri parameter and USING/WITH clause" ;
+        mf:action [
+            a ht:Request ;
+            ht:connectionAuthority "www.example" ;
+            ht:requests ([
+                    a ht:Request ;
+                    ht:absolutePath "/sparql/?using-named-graph-uri=http%3A%2F%2Fexample%2Fpeople" ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+WITH <http://example/addresses>
+DELETE { ?person foaf:givenName 'Bill' }
+INSERT { ?person foaf:givenName 'William' }
+WHERE {
+    ?person foaf:givenName 'Bill'
+}"""
+                    ] ;
+                    ht:headers ([
+                            a ht:RequestHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "application/sparql-update"
+                        ]
+                    ) ;
+                    ht:httpVersion "1.1" ;
+                    ht:methodName "POST" ;
+                    ht:resp [
+                        a ht:Response ;
+                        mf:expectedStatus ht:StatusCode4xx
+                    ]
+                ]
+            )
+        ] ;
         rdfs:comment """
 #### Request
     

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -1,4 +1,4 @@
-@prefix : <http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#> .
+@prefix :       <http://www.w3.org/2009/sparql/docs/tests/data-sparql11/protocol/manifest#> .
 @prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
@@ -9,45 +9,45 @@
     rdfs:label "SPARQL Protocol" ;
     mf:entries
     (
-		:query_post_form
-		:query_dataset_default_graphs_get
-		:query_dataset_default_graphs_post
-		:query_dataset_named_graphs_post
-		:query_dataset_named_graphs_get
-		:query_dataset_full
-		:query_multiple_dataset
-		:query_get
-		:query_content_type_select
-		:query_content_type_ask
-		:query_content_type_describe
-		:query_content_type_construct
-		:update_dataset_default_graph
-		:update_dataset_default_graphs
-		:update_dataset_named_graphs
-		:update_dataset_full
-		:update_post_form
-		:update_post_direct
-		:update_base_uri
-		:query_post_direct
-		:bad_query_method
-		:bad_multiple_queries
-		:bad_query_wrong_media_type
-		:bad_query_missing_form_type
-		:bad_query_missing_direct_type
-		:bad_query_non_utf8
-		:bad_query_syntax
-		:bad_update_get
-		:bad_multiple_updates
-		:bad_update_wrong_media_type
-		:bad_update_missing_form_type
-		:bad_update_non_utf8
-		:bad_update_syntax
-		:bad_update_dataset_conflict
-	) .
+        :query_post_form
+        :query_dataset_default_graphs_get
+        :query_dataset_default_graphs_post
+        :query_dataset_named_graphs_post
+        :query_dataset_named_graphs_get
+        :query_dataset_full
+        :query_multiple_dataset
+        :query_get
+        :query_content_type_select
+        :query_content_type_ask
+        :query_content_type_describe
+        :query_content_type_construct
+        :update_dataset_default_graph
+        :update_dataset_default_graphs
+        :update_dataset_named_graphs
+        :update_dataset_full
+        :update_post_form
+        :update_post_direct
+        :update_base_uri
+        :query_post_direct
+        :bad_query_method
+        :bad_multiple_queries
+        :bad_query_wrong_media_type
+        :bad_query_missing_form_type
+        :bad_query_missing_direct_type
+        :bad_query_non_utf8
+        :bad_query_syntax
+        :bad_update_get
+        :bad_multiple_updates
+        :bad_update_wrong_media_type
+        :bad_update_missing_form_type
+        :bad_update_non_utf8
+        :bad_update_syntax
+        :bad_update_dataset_conflict
+    ) .
 
 :query_post_form rdf:type mf:ProtocolTest ;
-       mf:name    "query via URL-encoded POST" ;
-       rdfs:comment """
+        mf:name    "query via URL-encoded POST" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
@@ -63,14 +63,14 @@
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
 
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_dataset_default_graphs_get rdf:type mf:ProtocolTest ;
-       mf:name    "GET query with protocol-specified default graph" ;
-       rdfs:comment """
+        mf:name    "GET query with protocol-specified default graph" ;
+        rdfs:comment """
 #### Request
 
     GET /sparql/?query=ASK%20%7B%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E%20a%20%3Ftype%20.%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E%20a%20%3Ftype%20.%20%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
@@ -82,14 +82,14 @@
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
 
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_dataset_default_graphs_post rdf:type mf:ProtocolTest ;
-       mf:name    "POST query with protocol-specified default graphs" ;
-       rdfs:comment """
+        mf:name    "POST query with protocol-specified default graphs" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -105,14 +105,14 @@
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
 
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_dataset_named_graphs_post rdf:type mf:ProtocolTest ;
-       mf:name    "POST query with protocol-specified named graphs" ;
-       rdfs:comment """
+        mf:name    "POST query with protocol-specified named graphs" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -128,14 +128,14 @@
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
 
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_dataset_named_graphs_get rdf:type mf:ProtocolTest ;
-       mf:name    "GET query with protocol-specified named graphs" ;
-       rdfs:comment """
+        mf:name    "GET query with protocol-specified named graphs" ;
+        rdfs:comment """
 #### Request
 
     GET /sparql/?query=ASK%20%7B%20GRAPH%20%3Fg1%20%7B%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E%20a%20%3Ftype%20%7D%20GRAPH%20%3Fg2%20%7B%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E%20a%20%3Ftype%20%7D%20%7D&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
@@ -147,14 +147,14 @@
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
 
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_dataset_full rdf:type mf:ProtocolTest ;
-       mf:name    "query with protocol-specified dataset (both named and default graphs)" ;
-       rdfs:comment """
+        mf:name    "query with protocol-specified dataset (both named and default graphs)" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -170,14 +170,14 @@
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
 
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_multiple_dataset rdf:type mf:ProtocolTest ;
-       mf:name    "query specifying dataset in both query string and protocol; test for use of protocol-specified dataset" ;
-       rdfs:comment """
+        mf:name    "query specifying dataset in both query string and protocol; test for use of protocol-specified dataset" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -193,14 +193,14 @@
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
 
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_get rdf:type mf:ProtocolTest ;
-       mf:name    "query via GET" ;
-       rdfs:comment """
+        mf:name    "query via GET" ;
+        rdfs:comment """
 #### Request
 
     GET /sparql/?query=ASK%20%7B%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
@@ -212,14 +212,14 @@
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
 
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_content_type_select rdf:type mf:ProtocolTest ;
-       mf:name    "query appropriate content type (expect one of: XML, JSON, CSV, TSV)" ;
-       rdfs:comment """
+        mf:name    "query appropriate content type (expect one of: XML, JSON, CSV, TSV)" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -233,14 +233,14 @@
 
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, text/tab-separated-values, text/csv, or any other valid media type for tabular SPARQL results
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_content_type_ask rdf:type mf:ProtocolTest ;
-       mf:name    "query appropriate content type (expect one of: XML, JSON)" ;
-       rdfs:comment """
+        mf:name    "query appropriate content type (expect one of: XML, JSON)" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -254,14 +254,14 @@
 
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_content_type_describe rdf:type mf:ProtocolTest ;
-       mf:name    "query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)" ;
-       rdfs:comment """
+        mf:name    "query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -275,14 +275,14 @@
 
     2xx or 3xx response
     Content-Type: application/rdf+xml, application/rdf+json, text/turtle, or any other valid media type for RDF results
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_content_type_construct rdf:type mf:ProtocolTest ;
-       mf:name    "query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)" ;
-       rdfs:comment """
+        mf:name    "query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -296,14 +296,14 @@
 
     2xx or 3xx response
     Content-Type: application/rdf+xml, application/rdf+json, text/turtle, or any other valid media type for RDF results
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :update_dataset_default_graph rdf:type mf:ProtocolTest ;
-       mf:name    "update with protocol-specified default graph" ;
-       rdfs:comment """
+        mf:name    "update with protocol-specified default graph" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf HTTP/1.1
@@ -328,9 +328,9 @@ followed by
     Content-Type: application/sparql-query
     
     ASK {
-    	GRAPH <http://example.org/protocol-update-dataset-test/> {
-    		<http://kasei.us/2009/09/sparql/data/data1.rdf> a <http://purl.org/dc/terms/BibliographicResource>
-    	}
+        GRAPH <http://example.org/protocol-update-dataset-test/> {
+            <http://kasei.us/2009/09/sparql/data/data1.rdf> a <http://purl.org/dc/terms/BibliographicResource>
+        }
     }
 
 #### Response
@@ -339,14 +339,14 @@ followed by
     Content-Type: application/sparql-results+xml
     
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :update_dataset_default_graphs rdf:type mf:ProtocolTest ;
-       mf:name    "update with protocol-specified default graphs" ;
-       rdfs:comment """
+        mf:name    "update with protocol-specified default graphs" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
@@ -371,15 +371,15 @@ followed by
     Content-Type: application/sparql-query
     
     ASK {
-    	GRAPH <http://example.org/protocol-update-dataset-graphs-test/> {
-    		<http://kasei.us/2009/09/sparql/data/data1.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
-    		<http://kasei.us/2009/09/sparql/data/data2.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
-    	}
-    	FILTER NOT EXISTS {
-    		GRAPH <http://example.org/protocol-update-dataset-graphs-test/> {
-    			<http://kasei.us/2009/09/sparql/data/data3.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
-    		}
-    	}
+        GRAPH <http://example.org/protocol-update-dataset-graphs-test/> {
+            <http://kasei.us/2009/09/sparql/data/data1.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+            <http://kasei.us/2009/09/sparql/data/data2.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+        }
+        FILTER NOT EXISTS {
+            GRAPH <http://example.org/protocol-update-dataset-graphs-test/> {
+                <http://kasei.us/2009/09/sparql/data/data3.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+            }
+        }
     }
 
 #### Response
@@ -388,14 +388,14 @@ followed by
     Content-Type: application/sparql-results+xml
     
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :update_dataset_named_graphs rdf:type mf:ProtocolTest ;
-       mf:name    "update with protocol-specified named graphs" ;
-       rdfs:comment """
+        mf:name    "update with protocol-specified named graphs" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/?using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
@@ -420,15 +420,15 @@ followed by
     Content-Type: application/sparql-query
     
     ASK {
-    	GRAPH <http://example.org/protocol-update-dataset-named-graphs-test/> {
-    		<http://kasei.us/2009/09/sparql/data/data1.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
-    		<http://kasei.us/2009/09/sparql/data/data2.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
-    	}
-    	FILTER NOT EXISTS {
-    		GRAPH <http://example.org/protocol-update-dataset-named-graphs-test/> {
-    			<http://kasei.us/2009/09/sparql/data/data3.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
-    		}
-    	}
+        GRAPH <http://example.org/protocol-update-dataset-named-graphs-test/> {
+            <http://kasei.us/2009/09/sparql/data/data1.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+            <http://kasei.us/2009/09/sparql/data/data2.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+        }
+        FILTER NOT EXISTS {
+            GRAPH <http://example.org/protocol-update-dataset-named-graphs-test/> {
+                <http://kasei.us/2009/09/sparql/data/data3.rdf> a <http://purl.org/dc/terms/BibliographicResource> .
+            }
+        }
     }
 
 #### Response
@@ -437,14 +437,14 @@ followed by
     Content-Type: application/sparql-results+xml
     
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :update_dataset_full rdf:type mf:ProtocolTest ;
-       mf:name    "update with protocol-specified dataset (both named and default graphs)" ;
-       rdfs:comment """
+        mf:name    "update with protocol-specified dataset (both named and default graphs)" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
@@ -469,15 +469,15 @@ followed by
     Content-Type: application/sparql-query
     
     ASK {
-    	GRAPH <http://example.org/protocol-update-dataset-full-test/> {
-    		<http://kasei.us/2009/09/sparql/data/data1.rdf> <http://example.org/in> "default" .
-    		<http://kasei.us/2009/09/sparql/data/data2.rdf> <http://example.org/in> <http://kasei.us/2009/09/sparql/data/data2.rdf> .
-    	}
-    	FILTER NOT EXISTS {
-    		GRAPH <http://example.org/protocol-update-dataset-full-test/> {
-    			<http://kasei.us/2009/09/sparql/data/data3.rdf> ?p ?o
-    		}
-    	}
+        GRAPH <http://example.org/protocol-update-dataset-full-test/> {
+            <http://kasei.us/2009/09/sparql/data/data1.rdf> <http://example.org/in> "default" .
+            <http://kasei.us/2009/09/sparql/data/data2.rdf> <http://example.org/in> <http://kasei.us/2009/09/sparql/data/data2.rdf> .
+        }
+        FILTER NOT EXISTS {
+            GRAPH <http://example.org/protocol-update-dataset-full-test/> {
+                <http://kasei.us/2009/09/sparql/data/data3.rdf> ?p ?o
+            }
+        }
     }
 
 #### Response
@@ -486,14 +486,14 @@ followed by
     Content-Type: application/sparql-results+xml
     
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :update_post_form rdf:type mf:ProtocolTest ;
-       mf:name    "update via URL-encoded POST" ;
-       rdfs:comment """
+        mf:name    "update via URL-encoded POST" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -506,14 +506,14 @@ followed by
 #### Response
 
     2xx or 3xx response
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :update_post_direct rdf:type mf:ProtocolTest ;
-       mf:name    "update via POST directly" ;
-       rdfs:comment """
+        mf:name    "update via POST directly" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -526,14 +526,14 @@ followed by
 #### Response
 
     2xx or 3xx response
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :update_base_uri rdf:type mf:ProtocolTest ;
-       mf:name    "test for service-defined BASE URI (\"which MAY be the service endpoint\")" ;
-       rdfs:comment """
+        mf:name    "test for service-defined BASE URI (\"which MAY be the service endpoint\")" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -568,14 +568,14 @@ followed by
     Content-Type: application/sparql-results+xml
     
     one result with `?o` bound to an IRI that is _not_ `<test>`
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :query_post_direct rdf:type mf:ProtocolTest ;
-       mf:name    "query via POST directly" ;
-       rdfs:comment """
+        mf:name    "query via POST directly" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -591,14 +591,14 @@ followed by
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
 
     true
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_query_method rdf:type mf:ProtocolTest ;
-       mf:name    "invoke query operation with a method other than GET or POST" ;
-       rdfs:comment """
+        mf:name    "invoke query operation with a method other than GET or POST" ;
+        rdfs:comment """
 #### Request
 
     PUT /sparql/?query=ASK%20%7B%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
@@ -609,14 +609,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_multiple_queries rdf:type mf:ProtocolTest ;
-       mf:name    "invoke query operation with more than one query string" ;
-       rdfs:comment """
+        mf:name    "invoke query operation with more than one query string" ;
+        rdfs:comment """
 #### Request
 
     GET /sparql/?query=ASK%20%7B%7D&query=SELECT%20%2A%20%7B%7D HTTP/1.1
@@ -624,14 +624,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_query_wrong_media_type rdf:type mf:ProtocolTest ;
-       mf:name    "invoke query operation with a POST with media type that's not url-encoded or application/sparql-query" ;
-       rdfs:comment """
+        mf:name    "invoke query operation with a POST with media type that's not url-encoded or application/sparql-query" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -644,14 +644,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_query_missing_form_type rdf:type mf:ProtocolTest ;
-       mf:name    "invoke query operation with url-encoded body, but without application/x-www-form-urlencoded media type" ;
-       rdfs:comment """
+        mf:name    "invoke query operation with url-encoded body, but without application/x-www-form-urlencoded media type" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -663,14 +663,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_query_missing_direct_type rdf:type mf:ProtocolTest ;
-       mf:name    "invoke query operation with SPARQL body, but without application/sparql-query media type" ;
-       rdfs:comment """
+        mf:name    "invoke query operation with SPARQL body, but without application/sparql-query media type" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -682,14 +682,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_query_non_utf8 rdf:type mf:ProtocolTest ;
-       mf:name    "invoke query operation with direct POST, but with a non-UTF8 encoding (UTF-16)" ;
-       rdfs:comment """
+        mf:name    "invoke query operation with direct POST, but with a non-UTF8 encoding (UTF-16)" ;
+        rdfs:comment """
 (Content body encoded in utf-16, with a preceding BOM.)
 
 #### Request
@@ -704,14 +704,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_query_syntax rdf:type mf:ProtocolTest ;
-       mf:name    "invoke query operation with invalid query syntax (4XX result)" ;
-       rdfs:comment """
+        mf:name    "invoke query operation with invalid query syntax (4XX result)" ;
+        rdfs:comment """
 #### Request
 
     GET /sparql/?query=ASK%20%7B HTTP/1.1
@@ -719,14 +719,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_update_get rdf:type mf:ProtocolTest ;
-       mf:name    "invoke update operation with GET" ;
-       rdfs:comment """
+        mf:name    "invoke update operation with GET" ;
+        rdfs:comment """
 #### Request
 
     GET /sparql/?update=CLEAR%20ALL HTTP/1.1
@@ -734,14 +734,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_multiple_updates rdf:type mf:ProtocolTest ;
-       mf:name    "invoke update operation with more than one update string" ;
-       rdfs:comment """
+        mf:name    "invoke update operation with more than one update string" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -754,14 +754,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_update_wrong_media_type rdf:type mf:ProtocolTest ;
-       mf:name    "invoke update operation with a POST with media type that's not url-encoded or application/sparql-update" ;
-       rdfs:comment """
+        mf:name    "invoke update operation with a POST with media type that's not url-encoded or application/sparql-update" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -774,14 +774,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_update_missing_form_type rdf:type mf:ProtocolTest ;
-       mf:name    "invoke update operation with url-encoded body, but without application/x-www-form-urlencoded media type" ;
-       rdfs:comment """
+        mf:name    "invoke update operation with url-encoded body, but without application/x-www-form-urlencoded media type" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -793,14 +793,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_update_non_utf8 rdf:type mf:ProtocolTest ;
-       mf:name    "invoke update operation with direct POST, but with a non-UTF8 encoding" ;
-       rdfs:comment """
+        mf:name    "invoke update operation with direct POST, but with a non-UTF8 encoding" ;
+        rdfs:comment """
 (Content body encoded in utf-16, with a preceding BOM.)
 
 #### Request
@@ -815,14 +815,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_update_syntax rdf:type mf:ProtocolTest ;
-       mf:name    "invoke update operation with invalid update syntax" ;
-       rdfs:comment """
+        mf:name    "invoke update operation with invalid update syntax" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -835,14 +835,14 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .
 
 :bad_update_dataset_conflict rdf:type mf:ProtocolTest ;
-       mf:name    "invoke update with both using-graph-uri/using-named-graph-uri parameter and USING/WITH clause" ;
-       rdfs:comment """
+        mf:name    "invoke update with both using-graph-uri/using-named-graph-uri parameter and USING/WITH clause" ;
+        rdfs:comment """
 #### Request
 
     POST /sparql/ HTTP/1.1
@@ -855,7 +855,7 @@ followed by
 #### Response
 
     4xx
-       """ ;
-       dawgt:approval dawgt:Approved ;
-       dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
-       .
+        """ ;
+        dawgt:approval dawgt:Approved ;
+        dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-20#resolution_3> ;
+        .

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -1287,7 +1287,7 @@ followed by
                     ht:body [
                         a cnt:ContentAsText ;
                         cnt:characterEncoding "UTF-8" ;
-                        cnt:chars """CLEAR GRAPH <http://example.org/protocol-base-test/> ;
+                        cnt:chars """CLEAR SILENT GRAPH <http://example.org/protocol-base-test/> ;
 INSERT DATA { GRAPH <http://example.org/protocol-base-test/> { <http://example.org/s> <http://example.org/p> <test> } }"""
                 ] ;
                 ht:headers ([

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -344,7 +344,6 @@ followed by
     
     POST /sparql/ HTTP/1.1
     Host: www.example
-    Accept: application/sparql-results+xml
     Content-Length: 172
     Content-Type: application/sparql-query
     
@@ -357,7 +356,7 @@ followed by
 #### Response
     
     2xx or 3xx response
-    Content-Type: application/sparql-results+xml
+    Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
         
     true
         """ ;
@@ -402,7 +401,6 @@ followed by
     
     POST /sparql/ HTTP/1.1
     Host: www.example
-    Accept: application/sparql-results+xml
     Content-Length: 484
     Content-Type: application/sparql-query
     
@@ -421,7 +419,7 @@ followed by
 #### Response
     
     2xx or 3xx response
-    Content-Type: application/sparql-results+xml
+    Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
         
     true
         """ ;
@@ -468,7 +466,6 @@ followed by
     
     POST /sparql/ HTTP/1.1
     Host: www.example
-    Accept: application/sparql-results+xml
     Content-Length: 496
     Content-Type: application/sparql-query
     
@@ -487,7 +484,7 @@ followed by
 #### Response
     
     2xx or 3xx response
-    Content-Type: application/sparql-results+xml
+    Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
         
     true
         """ ;
@@ -540,7 +537,6 @@ followed by
     
     POST /sparql/ HTTP/1.1
     Host: www.example
-    Accept: application/sparql-results+xml
     Content-Length: 437
     Content-Type: application/sparql-query
     
@@ -559,7 +555,7 @@ followed by
 #### Response
     
     2xx or 3xx response
-    Content-Type: application/sparql-results+xml
+    Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
         
     true
         """ ;
@@ -624,12 +620,13 @@ followed by
     
     2xx or 3xx response
 
+followed by
+
 #### Request
     
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Type: application/sparql-query
-    Accept: application/sparql-results+xml
     Content-Length: 123
 
     SELECT ?o WHERE {
@@ -641,7 +638,7 @@ followed by
 #### Response
     
     2xx or 3xx response
-    Content-Type: application/sparql-results+xml
+    Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for tabular SPARQL results
     
     one result with `?o` bound to an IRI that is _not_ `<test>`
         """ ;

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -356,7 +356,7 @@
             ht:connectionAuthority "www.example" ;
             ht:requests ([
                     a ht:Request ;
-                    ht:absolutePath "/sparql/?named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%26named-graph-uri%3Dhttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
+                    ht:absolutePath "/sparql/?named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf" ;
                     ht:body [
                         a cnt:ContentAsText ;
                         cnt:characterEncoding "UTF-8" ;

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -92,12 +92,13 @@
         rdfs:comment """
 #### Request
 
-    POST /sparql/ HTTP/1.1
+    POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 337
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 123
+    Content-Type: application/sparql-query
     
-    query=ASK+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+a+%3Ftype+.+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E+a+%3Ftype+.+%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf
+    ASK { <http://kasei.us/2009/09/sparql/data/data1.rdf> a ?type . <http://kasei.us/2009/09/sparql/data/data2.rdf> a ?type . }
+    
     
 #### Response
 
@@ -115,12 +116,13 @@
         rdfs:comment """
 #### Request
 
-    POST /sparql/ HTTP/1.1
+    POST /sparql/?named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 369
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 147
+    Content-Type: application/sparql-query
     
-    query=ASK+%7B+GRAPH+%3Fg1+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+a+%3Ftype+%7D+GRAPH+%3Fg2+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E+a+%3Ftype+%7D+%7D&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf
+    ASK { GRAPH ?g1 { <http://kasei.us/2009/09/sparql/data/data1.rdf> a ?type } GRAPH ?g2 { <http://kasei.us/2009/09/sparql/data/data2.rdf> a ?type } }
+    
     
 #### Response
 
@@ -157,12 +159,16 @@
         rdfs:comment """
 #### Request
 
-    POST /sparql/ HTTP/1.1
+    POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 547
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 209
+    Content-Type: application/sparql-query
     
-    query=ASK+%7B%0A%09%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf%3E+a+%3Ftype%0A%09GRAPH+%3Fg1+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+a+%3Ftype+%7D%0A%09GRAPH+%3Fg2+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E+a+%3Ftype+%7D%0A%7D%0A&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf
+    ASK {
+      <http://kasei.us/2009/09/sparql/data/data3.rdf> a ?type
+      GRAPH ?g1 { <http://kasei.us/2009/09/sparql/data/data1.rdf> a ?type }
+      GRAPH ?g2 { <http://kasei.us/2009/09/sparql/data/data2.rdf> a ?type }
+    }
     
 #### Response
 
@@ -180,12 +186,12 @@
         rdfs:comment """
 #### Request
 
-    POST /sparql/ HTTP/1.1
+    POST /sparql/?named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%26named-graph-uri%3Dhttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 442
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 200
+    Content-Type: application/sparql-query
     
-    query=ASK+FROM+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf%3E+%7B+GRAPH+%3Fg1+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+a+%3Ftype+%7D+GRAPH+%3Fg2+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E+a+%3Ftype+%7D+%7D&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf
+    ASK FROM <http://kasei.us/2009/09/sparql/data/data3.rdf> { GRAPH ?g1 { <http://kasei.us/2009/09/sparql/data/data1.rdf> a ?type } GRAPH ?g2 { <http://kasei.us/2009/09/sparql/data/data2.rdf> a ?type } }
     
 #### Response
 
@@ -222,12 +228,12 @@
         rdfs:comment """
 #### Request
 
-    POST /sparql/ HTTP/1.1
+    POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 115
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 23
+    Content-Type: application/sparql-query
     
-    query=SELECT+(1+AS+%3Fvalue)+%7B%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf
+    SELECT (1 AS ?value) {}
     
 #### Response
 
@@ -243,12 +249,12 @@
         rdfs:comment """
 #### Request
 
-    POST /sparql/ HTTP/1.1
+    POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 96
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 5
+    Content-Type: application/sparql-query
     
-    query=ASK+%7B%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf
+    ASK {}
     
 #### Response
 
@@ -264,12 +270,12 @@
         rdfs:comment """
 #### Request
 
-    POST /sparql/ HTTP/1.1
+    POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 128
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 30
+    Content-Type: application/sparql-query
     
-    query=DESCRIBE+%3Chttp%3A%2F%2Fexample.org%2F%3E&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf
+    DESCRIBE <http://example.org/>
     
 #### Response
 
@@ -285,12 +291,12 @@
         rdfs:comment """
 #### Request
 
-    POST /sparql/ HTTP/1.1
+    POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 134
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 32
+    Content-Type: application/sparql-query
     
-    query=CONSTRUCT+%7B+%3Cs%3E+%3Cp%3E+1+%7D+WHERE+%7B%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf
+    CONSTRUCT { <s> <p> 1 } WHERE {}
     
 #### Response
 
@@ -308,10 +314,25 @@
 
     POST /sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 554
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 399
+    Content-Type: application/sparql-update
     
-    update=PREFIX+dc%3A+%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%0APREFIX+foaf%3A+%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0ACLEAR+ALL+%3B%0AINSERT+DATA+%7B%0A%09GRAPH+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+%7B%0A%09%09%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+a+foaf%3ADocument%0A%09%7D%0A%7D+%3B%0AINSERT+%7B%0A%09GRAPH+%3Chttp%3A%2F%2Fexample.org%2Fprotocol-update-dataset-test%2F%3E+%7B%0A%09%09%3Fs+a+dc%3ABibliographicResource%0A%09%7D%0A%7D%0AWHERE+%7B%0A%09%3Fs+a+foaf%3ADocument%0A%7D%0A
+    PREFIX dc: <http://purl.org/dc/terms/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    CLEAR ALL ;
+    INSERT DATA {
+        GRAPH <http://kasei.us/2009/09/sparql/data/data1.rdf> {
+            <http://kasei.us/2009/09/sparql/data/data1.rdf> a foaf:Document
+        }
+    } ;
+    INSERT {
+        GRAPH <http://example.org/protocol-update-dataset-test/> {
+            ?s a dc:BibliographicResource
+        }
+    }
+    WHERE {
+        ?s a foaf:Document
+    }
     
 #### Response
 
@@ -351,10 +372,25 @@ followed by
 
     POST /sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 893
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 645
+    Content-Type: application/sparql-update
     
-    update=PREFIX+dc%3A+%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%0APREFIX+foaf%3A+%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0ADROP+ALL+%3B%0AINSERT+DATA+%7B%0A%09GRAPH+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+a+foaf%3ADocument+%7D%0A%09GRAPH+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E+a+foaf%3ADocument+%7D%0A%09GRAPH+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf%3E+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf%3E+a+foaf%3ADocument+%7D%0A%7D+%3B%0AINSERT+%7B%0A%09GRAPH+%3Chttp%3A%2F%2Fexample.org%2Fprotocol-update-dataset-graphs-test%2F%3E+%7B%0A%09%09%3Fs+a+dc%3ABibliographicResource%0A%09%7D%0A%7D%0AWHERE+%7B%0A%09%3Fs+a+foaf%3ADocument%0A%7D%0A
+    PREFIX dc: <http://purl.org/dc/terms/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    DROP ALL ;
+    INSERT DATA {
+        GRAPH <http://kasei.us/2009/09/sparql/data/data1.rdf> { <http://kasei.us/2009/09/sparql/data/data1.rdf> a foaf:Document }
+        GRAPH <http://kasei.us/2009/09/sparql/data/data2.rdf> { <http://kasei.us/2009/09/sparql/data/data2.rdf> a foaf:Document }
+        GRAPH <http://kasei.us/2009/09/sparql/data/data3.rdf> { <http://kasei.us/2009/09/sparql/data/data3.rdf> a foaf:Document }
+    } ;
+    INSERT {
+        GRAPH <http://example.org/protocol-update-dataset-graphs-test/> {
+            ?s a dc:BibliographicResource
+        }
+    }
+    WHERE {
+        ?s a foaf:Document
+    }
     
 #### Response
 
@@ -400,10 +436,27 @@ followed by
 
     POST /sparql/?using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 931
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 676
+    Content-Type: application/sparql-update
     
-    update=PREFIX+dc%3A+%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%0APREFIX+foaf%3A+%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0ADROP+ALL+%3B%0AINSERT+DATA+%7B%0A%09GRAPH+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+a+foaf%3ADocument+%7D%0A%09GRAPH+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E+a+foaf%3ADocument+%7D%0A%09GRAPH+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf%3E+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf%3E+a+foaf%3ADocument+%7D%0A%7D+%3B%0AINSERT+%7B%0A%09GRAPH+%3Chttp%3A%2F%2Fexample.org%2Fprotocol-update-dataset-named-graphs-test%2F%3E+%7B%0A%09%09%3Fs+a+dc%3ABibliographicResource%0A%09%7D%0A%7D%0AWHERE+%7B%0A%09GRAPH+%3Fg+%7B%0A%09%09%3Fs+a+foaf%3ADocument%0A%09%7D%0A%7D%0A
+    PREFIX dc: <http://purl.org/dc/terms/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    DROP ALL ;
+    INSERT DATA {
+        GRAPH <http://kasei.us/2009/09/sparql/data/data1.rdf> { <http://kasei.us/2009/09/sparql/data/data1.rdf> a foaf:Document }
+        GRAPH <http://kasei.us/2009/09/sparql/data/data2.rdf> { <http://kasei.us/2009/09/sparql/data/data2.rdf> a foaf:Document }
+        GRAPH <http://kasei.us/2009/09/sparql/data/data3.rdf> { <http://kasei.us/2009/09/sparql/data/data3.rdf> a foaf:Document }
+    } ;
+    INSERT {
+        GRAPH <http://example.org/protocol-update-dataset-named-graphs-test/> {
+            ?s a dc:BibliographicResource
+        }
+    }
+    WHERE {
+        GRAPH ?g {
+            ?s a foaf:Document
+        }
+    }
     
 #### Response
 
@@ -449,10 +502,33 @@ followed by
 
     POST /sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 1071
-    Content-Type: application/x-www-form-urlencoded
+    Content-Length: 779
+    Content-Type: application/sparql-update
     
-    update=PREFIX+dc%3A+%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%0APREFIX+foaf%3A+%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0ADROP+ALL+%3B%0AINSERT+DATA+%7B%0A%09GRAPH+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E+a+foaf%3ADocument+%7D%0A%09GRAPH+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E+a+foaf%3ADocument+%7D%0A%09GRAPH+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf%3E+%7B+%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf%3E+a+foaf%3ADocument+%7D%0A%7D+%3B%0AINSERT+%7B%0A%09GRAPH+%3Chttp%3A%2F%2Fexample.org%2Fprotocol-update-dataset-full-test%2F%3E+%7B%0A%09%09%3Fs+%3Chttp%3A%2F%2Fexample.org%2Fin%3E+%3Fin%0A%09%7D%0A%7D%0AWHERE+%7B%0A%09%7B%0A%09%09GRAPH+%3Fg+%7B+%3Fs+a+foaf%3ADocument+%7D%0A%09%09BIND(%3Fg+AS+%3Fin)%0A%09%7D%0A%09UNION%0A%09%7B%0A%09%09%3Fs+a+foaf%3ADocument+.%0A%09%09BIND(%22default%22+AS+%3Fin)%0A%09%7D%0A%7D%0A
+    PREFIX dc: <http://purl.org/dc/terms/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    DROP ALL ;
+    INSERT DATA {
+        GRAPH <http://kasei.us/2009/09/sparql/data/data1.rdf> { <http://kasei.us/2009/09/sparql/data/data1.rdf> a foaf:Document }
+        GRAPH <http://kasei.us/2009/09/sparql/data/data2.rdf> { <http://kasei.us/2009/09/sparql/data/data2.rdf> a foaf:Document }
+        GRAPH <http://kasei.us/2009/09/sparql/data/data3.rdf> { <http://kasei.us/2009/09/sparql/data/data3.rdf> a foaf:Document }
+    } ;
+    INSERT {
+        GRAPH <http://example.org/protocol-update-dataset-full-test/> {
+            ?s <http://example.org/in> ?in
+        }
+    }
+    WHERE {
+        {
+            GRAPH ?g { ?s a foaf:Document }
+            BIND(?g AS ?in)
+        }
+        UNION
+        {
+            ?s a foaf:Document .
+            BIND("default" AS ?in)
+        }
+    }
     
 #### Response
 
@@ -845,12 +921,18 @@ followed by
         rdfs:comment """
 #### Request
 
-    POST /sparql/ HTTP/1.1
+    POST /sparql/?using-named-graph-uri=http%3A%2F%2Fexample%2Fpeople HTTP/1.1
     Host: www.example
-    Content-Type: application/x-www-form-urlencoded
-    Content-Length: 418
+    Content-Type: application/sparql-update
+    Content-Length: 203
 
-    using-named-graph-uri=http%3A%2F%2Fexample%2Fpeople&update=%09%09PREFIX%20foaf%3A%20%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0A%09%09WITH%20%3Chttp%3A%2F%2Fexample%2Faddresses%3E%0A%09%09DELETE%20%7B%20%3Fperson%20foaf%3AgivenName%20%27Bill%27%20%7D%0A%09%09INSERT%20%7B%20%3Fperson%20foaf%3AgivenName%20%27William%27%20%7D%0A%09%09WHERE%20%7B%0A%09%09%09%3Fperson%20foaf%3AgivenName%20%27Bill%27%0A%09%09%7D%0A
+    PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+    WITH <http://example/addresses>
+    DELETE { ?person foaf:givenName 'Bill' }
+    INSERT { ?person foaf:givenName 'William' }
+    WHERE {
+        ?person foaf:givenName 'Bill'
+    }
 
 #### Response
 

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -49,19 +49,19 @@
         mf:name    "query via URL-encoded POST" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
     Content-Type: application/x-www-form-urlencoded
     Content-Length: 18
-
+    
     query=ASK%20%7B%7D
 
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
-
+        
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -72,15 +72,15 @@
         mf:name    "GET query with protocol-specified default graph" ;
         rdfs:comment """
 #### Request
-
+    
     GET /sparql/?query=ASK%20%7B%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E%20a%20%3Ftype%20.%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E%20a%20%3Ftype%20.%20%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
-
+        
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -91,7 +91,7 @@
         mf:name    "POST query with protocol-specified default graphs" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
     Content-Length: 123
@@ -101,10 +101,10 @@
     
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
-
+        
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -115,7 +115,7 @@
         mf:name    "POST query with protocol-specified named graphs" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
     Content-Length: 147
@@ -125,10 +125,10 @@
     
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
-
+    
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -139,15 +139,15 @@
         mf:name    "GET query with protocol-specified named graphs" ;
         rdfs:comment """
 #### Request
-
+    
     GET /sparql/?query=ASK%20%7B%20GRAPH%20%3Fg1%20%7B%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%3E%20a%20%3Ftype%20%7D%20GRAPH%20%3Fg2%20%7B%20%3Chttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf%3E%20a%20%3Ftype%20%7D%20%7D&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
-
+    
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -158,7 +158,7 @@
         mf:name    "query with protocol-specified dataset (both named and default graphs)" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata3.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
     Content-Length: 209
@@ -171,10 +171,10 @@
     }
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
-
+    
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -185,7 +185,7 @@
         mf:name    "query specifying dataset in both query string and protocol; test for use of protocol-specified dataset" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf%26named-graph-uri%3Dhttp%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
     Content-Length: 200
@@ -194,10 +194,10 @@
     ASK FROM <http://kasei.us/2009/09/sparql/data/data3.rdf> { GRAPH ?g1 { <http://kasei.us/2009/09/sparql/data/data1.rdf> a ?type } GRAPH ?g2 { <http://kasei.us/2009/09/sparql/data/data2.rdf> a ?type } }
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
-
+    
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -208,15 +208,15 @@
         mf:name    "query via GET" ;
         rdfs:comment """
 #### Request
-
+    
     GET /sparql/?query=ASK%20%7B%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
-
+    
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -227,7 +227,7 @@
         mf:name    "query appropriate content type (expect one of: XML, JSON, CSV, TSV)" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
     Content-Length: 23
@@ -236,7 +236,7 @@
     SELECT (1 AS ?value) {}
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, text/tab-separated-values, text/csv, or any other valid media type for tabular SPARQL results
         """ ;
@@ -248,7 +248,7 @@
         mf:name    "query appropriate content type (expect one of: XML, JSON)" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
     Content-Length: 5
@@ -257,7 +257,7 @@
     ASK {}
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
         """ ;
@@ -269,7 +269,7 @@
         mf:name    "query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
     Content-Length: 30
@@ -278,7 +278,7 @@
     DESCRIBE <http://example.org/>
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/rdf+xml, application/rdf+json, text/turtle, or any other valid media type for RDF results
         """ ;
@@ -290,7 +290,7 @@
         mf:name    "query appropriate content type (expect one of: RDF/XML, Turtle, N-Triples, RDFa)" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
     Content-Length: 32
@@ -299,7 +299,7 @@
     CONSTRUCT { <s> <p> 1 } WHERE {}
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/rdf+xml, application/rdf+json, text/turtle, or any other valid media type for RDF results
         """ ;
@@ -311,7 +311,7 @@
         mf:name    "update with protocol-specified default graph" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf HTTP/1.1
     Host: www.example
     Content-Length: 399
@@ -335,13 +335,13 @@
     }
     
 #### Response
-
+    
     2xx or 3xx response
 
 followed by
 
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Accept: application/sparql-results+xml
@@ -355,10 +355,10 @@ followed by
     }
 
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml
-    
+        
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -369,7 +369,7 @@ followed by
         mf:name    "update with protocol-specified default graphs" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
     Content-Length: 645
@@ -393,13 +393,13 @@ followed by
     }
     
 #### Response
-
+    
     2xx or 3xx response
 
 followed by
 
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Accept: application/sparql-results+xml
@@ -419,10 +419,10 @@ followed by
     }
 
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml
-    
+        
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -433,7 +433,7 @@ followed by
         mf:name    "update with protocol-specified named graphs" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
     Content-Length: 676
@@ -459,13 +459,13 @@ followed by
     }
     
 #### Response
-
+    
     2xx or 3xx response
 
 followed by
 
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Accept: application/sparql-results+xml
@@ -485,10 +485,10 @@ followed by
     }
 
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml
-    
+        
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -499,7 +499,7 @@ followed by
         mf:name    "update with protocol-specified dataset (both named and default graphs)" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?using-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata1.rdf&using-named-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata2.rdf HTTP/1.1
     Host: www.example
     Content-Length: 779
@@ -531,13 +531,13 @@ followed by
     }
     
 #### Response
-
+    
     2xx or 3xx response
 
 followed by
 
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Accept: application/sparql-results+xml
@@ -557,10 +557,10 @@ followed by
     }
 
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml
-    
+        
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -571,7 +571,7 @@ followed by
         mf:name    "update via URL-encoded POST" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Length: 16
@@ -580,7 +580,7 @@ followed by
     update=CLEAR+ALL
     
 #### Response
-
+    
     2xx or 3xx response
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -591,7 +591,7 @@ followed by
         mf:name    "update via POST directly" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Length: 9
@@ -600,7 +600,7 @@ followed by
     CLEAR ALL
     
 #### Response
-
+    
     2xx or 3xx response
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -611,7 +611,7 @@ followed by
         mf:name    "test for service-defined BASE URI (\"which MAY be the service endpoint\")" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Type: application/sparql-update
@@ -621,11 +621,11 @@ followed by
     INSERT DATA { GRAPH <http://example.org/protocol-base-test/> { <http://example.org/s> <http://example.org/p> <test> } }
     
 #### Response
-
+    
     2xx or 3xx response
 
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Type: application/sparql-query
@@ -639,7 +639,7 @@ followed by
     }
 
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml
     
@@ -653,7 +653,7 @@ followed by
         mf:name    "query via POST directly" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Length: 6
@@ -662,10 +662,10 @@ followed by
     ASK {}
     
 #### Response
-
+    
     2xx or 3xx response
     Content-Type: application/sparql-results+xml, application/sparql-results+json, or any other valid media type for boolean SPARQL results
-
+    
     true
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -676,14 +676,14 @@ followed by
         mf:name    "invoke query operation with a method other than GET or POST" ;
         rdfs:comment """
 #### Request
-
+    
     PUT /sparql/?query=ASK%20%7B%7D&default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
     Content-Length: 0
     Content-Type: application/x-www-form-urlencoded
     
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -694,11 +694,11 @@ followed by
         mf:name    "invoke query operation with more than one query string" ;
         rdfs:comment """
 #### Request
-
+    
     GET /sparql/?query=ASK%20%7B%7D&query=SELECT%20%2A%20%7B%7D HTTP/1.1
-
+    
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -709,7 +709,7 @@ followed by
         mf:name    "invoke query operation with a POST with media type that's not url-encoded or application/sparql-query" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Type: text/plain
@@ -718,7 +718,7 @@ followed by
     ASK {}
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -729,7 +729,7 @@ followed by
         mf:name    "invoke query operation with url-encoded body, but without application/x-www-form-urlencoded media type" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Length: 18
@@ -737,7 +737,7 @@ followed by
     query=ASK%20%7B%7D
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -748,7 +748,7 @@ followed by
         mf:name    "invoke query operation with SPARQL body, but without application/sparql-query media type" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Length: 6
@@ -756,7 +756,7 @@ followed by
     ASK {}
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -769,7 +769,7 @@ followed by
 (Content body encoded in utf-16, with a preceding BOM.)
 
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Type: application/sparql-query; charset=UTF-16
@@ -778,7 +778,7 @@ followed by
     ASK {}
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -789,11 +789,11 @@ followed by
         mf:name    "invoke query operation with invalid query syntax (4XX result)" ;
         rdfs:comment """
 #### Request
-
+    
     GET /sparql/?query=ASK%20%7B HTTP/1.1
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -804,11 +804,11 @@ followed by
         mf:name    "invoke update operation with GET" ;
         rdfs:comment """
 #### Request
-
+    
     GET /sparql/?update=CLEAR%20ALL HTTP/1.1
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -819,7 +819,7 @@ followed by
         mf:name    "invoke update operation with more than one update string" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Type: application/x-www-form-urlencoded
@@ -828,7 +828,7 @@ followed by
     update=CLEAR%20NAMED&update=CLEAR%20DEFAULT
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -839,7 +839,7 @@ followed by
         mf:name    "invoke update operation with a POST with media type that's not url-encoded or application/sparql-update" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Type: text/plain
@@ -848,7 +848,7 @@ followed by
     CLEAR NAMED
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -859,7 +859,7 @@ followed by
         mf:name    "invoke update operation with url-encoded body, but without application/x-www-form-urlencoded media type" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Length: 20
@@ -867,7 +867,7 @@ followed by
     update=CLEAR%20NAMED
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -880,7 +880,7 @@ followed by
 (Content body encoded in utf-16, with a preceding BOM.)
 
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Type: application/sparql-update; charset=UTF-16
@@ -889,7 +889,7 @@ followed by
     CLEAR NAMED
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -900,7 +900,7 @@ followed by
         mf:name    "invoke update operation with invalid update syntax" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/ HTTP/1.1
     Host: www.example
     Content-Type: application/x-www-form-urlencoded
@@ -909,7 +909,7 @@ followed by
     update=CLEAR%20XYZ
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;
@@ -920,7 +920,7 @@ followed by
         mf:name    "invoke update with both using-graph-uri/using-named-graph-uri parameter and USING/WITH clause" ;
         rdfs:comment """
 #### Request
-
+    
     POST /sparql/?using-named-graph-uri=http%3A%2F%2Fexample%2Fpeople HTTP/1.1
     Host: www.example
     Content-Type: application/sparql-update
@@ -935,7 +935,7 @@ followed by
     }
 
 #### Response
-
+    
     4xx
         """ ;
         dawgt:approval dawgt:Approved ;

--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -11,6 +11,31 @@
 
 <>  rdf:type mf:Manifest ;
     rdfs:label "SPARQL Protocol" ;
+    rdfs:comment """
+    	This manifest encodes tests for the SPARQL Protocol. Each test record
+    	has one or more ht:Requests that must be run in order to produce the
+    	expected results.
+    	
+    	Expected results are encoded in the ht:Response using one of four new
+    	terms:
+    	
+    	* `mf:expectedStatus` - Expected HTTP status code (pointing to values
+    	      like `ht:StatusCode2xx`);
+    	* `mf:expectedBoolean` - Expected results for ASK queries.
+    	* `mf:expectedFormat` - Expected serialization format of the results;
+    	      the range here is one of the literals: `"boolean"`, `"tabular"`,
+    	      or `"RDF"`
+    	* `mf:expectation` - A textual description of the expected results for
+    	      the single test `update_base_uri` where modeling the expectation
+    	      would have been prohibitive.
+
+    	Each request has a ht:absolutePath value that starts with `/sparql/`.
+    	A program using this manifest data to run the tests must replace this
+    	value with whatever path prefix is appropriate for the endpoint being
+    	tested. Every ht:absolutePath value in this manifest starts with
+    	`/sparql/`, but and endpoint being tested may require different
+    	endpoints to be used for Query and Update requests.
+    """ ;
     mf:entries
     (
         :query_post_form


### PR DESCRIPTION
This adds modeling for all the existing Protocol tests based heavily on Gregg's work in #79 (which I think has diverged enough from the current manifest as a result of #306 that it's not worth trying to reconcile).

I am reasonably confident that this new data is a faithful encoding as they were produced automatically by parsing the HTTP requests in the previous `rdfs:comment` strings and modeling the resulting data. I used some regex matching to figure out the input for the expected results modeling.

There are a few of differences from Gregg's original model:

* I do not provide an extra layer of modeling for headers (for example, `"application/sparql-query; charset=UTF-16"` is not also broken down into the header name and parameter elements)
* I do not use `ht:statusCodeValue` with literal values like `"4XX"` (more on this below), instead using values such as `ht:StatusCode2xx` with a new `mf:expectedStatus` property
* For expected results, I have moved away from the tests enumerating the acceptable media types (which seems fraught and likely to lag new, valid formats) and instead simply declare the type of results expected (boolean, tabular, or RDF; more on this below)

I introduce four new manifest terms to model the expected results:

* `mf:expectedStatus` - Expected HTTP status code (pointing to values like `ht:StatusCode2xx`); this differs from Gregg's model which used `_:response ht:statusCodeValue "2XX"` which did not conform to the semantics of `ht:statusCodeValue`, and was my biggest issue with #79
* `mf:expectedBoolean` - Expected results for ASK queries.
* `mf:expectedFormat` - Expected serialization format of the results; the range here is one of the literals: `"boolean"`, `"tabular"`, or `"RDF"` (I'm open to changing this to a controlled set of IRIs if desired and with suggestions on where such IRIs might live)
* `mf:expectation` - A textual description of the expected results for the singel test `update_base_uri` where modeling the expectation would have been prohibitive. (Changing the test to check the expectation as a `FILTER` in the query and then using `ASK` might be a better approach here.)

I also (ab)use the SPARQL Update `ut:graphData` modeling to indicate the named graphs that should be loaded into the Dataset before the test is run:

```
ut:graphData [ ut:graph <data1.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data1.rdf" ] ;
ut:graphData [ ut:graph <data2.nt> ; rdfs:label "http://kasei.us/2009/09/sparql/data/data2.rdf" ] ;
```

For now those `ut:graphData` properties are hanging off of the test itself, which feels a bit strange, but it didn't feel any better to hang them off of the mf:action which in this manifest is a `ht:Request`. This is another area where I'm open to suggestions.

Finally, I made a few substantive (but I expect uncontroversial) changes to a few tests. For the following tests, I removed the requirement to return results in SPARQL XML format (removing the Accept header in the request, and the expected Content-Type of the result)

* `update_dataset_default_graphs`
* `update_base_uri`
* `update_dataset_default_graph`
* `update_dataset_named_graphs`
* `update_dataset_full`
