### PR TITLE
new test checking boolean keywords with unusual case

### DIFF
--- a/sparql/sparql12/expression/case-insensitive-booleans.rq
+++ b/sparql/sparql12/expression/case-insensitive-booleans.rq
@@ -1,0 +1,1 @@
+SELECT (TRUE as ?t) (False as ?f) {}

--- a/sparql/sparql12/expression/case-insensitive-booleans.srj
+++ b/sparql/sparql12/expression/case-insensitive-booleans.srj
@@ -2,7 +2,7 @@
     "head": {
         "vars": [
             "t",
-            "f",
+            "f"
         ]
     },
     "results": {

--- a/sparql/sparql12/expression/case-insensitive-booleans.srj
+++ b/sparql/sparql12/expression/case-insensitive-booleans.srj
@@ -1,0 +1,24 @@
+{
+    "head": {
+        "vars": [
+            "t",
+            "f",
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "t": {
+                    "value": "true",
+                    "type": "literal",
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean"
+                },
+                "f": {
+                    "value": "false",
+                    "type": "literal",
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean"
+                }
+            }
+        ]
+    }
+}

--- a/sparql/sparql12/expression/manifest.ttl
+++ b/sparql/sparql12/expression/manifest.ttl
@@ -14,6 +14,7 @@
     :triple-on-str-literals
     :triple-on-triple-terms
     :triple-on-undefs
+    :case-insensitive-booleans
     ) .
 
 
@@ -60,4 +61,13 @@
     mf:action
          [ qt:query  <triple-on-undefs.rq> ] ;
     mf:result  <triple-on-undefs.srj>
+    .
+
+:case-insensitive-booleans rdf:type mf:QueryEvaluationTest ;
+    mf:name "case-insensitive booleans";
+    rdfs:comment    "Boolean keywords are case insensitive, and produce valid boolean literals" ;
+    dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <case-insensitive-booleans.rq> ] ;
+    mf:result  <case-insensitive-booleans.srj>
     .


### PR DESCRIPTION
it is not just a syntax test, because we must also make sure that they are not returned as ill-typed literal (e.g. "TRUE"^^xsd:boolean)