### PR TITLE
Update GSP tests to improve modeling and fix existing bugs.

### DIFF
--- a/sparql/sparql11/graph-store-protocol/manifest.ttl
+++ b/sparql/sparql11/graph-store-protocol/manifest.ttl
@@ -220,7 +220,7 @@ gsp:put_get_default rdf:type mf:GraphStoreProtocolTest ;
                 ) ;
                 ht:resp [
                     a ht:Response ;
-                    mf:expectedStatus hts:Created, hts:NoContent
+                    mf:expectedStatus hts:NoContent
                 ]
             ]
             [

--- a/sparql/sparql11/graph-store-protocol/manifest.ttl
+++ b/sparql/sparql11/graph-store-protocol/manifest.ttl
@@ -1,0 +1,646 @@
+@prefix : <http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#> .
+@prefix dawg: <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
+@prefix gsp: <http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#> .
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix cnt:    <http://www.w3.org/2011/content#> .
+@prefix ht:     <http://www.w3.org/2011/http#> .
+@prefix hts:    <http://www.w3.org/2011/http-statusCodes#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<> a mf:Manifest;
+    rdfs:label "SPARQL Graph Store Protocol";
+    rdfs:comment """
+        This manifest encodes tests for the SPARQL Graph Store Protocol.
+        Each test record has one or more ht:Requests that must be run in order
+        to produce the expected results.
+        
+        Expected results are encoded in the ht:Response. The ht:Response may
+        have a `mf:expectedStatus` property, describing the expected HTTP
+        status code or class of status code (pointing to values
+        like `hts:Created` or `hts:StatusCode2xx`);
+        
+        The ht:Response may have a `mf:expectedLocation` property whose value
+        is a literal. In the presence of this property, the current response
+        must have a `Location` header field value. Futher, the literal value
+        must be used as a template variable and replaced in subsequent requests
+        with the header field value (replacement occurring in the request URI
+        as well as the request bodies).
+        
+        The ht:Response may include expected RDF response content, described
+        by `ht:headers` and `ht:body`. When present, the graph resulting from
+        parsing the ht:body content appropriately for the RDF format described
+        by the Content-Type header must be graph isomorphic to the one in the
+        response to the Graph Store Protocol request.
+
+        Each request has a ht:absolutePath value that starts with `/gsp`.
+        A program using this manifest data to run the tests must replace this
+        value with whatever path prefix is appropriate for the Graph Store
+        Protocol endpoint being tested.
+    """ ;
+    mf:entries ( gsp:put_get_repeat
+                 gsp:put_get_default
+                 gsp:put_delete_get_delete
+                 gsp:post_get_post_get
+                 gsp:post_get_new_graph
+                 gsp:head_existing
+                 gsp:head_non_existing
+               ) .
+
+gsp:put_get_repeat rdf:type mf:GraphStoreProtocolTest ;
+    mf:name    "PUT/GET repetition on same graph using varying graph identification" ;
+    mf:action [
+        a ht:Connection ;
+        ht:connectionAuthority "www.example" ;
+        ht:requests ([
+                a ht:Request ;
+                ht:absolutePath "/gsp/person/1.ttl" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "content-type" ;
+                        ht:fieldValue "text/turtle; charset=utf-8"
+                    ]
+                ) ;
+                ht:body [
+                    a cnt:ContentAsText ;
+                    cnt:characterEncoding "UTF-8" ;
+                    cnt:chars """
+                        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                        @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                        
+                        <http://www.example/gsp/person/1> a foaf:Person;
+                            foaf:businessCard [
+                                a v:VCard;
+                                v:fn "John Doe"
+                            ].
+                    """
+                ] ;
+                ht:httpVersion "1.1" ;
+                ht:methodName "PUT" ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:Created
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "GET" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp?graph=http://www.example/gsp/person/1.ttl" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "accept" ;
+                        ht:fieldValue "text/turtle"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:OK ;
+                    ht:headers ([
+                            a ht:ResponseHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "text/turtle; charset=utf-8"
+                        ]
+                    ) ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """
+                            @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                            @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                        
+                            <http://www.example/gsp/person/1> a foaf:Person;
+                               foaf:businessCard [
+                                    a v:VCard;
+                                    v:fn "John Doe"
+                               ].
+                        """
+                    ] ;
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "PUT" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp?graph=http://www.example/gsp/person/1.ttl" ;
+                ht:body [
+                    a cnt:ContentAsText ;
+                    cnt:characterEncoding "UTF-8" ;
+                    cnt:chars """
+                        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                        @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                    
+                        <http://www.example/gsp/person/1> a foaf:Person;
+                            foaf:businessCard [
+                                a v:VCard;
+                                v:fn "Jane Doe"
+                            ].
+                    """
+                ] ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "content-type" ;
+                        ht:fieldValue "text/turtle; charset=utf-8"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:NoContent ;
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "GET" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/1.ttl" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "accept" ;
+                        ht:fieldValue "text/turtle"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:OK ;
+                    ht:headers ([
+                            a ht:ResponseHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "text/turtle; charset=utf-8"
+                        ]
+                    ) ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """
+                            @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                            @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                        
+                            <http://www.example/gsp/person/1> a foaf:Person;
+                               foaf:businessCard [
+                                    a v:VCard;
+                                    v:fn "Jane Doe"
+                               ] .
+                        """
+                    ] ;
+                ]
+            ]
+        )
+    ] ;
+    .
+
+gsp:put_get_default rdf:type mf:GraphStoreProtocolTest ;
+    mf:name    "PUT/GET on the default graph" ;
+    mf:action [
+        a ht:Connection ;
+        ht:connectionAuthority "www.example" ;
+        ht:requests ([
+                a ht:Request ;
+                ht:methodName "PUT" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp?default" ;
+                ht:body [
+                    a cnt:ContentAsText ;
+                    cnt:characterEncoding "UTF-8" ;
+                    cnt:chars """
+                        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                        @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                    
+                        []  a foaf:Person;
+                            foaf:businessCard [
+                                a v:VCard;
+                                v:given-name "Alice"
+                            ] .
+                    """
+                ] ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "content-type" ;
+                        ht:fieldValue "text/turtle; charset=utf-8"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:Created
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "GET" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp?default" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "accept" ;
+                        ht:fieldValue "text/turtle"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:OK ;
+                    ht:headers ([
+                            a ht:ResponseHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "text/turtle; charset=utf-8"
+                        ]
+                    ) ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """
+                            @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                            @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                        
+                            []  a foaf:Person;
+                                foaf:businessCard [
+                                    a v:VCard;
+                                    v:given-name "Alice"
+                                ] .
+                        """
+                    ] ;
+                ]
+            ]
+        )
+    ] ;
+
+    .
+gsp:put_delete_get_delete rdf:type mf:GraphStoreProtocolTest ;
+    mf:name    "PUT initialization, then DELETE/GET/DELETE on a direct-identified graph" ;
+    mf:action [
+        a ht:Connection ;
+        ht:connectionAuthority "www.example" ;
+        ht:requests ([
+                a ht:Request ;
+                ht:methodName "PUT" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/2.ttl" ;
+                ht:body [
+                    a cnt:ContentAsText ;
+                    cnt:characterEncoding "UTF-8" ;
+                    cnt:chars """
+                        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                        @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                    
+                        []  a foaf:Person;
+                            foaf:businessCard [
+                                a v:VCard;
+                                v:given-name "Alice"
+                            ] .
+                    """
+                ] ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "content-type" ;
+                        ht:fieldValue "text/turtle; charset=utf-8"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:Created
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "DELETE" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/2.ttl" ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:OK, hts:NoContent ;
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "GET" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/2.ttl" ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:NotFound ;
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "DELETE" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/2.ttl" ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:NotFound, hts:OK, hts:NoContent ;
+                ]
+            ]
+        )
+    ] ;
+    .
+
+gsp:post_get_post_get rdf:type mf:GraphStoreProtocolTest ;
+    mf:name    "Two iterations os POST/GET, with the second using multipart/form-data" ;
+    mf:action [
+        a ht:Connection ;
+        ht:connectionAuthority "www.example" ;
+        ht:requests (
+            [
+                a ht:Request ;
+                ht:methodName "POST" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/1.ttl" ;
+                ht:body [
+                    a cnt:ContentAsText ;
+                    cnt:characterEncoding "UTF-8" ;
+                    cnt:chars """
+                            @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                            @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                        
+                            <http://www.example/gsp/person/1> a foaf:Person;
+                               foaf:businessCard [
+                                    a v:VCard;
+                                    v:fn "Jane Doe"
+                               ] .
+                    """
+                ] ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "content-type" ;
+                        ht:fieldValue "text/turtle; charset=utf-8"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:NoContent, hts:OK
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "GET" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/1.ttl" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "accept" ;
+                        ht:fieldValue "text/turtle"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:OK ;
+                    ht:headers ([
+                            a ht:ResponseHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "text/turtle; charset=utf-8"
+                        ]
+                    ) ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """
+                            @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                            @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                        
+                            <http://www.example/gsp/person/1> a foaf:Person;
+                               foaf:businessCard [
+                                    a v:VCard;
+                                    v:fn "Jane Doe"
+                               ] .
+                        """
+                    ] ;
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "POST" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/1.ttl" ;
+                ht:body [
+                    a cnt:ContentAsText ;
+                    cnt:characterEncoding "UTF-8" ;
+                    cnt:chars """--a6fe4cd636164618814be9f8d3d1a0de\r
+Content-Disposition: form-data; name="lastName.ttl"; filename="lastName.ttl"\r
+Content-Type: text/turtle; charset=utf-8\r
+\r
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .\r
+<http://www.example/gsp/person/1> foaf:familyName "Doe" .\r
+\r
+--a6fe4cd636164618814be9f8d3d1a0de\r
+Content-Disposition: form-data; name="firstName.ttl"; filename="firstName.ttl"\r
+Content-Type: text/turtle; charset=utf-8\r
+\r
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .\r
+<http://www.example/gsp/person/1> foaf:givenName "Jane" .\r
+\r
+--a6fe4cd636164618814be9f8d3d1a0de--\r
+"""
+                ] ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "content-type" ;
+                        ht:fieldValue "multipart/form-data; boundary=a6fe4cd636164618814be9f8d3d1a0de"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:NoContent, hts:OK
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "GET" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/1.ttl" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "accept" ;
+                        ht:fieldValue "text/turtle"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:OK ;
+                    ht:headers ([
+                            a ht:ResponseHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "text/turtle; charset=utf-8"
+                        ]
+                    ) ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """
+                            @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                            @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                        
+                            <http://www.example/gsp/person/1> a foaf:Person;
+                                foaf:givenName      "Jane";
+                                foaf:familyName     "Doe";
+                                foaf:businessCard [
+                                    a               v:VCard;
+                                    v:fn            "Jane Doe"
+                                ] .
+                        """
+                    ] ;
+                ]
+            ]
+        )
+    ] ;
+    .
+
+gsp:post_get_new_graph rdf:type mf:GraphStoreProtocolTest ;
+    mf:name    "PUT initialization, then DELETE/GET/DELETE on a direct-identified graph" ;
+    mf:action [
+        a ht:Connection ;
+        ht:connectionAuthority "www.example" ;
+        ht:requests ([
+                a ht:Request ;
+                ht:methodName "POST" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "content-type" ;
+                        ht:fieldValue "text/turtle; charset=utf-8"
+                    ]
+                ) ;
+                ht:body [
+                    a cnt:ContentAsText ;
+                    cnt:characterEncoding "UTF-8" ;
+                    cnt:chars """
+                        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                        @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                    
+                        []  a foaf:Person;
+                            foaf:businessCard [
+                                a v:VCard;
+                                v:given-name "Alice"
+                            ] .
+                    """
+                ] ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:Created ;
+                    mf:expectedLocation "$LOCATION$" # Make the value of the Location header available as a template variable $LOCATION$ in subsequent Requests within this Connection
+                ]
+            ]            
+            [
+                a ht:Request ;
+                ht:methodName "GET" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp?graph=$LOCATION$" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "accept" ;
+                        ht:fieldValue "text/turtle"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:OK ;
+                    ht:headers ([
+                            a ht:ResponseHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "text/turtle; charset=utf-8"
+                        ]
+                    ) ;
+                    ht:body [
+                        a cnt:ContentAsText ;
+                        cnt:characterEncoding "UTF-8" ;
+                        cnt:chars """
+                            @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                            @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                        
+                            []  a foaf:Person;
+                                foaf:businessCard [
+                                    a v:VCard;
+                                    v:given-name "Alice"
+                                ] .
+                        """
+                    ] ;
+                ]
+            ]
+        )
+    ] ;
+    .
+
+gsp:head_existing rdf:type mf:GraphStoreProtocolTest ;
+    mf:name    "PUT initialization, then HEAD on existing graph" ;
+    mf:action [
+        a ht:Connection ;
+        ht:connectionAuthority "www.example" ;
+        ht:requests ([
+                a ht:Request ;
+                ht:absolutePath "/gsp/person/1.ttl" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "content-type" ;
+                        ht:fieldValue "text/turtle; charset=utf-8"
+                    ]
+                ) ;
+                ht:body [
+                    a cnt:ContentAsText ;
+                    cnt:characterEncoding "UTF-8" ;
+                    cnt:chars """
+                        @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+                        @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+                        
+                        <http://www.example/gsp/person/1> a foaf:Person;
+                            foaf:businessCard [
+                                a v:VCard;
+                                v:fn "John Doe"
+                            ].
+                    """
+                ] ;
+                ht:httpVersion "1.1" ;
+                ht:methodName "PUT" ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:Created
+                ]
+            ]
+            [
+                a ht:Request ;
+                ht:methodName "HEAD" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/1.ttl" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "accept" ;
+                        ht:fieldValue "text/turtle; charset=utf-8"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:OK ;
+                    ht:headers ([
+                            a ht:ResponseHeader ;
+                            ht:fieldName "content-type" ;
+                            ht:fieldValue "text/turtle; charset=utf-8"
+                        ]
+                    ) ;
+                ]
+            ]
+        )
+    ] ;
+    .
+
+gsp:head_non_existing rdf:type mf:GraphStoreProtocolTest ;
+    mf:name    "HEAD on non-existing graph" ;
+    mf:action [
+        a ht:Connection ;
+        ht:connectionAuthority "www.example" ;
+        ht:requests ([
+                a ht:Request ;
+                ht:methodName "HEAD" ;
+                ht:httpVersion "1.1" ;
+                ht:absolutePath "/gsp/person/4.ttl" ;
+                ht:headers ([
+                        a ht:RequestHeader ;
+                        ht:fieldName "accept" ;
+                        ht:fieldValue "text/turtle; charset=utf-8"
+                    ]
+                ) ;
+                ht:resp [
+                    a ht:Response ;
+                    mf:expectedStatus hts:NotFound ;
+                ]
+            ]
+        )
+    ] ;
+    .
+

--- a/sparql/sparql11/graph-store-protocol/manifest.ttl
+++ b/sparql/sparql11/graph-store-protocol/manifest.ttl
@@ -145,7 +145,7 @@ gsp:put_get_repeat rdf:type mf:GraphStoreProtocolTest ;
                 ) ;
                 ht:resp [
                     a ht:Response ;
-                    mf:expectedStatus hts:NoContent ;
+                    mf:expectedStatus hts:OK, hts:NoContent ;
                 ]
             ]
             [
@@ -220,7 +220,7 @@ gsp:put_get_default rdf:type mf:GraphStoreProtocolTest ;
                 ) ;
                 ht:resp [
                     a ht:Response ;
-                    mf:expectedStatus hts:NoContent
+                    mf:expectedStatus hts:OK, hts:NoContent
                 ]
             ]
             [
@@ -295,7 +295,7 @@ gsp:put_delete_get_delete rdf:type mf:GraphStoreProtocolTest ;
                 ) ;
                 ht:resp [
                     a ht:Response ;
-                    mf:expectedStatus hts:Created, hts:NoContent
+                    mf:expectedStatus hts:Created, hts:OK, hts:NoContent
                 ]
             ]
             [
@@ -365,7 +365,7 @@ gsp:post_get_post_get rdf:type mf:GraphStoreProtocolTest ;
                 ) ;
                 ht:resp [
                     a ht:Response ;
-                    mf:expectedStatus hts:NoContent, hts:OK
+                    mf:expectedStatus hts:OK, hts:NoContent
                 ]
             ]
             [
@@ -437,7 +437,7 @@ Content-Type: text/turtle; charset=utf-8\r
                 ) ;
                 ht:resp [
                     a ht:Response ;
-                    mf:expectedStatus hts:NoContent, hts:OK
+                    mf:expectedStatus hts:OK, hts:NoContent
                 ]
             ]
             [
@@ -590,7 +590,7 @@ gsp:head_existing rdf:type mf:GraphStoreProtocolTest ;
                 ] ;
                 ht:resp [
                     a ht:Response ;
-                    mf:expectedStatus hts:Created, hts:NoContent
+                    mf:expectedStatus hts:OK, hts:Created, hts:NoContent
                 ]
             ]
             [

--- a/sparql/sparql11/graph-store-protocol/manifest.ttl
+++ b/sparql/sparql11/graph-store-protocol/manifest.ttl
@@ -220,7 +220,7 @@ gsp:put_get_default rdf:type mf:GraphStoreProtocolTest ;
                 ) ;
                 ht:resp [
                     a ht:Response ;
-                    mf:expectedStatus hts:Created
+                    mf:expectedStatus hts:Created, hts:NoContent
                 ]
             ]
             [
@@ -295,7 +295,7 @@ gsp:put_delete_get_delete rdf:type mf:GraphStoreProtocolTest ;
                 ) ;
                 ht:resp [
                     a ht:Response ;
-                    mf:expectedStatus hts:Created
+                    mf:expectedStatus hts:Created, hts:NoContent
                 ]
             ]
             [
@@ -565,6 +565,8 @@ gsp:head_existing rdf:type mf:GraphStoreProtocolTest ;
         ht:connectionAuthority "www.example" ;
         ht:requests ([
                 a ht:Request ;
+                ht:methodName "PUT" ;
+                ht:httpVersion "1.1" ;
                 ht:absolutePath "/gsp/person/1.ttl" ;
                 ht:headers ([
                         a ht:RequestHeader ;
@@ -586,11 +588,9 @@ gsp:head_existing rdf:type mf:GraphStoreProtocolTest ;
                             ].
                     """
                 ] ;
-                ht:httpVersion "1.1" ;
-                ht:methodName "PUT" ;
                 ht:resp [
                     a ht:Response ;
-                    mf:expectedStatus hts:Created
+                    mf:expectedStatus hts:Created, hts:NoContent
                 ]
             ]
             [

--- a/sparql/sparql11/http-rdf-update/manifest.ttl
+++ b/sparql/sparql11/http-rdf-update/manifest.ttl
@@ -2,6 +2,9 @@
 @prefix dawg: <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
 @prefix gsp: <http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix cnt:    <http://www.w3.org/2011/content#> .
+@prefix ht:     <http://www.w3.org/2011/http#> .
+@prefix hts:    <http://www.w3.org/2011/http-statusCodes#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
@@ -29,7 +32,8 @@
                  gsp:head_on_a_nonexisting_graph ) .
 
 gsp:put__initial_state a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "PUT - Initial state" ;
     rdfs:comment """
@@ -55,7 +59,8 @@ gsp:put__initial_state a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:get_of_put__initial_state a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "GET of PUT - Initial state" ;
     rdfs:comment """
@@ -82,7 +87,8 @@ gsp:get_of_put__initial_state a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:put__graph_already_in_store a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "PUT - graph already in store" ;
     rdfs:comment """
@@ -107,7 +113,8 @@ gsp:put__graph_already_in_store a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:get_of_put__graph_already_in_store a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "GET of PUT - graph already in store" ;
     rdfs:comment """
@@ -134,7 +141,8 @@ gsp:get_of_put__graph_already_in_store a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:put__default_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "PUT - default graph" ;
     rdfs:comment """
@@ -159,7 +167,8 @@ gsp:put__default_graph a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:get_of_put__default_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "GET of PUT - default graph" ;
     rdfs:comment """
@@ -186,7 +195,8 @@ gsp:get_of_put__default_graph a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:delete__existing_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "DELETE - existing graph" ;
     rdfs:comment """
@@ -201,7 +211,8 @@ gsp:delete__existing_graph a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:get_of_delete__existing_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "GET of DELETE - existing graph" ;
     rdfs:comment """
@@ -216,7 +227,8 @@ gsp:get_of_delete__existing_graph a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:delete__nonexistent_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "DELETE - non-existent graph" ;
     rdfs:comment """
@@ -231,7 +243,8 @@ gsp:delete__nonexistent_graph a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:post__existing_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "POST - existing graph" ;
     rdfs:comment """
@@ -251,7 +264,8 @@ gsp:post__existing_graph a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:get_of_post__existing_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "GET of POST - existing graph" ;
     rdfs:comment """
@@ -278,7 +292,8 @@ gsp:get_of_post__existing_graph a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:post__multipart_formdata a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "POST - multipart/form-data" ;
     rdfs:comment """
@@ -310,7 +325,8 @@ gsp:post__multipart_formdata a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:get_of_post__multipart_formdata a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "GET of POST - multipart/form-data" ;
     rdfs:comment """
@@ -339,7 +355,8 @@ gsp:get_of_post__multipart_formdata a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:post__create__new_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "POST - create new graph" ;
     rdfs:comment """
@@ -365,7 +382,8 @@ gsp:post__create__new_graph a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:get_of_post__create__new_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "GET of POST - create new graph" ;
     rdfs:comment """
@@ -392,7 +410,8 @@ gsp:get_of_post__create__new_graph a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:get_of_post__after_noop a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "GET of POST - after noop" ;
     rdfs:comment """
@@ -419,7 +438,8 @@ gsp:get_of_post__after_noop a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:head_on_an_existing_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "HEAD on an existing graph" ;
     rdfs:comment """
@@ -436,7 +456,8 @@ gsp:head_on_an_existing_graph a mf:GraphStoreProtocolTest;
     """ .
 
 gsp:head_on_a_nonexisting_graph a mf:GraphStoreProtocolTest;
-    dawg:approval dawg:Approved;
+    dawg:approval dawg:Deprecated;
+    rdfs:comment "This test is deprecated in favor of the tests in ../graph-store-protocol/manifest.ttl" ;
     dawg:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-11-27#resolution_3>;
     mf:name "HEAD on a non-existing graph" ;
     rdfs:comment """

--- a/sparql/sparql11/http-rdf-update/manifest.ttl
+++ b/sparql/sparql11/http-rdf-update/manifest.ttl
@@ -2,9 +2,6 @@
 @prefix dawg: <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
 @prefix gsp: <http://www.w3.org/2009/sparql/docs/tests/data-sparql11/http-rdf-update/manifest#> .
 @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
-@prefix cnt:    <http://www.w3.org/2011/content#> .
-@prefix ht:     <http://www.w3.org/2011/http#> .
-@prefix hts:    <http://www.w3.org/2011/http-statusCodes#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 

--- a/sparql/sparql11/manifest-all.ttl
+++ b/sparql/sparql11/manifest-all.ttl
@@ -39,7 +39,7 @@
 		<syntax-fed/manifest.ttl>
 		<service-description/manifest.ttl>
 		<protocol/manifest.ttl>
-		<http-rdf-update/manifest.ttl>
+		<graph-store-protocol/manifest.ttl>
 	) ;
 	mf:includedSpecifications (
 		<http://www.w3.org/TR/sparql11-query/>
@@ -120,5 +120,5 @@
 
 <http://www.w3.org/TR/sparql11-http-rdf-update/> rdfs:label "SPARQL 1.1 Graph Store HTTP Protocol" ;
 	mf:conformanceRequirement (
-		<http-rdf-update/manifest.ttl>
+		<graph-store-protocol/manifest.ttl>
 	).


### PR DESCRIPTION
The previous text-based modeling included many bugs and was essentially impossible to use as the source of truth for automated testing. This change uses the modeling introduced in #312 and attempts to preserve the intent of the existing tests, with several differences:

1. Each test assumes an empty initial dataset.
2. Many tests define a sequence of several request-response pairs that depend on the state changes of previous requests in the same test.
3. There is a new mf:expectedLocation property used to make the Location response header value returned after the creation of a new graph to be made available as a template variable in subsequent requests within the same test.

With this new modeling, the tests in http-rdf-update/ are marked as deprecated and removed from manifest-all.ttl, with the new tests being added to that manifest and existing in the new graph-store-protocol/ directory.

Closes #252