### PR TITLE
Re-order the definitions of GSP tests in the manifest.

### DIFF
--- a/sparql/sparql11/http-rdf-update/manifest.ttl
+++ b/sparql/sparql11/http-rdf-update/manifest.ttl
@@ -28,213 +28,30 @@
                  gsp:head_on_an_existing_graph
                  gsp:head_on_a_nonexisting_graph ) .
 
-gsp:delete__existing_graph a mf:GraphStoreProtocolTest;
+gsp:put__initial_state a mf:GraphStoreProtocolTest;
     dawg:approval dawg:Approved;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "DELETE - existing graph" ;
+    mf:name "PUT - Initial state" ;
     rdfs:comment """
 #### Request
 
-    DELETE $GRAPHSTORE$/person/2.ttl HTTP/1.1
+
+    PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1
     Host: $HOST$
-
-#### Response
-
-    200 OK
-    """ .
-
-gsp:delete__nonexistent_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
-    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "DELETE - non-existent graph" ;
-    rdfs:comment """
-#### Request
-
-    DELETE $GRAPHSTORE$/person/2.ttl HTTP/1.1
-    Host: $HOST$
-
-#### Response
-
-    404 Not Found
-    """ .
-
-gsp:get_of_delete__existing_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
-    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "GET of DELETE - existing graph" ;
-    rdfs:comment """
-#### Request
-
-    GET $GRAPHSTORE$/person/2.ttl HTTP/1.1
-    Host: $HOST$
-
-#### Response
-
-    404 Not Found
-    """ .
-
-gsp:get_of_post__after_noop a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
-    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "GET of POST - after noop" ;
-    rdfs:comment """
-#### Request
-
-    GET $NEWPATH$ HTTP/1.1
-    Host: $HOST$
-    Accept: text/turtle
-
-#### Response
-
-    200 OK
     Content-Type: text/turtle; charset=utf-8
-    Content-Length: ...
-
-    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
-
-    []  a foaf:Person;
-        foaf:businessCard [
-            a v:VCard;
-            v:given-name "Alice"
-        ] .
-    """ .
-
-gsp:get_of_post__create__new_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
-    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "GET of POST - create new graph" ;
-    rdfs:comment """
-#### Request
-
-    GET $NEWPATH$ HTTP/1.1
-    Host: $HOST$
-    Accept: text/turtle
-
-#### Response
-
-    200 OK
-    Content-Type: text/turtle; charset=utf-8
-    Content-Length: ...
-
-    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
-
-    []  a foaf:Person;
-        foaf:businessCard [
-            a v:VCard;
-            v:given-name "Alice"
-        ] .
-    """ .
-
-gsp:get_of_post__existing_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
-    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "GET of POST - existing graph" ;
-    rdfs:comment """
-#### Request
-
-    GET $GRAPHSTORE$/person/1.ttl HTTP/1.1
-    Host: $HOST$
-    Accept: text/turtle
-
-#### Response
-
-    200 OK
-    Content-Type: text/turtle; charset=utf-8
-    Content-Length: ...
 
     @prefix foaf: <http://xmlns.com/foaf/0.1/> .
     @prefix v: <http://www.w3.org/2006/vcard/ns#> .
 
     <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
-       foaf:businessCard [
+        foaf:businessCard [
             a v:VCard;
             v:fn "John Doe"
-       ] .
-    """ .
-
-gsp:get_of_post__multipart_formdata a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
-    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "GET of POST - multipart/form-data" ;
-    rdfs:comment """
-#### Request
-
-    GET $GRAPHSTORE$/person/1.ttl HTTP/1.1
-    Host: $HOST$
+        ].
 
 #### Response
 
-    200 OK
-    Content-Type: text/turtle; charset=utf-8
-    Content-Length: ...
-
-    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
-
-    <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
-        foaf:name           "Jane Doe";
-        foaf:givenName      "Jane";
-        foaf:familyName     "Doe";
-        foaf:businessCard [
-            a               v:VCard;
-            v:fn            "Jane Doe"
-        ] .
-    """ .
-
-gsp:get_of_put__default_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
-    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "GET of PUT - default graph" ;
-    rdfs:comment """
-#### Request
-
-    GET $GRAPHSTORE$?default HTTP/1.1
-    Host: $HOST$
-    Accept: text/turtle
-
-#### Response
-
-    200 OK
-    Content-Type: text/turtle; charset=utf-8
-    Content-Length: ...
-
-    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
-
-    []  a foaf:Person;
-        foaf:businessCard [
-            a v:VCard;
-            v:given-name "Alice"
-        ] .
-    """ .
-
-gsp:get_of_put__graph_already_in_store a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
-    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "GET of PUT - graph already in store" ;
-    rdfs:comment """
-#### Request
-
-    GET $GRAPHSTORE$/person/1.ttl HTTP/1.1
-    Host: $HOST$
-    Accept: text/turtle
-
-#### Response
-
-    200 OK
-    Content-Type: text/turtle; charset=utf-8
-    Content-Length: ...
-
-    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
-
-    <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
-       foaf:businessCard [
-            a v:VCard;
-            v:fn "Jane Doe"
-       ] .
+    201 Created
     """ .
 
 gsp:get_of_put__initial_state a mf:GraphStoreProtocolTest;
@@ -264,46 +81,66 @@ gsp:get_of_put__initial_state a mf:GraphStoreProtocolTest;
        ].
     """ .
 
-gsp:head_on_a_nonexisting_graph a mf:GraphStoreProtocolTest;
+gsp:put__graph_already_in_store a mf:GraphStoreProtocolTest;
     dawg:approval dawg:Approved;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "HEAD on a non-existing graph" ;
+    mf:name "PUT - graph already in store" ;
     rdfs:comment """
 #### Request
 
-    HEAD $GRAPHSTORE$/person/4.ttl HTTP/1.1
+    PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1
     Host: $HOST$
+    Content-Type: text/turtle; charset=utf-8
+
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+
+    <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
+        foaf:businessCard [
+            a v:VCard;
+            v:fn "Jane Doe"
+        ].
 
 #### Response
 
-    404 Not Found
+    204 No Content
     """ .
 
-gsp:head_on_an_existing_graph a mf:GraphStoreProtocolTest;
+gsp:get_of_put__graph_already_in_store a mf:GraphStoreProtocolTest;
     dawg:approval dawg:Approved;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "HEAD on an existing graph" ;
+    mf:name "GET of PUT - graph already in store" ;
     rdfs:comment """
 #### Request
 
-    HEAD $GRAPHSTORE$/person/1.ttl HTTP/1.1
+    GET $GRAPHSTORE$/person/1.ttl HTTP/1.1
     Host: $HOST$
+    Accept: text/turtle
 
 #### Response
 
     200 OK
     Content-Type: text/turtle; charset=utf-8
     Content-Length: ...
+
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+
+    <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
+       foaf:businessCard [
+            a v:VCard;
+            v:fn "Jane Doe"
+       ] .
     """ .
 
-gsp:post__create__new_graph a mf:GraphStoreProtocolTest;
+gsp:put__default_graph a mf:GraphStoreProtocolTest;
     dawg:approval dawg:Approved;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "POST - create new graph" ;
+    mf:name "PUT - default graph" ;
     rdfs:comment """
 #### Request
 
-    POST $GRAPHSTORE$ HTTP/1.1
+    PUT $GRAPHSTORE$?default HTTP/1.1
     Host: $HOST$
     Content-Type: text/turtle; charset=utf-8
 
@@ -319,7 +156,78 @@ gsp:post__create__new_graph a mf:GraphStoreProtocolTest;
 #### Response
 
     201 Created
-    Location: $NEWPATH$
+    """ .
+
+gsp:get_of_put__default_graph a mf:GraphStoreProtocolTest;
+    dawg:approval dawg:Approved;
+    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
+    mf:name "GET of PUT - default graph" ;
+    rdfs:comment """
+#### Request
+
+    GET $GRAPHSTORE$?default HTTP/1.1
+    Host: $HOST$
+    Accept: text/turtle
+
+#### Response
+
+    200 OK
+    Content-Type: text/turtle; charset=utf-8
+    Content-Length: ...
+
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+
+    []  a foaf:Person;
+        foaf:businessCard [
+            a v:VCard;
+            v:given-name "Alice"
+        ] .
+    """ .
+
+gsp:delete__existing_graph a mf:GraphStoreProtocolTest;
+    dawg:approval dawg:Approved;
+    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
+    mf:name "DELETE - existing graph" ;
+    rdfs:comment """
+#### Request
+
+    DELETE $GRAPHSTORE$/person/2.ttl HTTP/1.1
+    Host: $HOST$
+
+#### Response
+
+    200 OK
+    """ .
+
+gsp:get_of_delete__existing_graph a mf:GraphStoreProtocolTest;
+    dawg:approval dawg:Approved;
+    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
+    mf:name "GET of DELETE - existing graph" ;
+    rdfs:comment """
+#### Request
+
+    GET $GRAPHSTORE$/person/2.ttl HTTP/1.1
+    Host: $HOST$
+
+#### Response
+
+    404 Not Found
+    """ .
+
+gsp:delete__nonexistent_graph a mf:GraphStoreProtocolTest;
+    dawg:approval dawg:Approved;
+    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
+    mf:name "DELETE - non-existent graph" ;
+    rdfs:comment """
+#### Request
+
+    DELETE $GRAPHSTORE$/person/2.ttl HTTP/1.1
+    Host: $HOST$
+
+#### Response
+
+    404 Not Found
     """ .
 
 gsp:post__existing_graph a mf:GraphStoreProtocolTest;
@@ -340,6 +248,33 @@ gsp:post__existing_graph a mf:GraphStoreProtocolTest;
 #### Response
 
     200 OK
+    """ .
+
+gsp:get_of_post__existing_graph a mf:GraphStoreProtocolTest;
+    dawg:approval dawg:Approved;
+    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
+    mf:name "GET of POST - existing graph" ;
+    rdfs:comment """
+#### Request
+
+    GET $GRAPHSTORE$/person/1.ttl HTTP/1.1
+    Host: $HOST$
+    Accept: text/turtle
+
+#### Response
+
+    200 OK
+    Content-Type: text/turtle; charset=utf-8
+    Content-Length: ...
+
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+
+    <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
+       foaf:businessCard [
+            a v:VCard;
+            v:fn "John Doe"
+       ] .
     """ .
 
 gsp:post__multipart_formdata a mf:GraphStoreProtocolTest;
@@ -374,14 +309,43 @@ gsp:post__multipart_formdata a mf:GraphStoreProtocolTest;
     200 OK
     """ .
 
-gsp:put__default_graph a mf:GraphStoreProtocolTest;
+gsp:get_of_post__multipart_formdata a mf:GraphStoreProtocolTest;
     dawg:approval dawg:Approved;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "PUT - default graph" ;
+    mf:name "GET of POST - multipart/form-data" ;
     rdfs:comment """
 #### Request
 
-    PUT $GRAPHSTORE$?default HTTP/1.1
+    GET $GRAPHSTORE$/person/1.ttl HTTP/1.1
+    Host: $HOST$
+
+#### Response
+
+    200 OK
+    Content-Type: text/turtle; charset=utf-8
+    Content-Length: ...
+
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+    @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+
+    <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
+        foaf:name           "Jane Doe";
+        foaf:givenName      "Jane";
+        foaf:familyName     "Doe";
+        foaf:businessCard [
+            a               v:VCard;
+            v:fn            "Jane Doe"
+        ] .
+    """ .
+
+gsp:post__create__new_graph a mf:GraphStoreProtocolTest;
+    dawg:approval dawg:Approved;
+    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
+    mf:name "POST - create new graph" ;
+    rdfs:comment """
+#### Request
+
+    POST $GRAPHSTORE$ HTTP/1.1
     Host: $HOST$
     Content-Type: text/turtle; charset=utf-8
 
@@ -397,56 +361,92 @@ gsp:put__default_graph a mf:GraphStoreProtocolTest;
 #### Response
 
     201 Created
+    Location: $NEWPATH$
     """ .
 
-gsp:put__graph_already_in_store a mf:GraphStoreProtocolTest;
+gsp:get_of_post__create__new_graph a mf:GraphStoreProtocolTest;
     dawg:approval dawg:Approved;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "PUT - graph already in store" ;
+    mf:name "GET of POST - create new graph" ;
     rdfs:comment """
 #### Request
 
-    PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1
+    GET $NEWPATH$ HTTP/1.1
     Host: $HOST$
+    Accept: text/turtle
+
+#### Response
+
+    200 OK
     Content-Type: text/turtle; charset=utf-8
+    Content-Length: ...
 
     @prefix foaf: <http://xmlns.com/foaf/0.1/> .
     @prefix v: <http://www.w3.org/2006/vcard/ns#> .
 
-    <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
+    []  a foaf:Person;
         foaf:businessCard [
             a v:VCard;
-            v:fn "Jane Doe"
-        ].
-
-#### Response
-
-    204 No Content
+            v:given-name "Alice"
+        ] .
     """ .
 
-gsp:put__initial_state a mf:GraphStoreProtocolTest;
+gsp:get_of_post__after_noop a mf:GraphStoreProtocolTest;
     dawg:approval dawg:Approved;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
-    mf:name "PUT - Initial state" ;
+    mf:name "GET of POST - after noop" ;
     rdfs:comment """
 #### Request
 
-
-    PUT $GRAPHSTORE$/person/1.ttl HTTP/1.1
+    GET $NEWPATH$ HTTP/1.1
     Host: $HOST$
+    Accept: text/turtle
+
+#### Response
+
+    200 OK
     Content-Type: text/turtle; charset=utf-8
+    Content-Length: ...
 
     @prefix foaf: <http://xmlns.com/foaf/0.1/> .
     @prefix v: <http://www.w3.org/2006/vcard/ns#> .
 
-    <http://$HOST$/$GRAPHSTORE$/person/1> a foaf:Person;
+    []  a foaf:Person;
         foaf:businessCard [
             a v:VCard;
-            v:fn "John Doe"
-        ].
+            v:given-name "Alice"
+        ] .
+    """ .
+
+gsp:head_on_an_existing_graph a mf:GraphStoreProtocolTest;
+    dawg:approval dawg:Approved;
+    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
+    mf:name "HEAD on an existing graph" ;
+    rdfs:comment """
+#### Request
+
+    HEAD $GRAPHSTORE$/person/1.ttl HTTP/1.1
+    Host: $HOST$
 
 #### Response
 
-    201 Created
+    200 OK
+    Content-Type: text/turtle; charset=utf-8
+    Content-Length: ...
+    """ .
+
+gsp:head_on_a_nonexisting_graph a mf:GraphStoreProtocolTest;
+    dawg:approval dawg:Approved;
+    dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
+    mf:name "HEAD on a non-existing graph" ;
+    rdfs:comment """
+#### Request
+
+    HEAD $GRAPHSTORE$/person/4.ttl HTTP/1.1
+    Host: $HOST$
+
+#### Response
+
+    404 Not Found
     """ .
 


### PR DESCRIPTION
The expected order or execution of these tests is defined by the mf:entries List. This commit re-orders the definitions of each test in the manifest to match the order in that entries list. No semantic changes are made.