### PR TITLE
Bad syntax - surrogates via numeric escape sequences (Turtle)

### DIFF
--- a/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
@@ -113,6 +113,15 @@ trs:manifest  rdf:type mf:Manifest ;
         trs:turtle12-version-bad-04
         trs:turtle12-version-bad-05
         trs:turtle12-version-bad-06
+
+## Surrogate handling
+        trs:turtle12-surrogate-pair-bad-01
+        trs:turtle12-surrogate-pair-bad-02
+        trs:turtle12-surrogates-bad-01
+        trs:turtle12-surrogates-bad-02
+        trs:turtle12-surrogates-bad-03
+        trs:turtle12-surrogates-bad-04
+        trs:turtle12-surrogates-bad-05
     ) .
 
 ## Good Syntax
@@ -411,7 +420,7 @@ trs:turtle12-version-02 rdf:type rdft:TestTurtlePositiveSyntax ;
    .
 
 trs:turtle12-version-03 rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name      "Turtle 1.2 - VERSION in data " ;
+   mf:name      "Turtle 1.2 - VERSION in data" ;
    mf:action    <turtle12-version-03.ttl> ;
    .
 
@@ -470,3 +479,40 @@ trs:turtle12-version-bad-06 rdf:type rdft:TestTurtleNegativeSyntax ;
    mf:action    <turtle12-version-bad-06.ttl> ;
    .
 
+## Surrogates
+
+
+trs:turtle12-surrogate-pair-bad-01 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad - Surrogate pair numeric escape sequence" ;
+   mf:action    <turtle12-surrogates-pair-bad-01.ttl>
+   .
+   
+trs:turtle12-surrogate-pair-bad-02 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad - Surrogate pair via numeric escape sequence" ;
+   mf:action    <turtle12-surrogates-pair-bad-02.ttl>
+   .
+
+trs:turtle12-surrogates-bad-01 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad - Surrogates - wrong order" ;
+   mf:action    <turtle12-surrogates-bad-01.ttl>;
+   .
+
+trs:turtle12-surrogates-bad-02 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad - Surrogates - high-high" ;
+   mf:action    <turtle12-surrogates-bad-02.ttl>;
+   .
+
+trs:turtle12-surrogates-bad-03 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad - Surrogates - low-low" ;
+   mf:action    <turtle12-surrogates-bad-03.ttl>;
+   .
+
+trs:turtle12-surrogates-bad-04 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad - Surrogates - lone high surrogate" ;
+   mf:action    <turtle12-surrogates-bad-04.ttl>;
+   .
+
+trs:turtle12-surrogates-bad-05 rdf:type rdft:TestTurtleNegativeSyntax ;
+   mf:name      "Turtle 1.2 - Bad - Surrogates - lone low surrogate" ;
+   mf:action    <turtle12-surrogates-bad-05.ttl>;
+   .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogate-pair-bad-01.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogate-pair-bad-01.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p "\uD83C\uDCA1" .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogate-pair-bad-02.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogate-pair-bad-02.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p 'Ace of spades : \uD83C\uDCA1' .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-01.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-01.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+# Bad low-high, not high-low
+:s :p "\uDCA1\uD83C" .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-02.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-02.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+## Surrogates : high-high
+:s :p "\uD83C\uD83D" .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-03.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-03.ttl
@@ -1,0 +1,3 @@
+PREFIX : <http://example/>
+## Surrogates : low-low
+:s :p "\uDCA1\uDCA2" .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-04.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-04.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p "Single high surrogate (\uD83C)" .

--- a/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-05.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/turtle12-surrogates-bad-05.ttl
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+:s :p "Single low surrogate (\uDCA1)" .


### PR DESCRIPTION
The WG resolved to not make changes for surrogate pairs via numeric escape sequences.
Numeric escape sequences for surrogates codepoints are illegal syntax.

https://github.com/w3c/rdf-turtle/issues/131#issuecomment-4363769115

This PR replaces #323.
