### PR TITLE
Numeric escape sequence with surrogate pairs (Turtle)

### DIFF
--- a/rdf/rdf12/rdf-turtle/eval/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/manifest.ttl
@@ -55,6 +55,8 @@ trs:manifest  rdf:type mf:Manifest ;
         trs:turtle12-reified-triples-annotation-01
         trs:turtle12-reified-triples-annotation-02
         trs:turtle12-reified-triples-annotation-03
+        trs:turtle12-surrogates-01
+        trs:turtle12-surrogates-02
     ) .
 
 trs:turtle12-rt-01 rdf:type rdft:TestTurtleEval ;
@@ -231,3 +233,14 @@ trs:turtle12-reified-triples-annotation-03 rdf:type rdft:TestTurtleEval ;
    mf:result    <turtle12-eval-reified-triples-annotation-03.nt> ;
    .
 
+trs:turtle12-surrogates-01 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle 1.2 - Surrogate pair" ;
+   mf:action    <turtle12-eval-surrogate-pair-01.ttl> ;
+   mf:result    <turtle12-eval-surrogate-pair-01.nt> ;
+   .
+
+trs:turtle12-surrogates-02 rdf:type rdft:TestTurtleEval ;
+   mf:name      "Turtle 1.2 - Surrogate pair (alt)" ;
+   mf:action    <turtle12-eval-surrogate-pair-02.ttl> ;
+   mf:result    <turtle12-eval-surrogate-pair-02.nt> ;
+   .

--- a/rdf/rdf12/rdf-turtle/eval/turtle12-eval-surrogate-pair-01.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle12-eval-surrogate-pair-01.nt
@@ -1,0 +1,1 @@
+<http://example/s> <http://example/p> "🂡" .

--- a/rdf/rdf12/rdf-turtle/eval/turtle12-eval-surrogate-pair-01.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle12-eval-surrogate-pair-01.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p "\uD83C\uDCA1" .

--- a/rdf/rdf12/rdf-turtle/eval/turtle12-eval-surrogate-pair-02.nt
+++ b/rdf/rdf12/rdf-turtle/eval/turtle12-eval-surrogate-pair-02.nt
@@ -1,0 +1,1 @@
+<http://example/s> <http://example/p> "\U0001F0A1" .

--- a/rdf/rdf12/rdf-turtle/eval/turtle12-eval-surrogate-pair-02.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/turtle12-eval-surrogate-pair-02.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p "\uD83C\uDCA1" .

--- a/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
@@ -113,6 +113,16 @@ trs:manifest  rdf:type mf:Manifest ;
         trs:turtle12-version-bad-04
         trs:turtle12-version-bad-05
         trs:turtle12-version-bad-06
+
+## Surrogate handling
+        trs:turtle12-surrogates-01
+        trs:turtle12-surrogates-02
+        
+        trs:turtle12-surrogates-bad-01
+        trs:turtle12-surrogates-bad-02
+        trs:turtle12-surrogates-bad-03
+        trs:turtle12-surrogates-bad-04
+        trs:turtle12-surrogates-bad-05
     ) .
 
 ## Good Syntax
@@ -411,7 +421,7 @@ trs:turtle12-version-02 rdf:type rdft:TestTurtlePositiveSyntax ;
    .
 
 trs:turtle12-version-03 rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name      "Turtle 1.2 - VERSION in data " ;
+   mf:name      "Turtle 1.2 - VERSION in data" ;
    mf:action    <turtle12-version-03.ttl> ;
    .
 
@@ -470,3 +480,40 @@ trs:turtle12-version-bad-06 rdf:type rdft:TestTurtleNegativeSyntax ;
    mf:action    <turtle12-version-bad-06.ttl> ;
    .
 
+## Surrogates
+
+
+trs:turtle12-surrogates-01 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle 1.2 - Surrogates via numeric escape sequence" ;
+   mf:action    <turtle12-surrogates-01.ttl>
+   .
+   
+trs:turtle12-surrogates-02 rdf:type rdft:TestTurtlePositiveSyntax ;
+   mf:name      "Turtle 1.2 - Surrogates via numeric escape sequence" ;
+   mf:action    <turtle12-surrogates-02.ttl>
+   .
+
+trs:turtle12-surrogates-bad-01 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad surrogates - wrong order" ;
+   mf:action    <turtle12-surrogates-bad-01.ttl>;
+   .
+
+trs:turtle12-surrogates-bad-02 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad surrogates - high-high" ;
+   mf:action    <turtle12-surrogates-bad-02.ttl>;
+   .
+
+trs:turtle12-surrogates-bad-03 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad surrogates - low-low" ;
+   mf:action    <turtle12-surrogates-bad-03.ttl>;
+   .
+
+trs:turtle12-surrogates-bad-04 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad surrogates - lone high surrogate" ;
+   mf:action    <turtle12-surrogates-bad-04.ttl>;
+   .
+
+trs:turtle12-surrogates-bad-05 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad surrogates - lone low surrogate" ;
+   mf:action    <turtle12-surrogates-bad-05.ttl>;
+   .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-01.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-01.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p "\uD83C\uDCA1" .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-02.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-02.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p 'Ace of spades : \uD83C\uDCA1' .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-01.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-01.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+# Bad low-high, not high-low
+:s :p "\uDCA1\uD83C" .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-02.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-02.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p "\uD83C\uD83D" .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-03.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-03.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p "\uDCA1\uDCA2" .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-04.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-04.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p "Single high surrogate (\uD83C)" .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-05.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-05.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p "Single low surrogate (\uDCA1)" .


### PR DESCRIPTION
This PR is part of the discussion https://github.com/w3c/rdf-turtle/issues/131.

The tests are for allowing a pair of numeric escapes `\uHHHH` to be a well-formed surrogate pair that is interpreted as the supplemental character codepoint represented by that surrogate pair. 

The surrogates are not part of the lexical form in the RDF data model, the supplemental character represented by that surrogate pair is and the RDFgraph is the same as if written using `\U`.

There are positive syntax tests for valid surrogate pairs written with `\uHHHH\uHHHH` (high-low surrogate) and negative tests for a malformed surrogate pairs (low-high, low-low, high-high) and for lone surrogates; the latter is also in the RDF 1.1 Turtle test suite but the same coverage is repeated for completeness.

There are evaluation tests for a valid surrogate pair with the same graph output in two forms, a supplemental character as UTF-8 and also written using `\U` (they parse to the same graph).

This PR is marked draft because the WG has not yet agreed a resolution of the i18n issue.
