### PR TITLE
Fix incorrect Content-Length in test case text description

### DIFF
--- a/sparql/sparql11/protocol/manifest.ttl
+++ b/sparql/sparql11/protocol/manifest.ttl
@@ -543,7 +543,7 @@
     
     POST /sparql/?default-graph-uri=http%3A%2F%2Fkasei.us%2F2009%2F09%2Fsparql%2Fdata%2Fdata0.rdf HTTP/1.1
     Host: www.example
-    Content-Length: 5
+    Content-Length: 6
     Content-Type: application/sparql-query
     
     ASK {}


### PR DESCRIPTION
Fix an error in the `Content-Length` of the text descriptions of one test case introduced in #312. @kasei 