### PR TITLE
Align xml-canon to previous behavior

### DIFF
--- a/rdf/rdf11/rdf-xml/xml-canon/test001.nt
+++ b/rdf/rdf11/rdf-xml/xml-canon/test001.nt
@@ -13,4 +13,4 @@
 # $Id: test001.nt,v 1.1 2003/08/18 10:09:29 jgrant Exp $
 #
 #####################################################################
-<http://www.example.org/a> <http://example.org/prop> "<br xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:eg=\"http://example.org/\"></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
+<http://www.example.org/a> <http://example.org/prop> "<br></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .

--- a/rdf/rdf11/rdf-xml/xml-canon/test002.nt
+++ b/rdf/rdf11/rdf-xml/xml-canon/test002.nt
@@ -11,8 +11,8 @@
 # Canonicalization of XMLLiterals with reification.
 #
 #####################################################################
-<http://www.example.org/a> <http://example.org/prop> "<br xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:eg=\"http://example.org/\"></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
+<http://www.example.org/a> <http://example.org/prop> "<br></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
 <http://example.com/#reif> <http://www.w3.org/1999/02/22-rdf-syntax-ns#subject> <http://www.example.org/a> .
 <http://example.com/#reif> <http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate> <http://example.org/prop> .
-<http://example.com/#reif> <http://www.w3.org/1999/02/22-rdf-syntax-ns#object> "<br xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:eg=\"http://example.org/\"></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
+<http://example.com/#reif> <http://www.w3.org/1999/02/22-rdf-syntax-ns#object> "<br></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
 <http://example.com/#reif> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement> .

--- a/rdf/rdf12/rdf-xml/eval/rdf12-xml-an-13.nt
+++ b/rdf/rdf12/rdf-xml/eval/rdf12-xml-an-13.nt
@@ -1,2 +1,2 @@
-<http://www.example.org/a> <http://example.org/prop> "<br xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:eg=\"http://example.org/\"></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
-<http://example.com/triple1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<(<http://www.example.org/a> <http://example.org/prop> "<br xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:eg=\"http://example.org/\"></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral>)>> .
+<http://www.example.org/a> <http://example.org/prop> "<br></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
+<http://example.com/triple1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<(<http://www.example.org/a> <http://example.org/prop> "<br></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral>)>> .

--- a/rdf/rdf12/rdf-xml/eval/rdf12-xml-an-14.nt
+++ b/rdf/rdf12/rdf-xml/eval/rdf12-xml-an-14.nt
@@ -1,2 +1,2 @@
-<http://www.example.org/a> <http://example.org/prop> "<br xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:eg=\"http://example.org/\"></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
-_:triple1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<(<http://www.example.org/a> <http://example.org/prop> "<br xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:eg=\"http://example.org/\"></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral>)>> .
+<http://www.example.org/a> <http://example.org/prop> "<br></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
+_:triple1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<(<http://www.example.org/a> <http://example.org/prop> "<br></br>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral>)>> .


### PR DESCRIPTION
The original test in [rdf11/rdf-xml/xml-canon/test001.rdf](https://github.com/w3c/rdf-tests/blob/main/rdf/rdf11/rdf-xml/xml-canon/)
for `rdf:XMLLiteral` changed and it seems to have changed RDF/XML behaviour.

https://github.com/w3c/rdf-tests/blob/main/rdf/rdf11/rdf-xml/xml-canon/
https://github.com/w3c/rdf-tests/pull/177 (added test002)
https://github.com/w3c/rdf-tests/pull/206 (changes test001.nt)

The RDF 1.1 tests are included in the RDF 1.2 tst manifest so an implementation that passed at RDF 1.1 will not pass when they try RDF 1.2.

There is wider issue: https://github.com/w3c/rdf-xml/issues/97
This PR is only for reverting `rdf11/rdf/xml-canon` behavior.
