### PR TITLE
Remove SPARQL Graph Store Protocol test gsp:put__mismatched_payload.

### DIFF
--- a/sparql/sparql11/http-rdf-update/manifest.ttl
+++ b/sparql/sparql11/http-rdf-update/manifest.ttl
@@ -15,7 +15,6 @@
                  gsp:get_of_put__graph_already_in_store
                  gsp:put__default_graph
                  gsp:get_of_put__default_graph
-                 gsp:put__mismatched_payload
                  gsp:delete__existing_graph
                  gsp:get_of_delete__existing_graph
                  gsp:delete__nonexistent_graph
@@ -449,30 +448,5 @@ gsp:put__initial_state a mf:GraphStoreProtocolTest;
 #### Response
 
     201 Created
-    """ .
-
-gsp:put__mismatched_payload a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
-    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "PUT - mismatched payload" ;
-    rdfs:comment """
-#### Request
-
-    PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1
-    Host: $HOST$
-    Content-Type: text/turtle; charset=utf-8
-
-    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
-
-    <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
-        foaf:businessCard [
-            a v:VCard;
-            v:fn "Jane Doe"
-        ].
-
-#### Response
-
-    400 Bad Request
     """ .
 


### PR DESCRIPTION
While this was approved by the SPARQL 1.1 WG, it does not seem to make any sense. The test name mentions "mismatched payload", but the payload in this test matches the content type in the header, and is the exact same request as in test gsp:put__graph_already_in_store (which expects success).

Have discussed this with @Tpt and @afs and agreed that removing the test was the best path forward.