### PR TITLE
Codepoint escapes updates

### DIFF
--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-01-bad.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-01-bad.rq
@@ -1,3 +1,2 @@
-\u0041\u0053\u004B\u0020\u007B\u007D
-
 # The query `ASK {}` entirely encoded using codepoint escapes.
+\u0041\u0053\u004B\u0020\u007B\u007D

--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-02-bad.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-02-bad.rq
@@ -1,0 +1,5 @@
+# Codepoint escape in prefixed name : PNAME_NS
+
+SELECT * {
+    ?x n\0073:abc ?o
+}

--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-02.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-02.rq
@@ -1,8 +1,0 @@
-PREFIX ns: <http://example.org/>
-SELECT * WHERE {
-	?s ?p ns:id\u005c=123
-}
-
-# the escape here produces '\' REVERSE SOLIDUS (U+5C)
-# its unescaping must lead to a Prefixed Name ns:id\=123 using an escaped
-# equals sign (U+3D), representing the IRI <http://example.org/id=123>.

--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-03-bad.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-03-bad.rq
@@ -1,0 +1,6 @@
+# Codepoint escape in prefixed name : PN_LOCAL
+PREFIX ns: <http://example/ns#>
+
+SELECT * {
+    ?x ns:a\u0062c ?o
+}

--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-04-bad.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-04-bad.rq
@@ -1,0 +1,7 @@
+# Codepoint escape in variable
+
+PREIFX ns: <http://example/ns#>
+
+SELECT * {
+    ?a\u0062c ns:abc ?o
+}

--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-04.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-04.rq
@@ -1,5 +1,0 @@
-SELECT * WHERE {
-	?s ?p "\\u0074"
-}
-# Legal codepoint escape of LATIN SMALL LETTER T (U+74), resulting in a
-# valid backslash escape \t for CHARACTER TABULATION (U+9).

--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-05.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-05.rq
@@ -1,5 +1,6 @@
-SELECT * WHERE {
-	?s ?p "\u005C\u005Cn"
+# Codepoint escape in an IRI
+
+SELECT * {
+  ## /abc
+  <http://example/\u0061\U00000062\u0063> ?p ?o .
 }
-# Two legal codepoint escapes of REVERSE SOLIDUS (U+5C), resulting in a
-# valid backslash escape \\ for REVERSE SOLIDUS (U+5C) followed by 'n'.

--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-06.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-06.rq
@@ -1,8 +1,6 @@
-PREFIX og: <http://ogp.me/ns#>
-SELECT * WHERE {
-	?page og:audio\u00253Atitle ?title
-}
+# Codepoint escape in a string
 
-# the escape here produces '%' PERCENT SIGN (U+25)
-# its unescaping must lead to a Prefixed Name og:audio%3Atitle which includes
-# the percent-encoding %3A (COLON).
+SELECT * {
+  ## "abc"
+  <http://example/abc> ?p "\U00000061\u0062\U00000063" .
+}

--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-07.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-07.rq
@@ -1,7 +1,6 @@
-SELECT\u0020*\U00000009WHERE {
-	?s ?p "value"
-}
+# Codepoint escape in a string
 
-# the escapes here produce whitespace -- SPACESPACE (U+20) and
-# CHARACTER TABULATION (U+9) -- surrounding the `*` token in the
-# SELECT projection.
+SELECT * {
+  ## 'abc'
+  <http://example/abc> ?p '\U00000061\u0062\U00000063' .
+}

--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-08.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-08.rq
@@ -1,6 +1,0 @@
-SELECT * WHERE {
-	?s ?p \u0022value"
-}
-
-# the escape here produces QUOTATION MARK (U+22)
-# its unescaping must lead to the literal 'value'.

--- a/sparql/sparql12/codepoint-escapes/codepoint-esc-bad-03.rq
+++ b/sparql/sparql12/codepoint-escapes/codepoint-esc-bad-03.rq
@@ -1,5 +1,0 @@
-SELECT * WHERE {
-	?s ?p "\\u0041"
-}
-# Legal codepoint escape of LATIN CAPITAL LETTER A (U+41), resulting in an
-# invalid backslash escape \A.

--- a/sparql/sparql12/codepoint-escapes/manifest.ttl
+++ b/sparql/sparql12/codepoint-escapes/manifest.ttl
@@ -16,6 +16,12 @@
         :codepoint-esc-05
         :codepoint-esc-06
         :codepoint-esc-07
+
+        :surrogate-esc-01-bad
+        :surrogate-esc-02-bad
+        :surrogate-esc-03-bad
+        :surrogate-esc-04-bad
+        :surrogate-esc-05-bad
     ) .
 
 
@@ -58,5 +64,37 @@
 :codepoint-esc-07 rdf:type   mf:PositiveSyntaxTest ;
    dawgt:approval dawgt:Proposed ;
    mf:name        "codepoint-esc-07.rq" ;
-   rdfs:comment   "Codepoint escape in string - singe quoted string" ;
+   rdfs:comment   "Codepoint escape in string - single quoted string" ;
    mf:action      <codepoint-esc-07.rq> .
+
+
+:surrogate-esc-01-bad rdf:type   mf:NegativeSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "surrogate-esc-01-bad.rq" ;
+   rdfs:comment   "Surrogate pair - not accepted" ;
+   mf:action      <surrogate-esc-01-bad.rq> .
+
+:surrogate-esc-02-bad rdf:type   mf:NegativeSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "surrogate-esc-02-bad.rq" ;
+   rdfs:comment   "Surrogate - low-high - not accepted" ;
+   mf:action      <surrogate-esc-02-bad.rq> .
+
+
+:surrogate-esc-03-bad rdf:type   mf:NegativeSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "surrogate-esc-03-bad.rq" ;
+   rdfs:comment   "Surrogate - lone high escape sequence" ;
+   mf:action      <surrogate-esc-03-bad.rq> .
+   
+:surrogate-esc-04-bad rdf:type   mf:NegativeSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "surrogate-esc-04-bad.rq" ;
+   rdfs:comment   "Surrogate - lone low escape sequence" ;
+   mf:action      <surrogate-esc-04-bad.rq> .
+
+:surrogate-esc-05-bad rdf:type   mf:NegativeSyntaxTest ;
+   dawgt:approval dawgt:Proposed ;
+   mf:name        "surrogate-esc-05-bad.rq" ;
+   rdfs:comment   "Surrogate pair - IRI" ;
+   mf:action      <surrogate-esc-05-bad.rq> .

--- a/sparql/sparql12/codepoint-escapes/manifest.ttl
+++ b/sparql/sparql12/codepoint-escapes/manifest.ttl
@@ -8,61 +8,55 @@
 <>  rdf:type mf:Manifest ;
     rdfs:label "SPARQL Codepoint-Escaping Tests" ;
     mf:entries
-    ( 
-    :codepoint-esc-01
-    :codepoint-esc-02
-    :codepoint-esc-bad-03
-    :codepoint-esc-04
-    :codepoint-esc-05
-    :codepoint-esc-06
-    :codepoint-esc-07
-    :codepoint-esc-08
+    (
+        :codepoint-esc-01-bad
+        :codepoint-esc-02-bad
+        :codepoint-esc-03-bad
+        :codepoint-esc-04-bad
+        :codepoint-esc-05
+        :codepoint-esc-06
+        :codepoint-esc-07
     ) .
 
 
-:codepoint-esc-01 rdf:type   mf:PositiveSyntaxTest ;
+:codepoint-esc-01-bad rdf:type   mf:NegativeSyntaxTest ;
    dawgt:approval dawgt:Proposed ;
-   mf:name        "codepoint-esc-01.rq" ;
-   mf:action      <codepoint-esc-01.rq> .
+   mf:name        "codepoint-esc-01-bad.rq" ;
+   rdfs:comment   "Whole query in codepoint escapes" ;
+   mf:action      <codepoint-esc-01-bad.rq> .
 
-:codepoint-esc-02 rdf:type   mf:PositiveSyntaxTest ;
+:codepoint-esc-02-bad rdf:type   mf:NegativeSyntaxTest ;
    dawgt:approval dawgt:Proposed ;
-   mf:name        "codepoint-esc-02.rq" ;
-   rdfs:comment   "codepoint escape for the backslash of a PN_LOCAL_ESC in the PN_LOCAL part of a PrefixedName" ;
-   mf:action      <codepoint-esc-02.rq> .
+   mf:name        "codepoint-esc-02-bad.rq" ;
+   rdfs:comment   "Codepoint escape in PNAME_NS of a prefixed name" ;
+   mf:action      <codepoint-esc-02-bad.rq> .
 
-:codepoint-esc-bad-03 rdf:type   mf:NegativeSyntaxTest ;
+:codepoint-esc-03-bad rdf:type   mf:NegativeSyntaxTest ;
    dawgt:approval dawgt:Proposed ;
-   mf:name        "codepoint-esc-bad-03.rq" ;
-   rdfs:comment   "codepoint escape that results in an invalid backslash escape (requires handling codepoint escaping before backslash escaping)" ;
-   mf:action      <codepoint-esc-bad-03.rq> .
+   mf:name        "codepoint-esc-03-bad.rq" ;
+   rdfs:comment   "Codepoint escape in PN_LOCAL of a prefixed name" ;
+   mf:action      <codepoint-esc-03-bad.rq> .
 
-:codepoint-esc-04 rdf:type   mf:PositiveSyntaxTest ;
+:codepoint-esc-04-bad rdf:type   mf:NegativeSyntaxTest ;
    dawgt:approval dawgt:Proposed ;
-   mf:name        "codepoint-esc-04.rq" ;
-   rdfs:comment   "codepoint escape that results in a valid backslash escape" ;
-   mf:action      <codepoint-esc-04.rq> .
+   mf:name        "codepoint-esc-04-bad.rq" ;
+   rdfs:comment   "Codepoint escape in variable" ;
+   mf:action      <codepoint-esc-04-bad.rq> .
 
 :codepoint-esc-05 rdf:type   mf:PositiveSyntaxTest ;
    dawgt:approval dawgt:Proposed ;
    mf:name        "codepoint-esc-05.rq" ;
+   rdfs:comment   "Codepoint escape in IRI" ;
    mf:action      <codepoint-esc-05.rq> .
 
 :codepoint-esc-06 rdf:type   mf:PositiveSyntaxTest ;
    dawgt:approval dawgt:Proposed ;
    mf:name        "codepoint-esc-06.rq" ;
-   rdfs:comment   "codepoint escape for the percent sign in the PL_LOCAL part of a PrefixedName" ;
+   rdfs:comment   "Codepoint escape in string - double quoted string" ;
    mf:action      <codepoint-esc-06.rq> .
 
 :codepoint-esc-07 rdf:type   mf:PositiveSyntaxTest ;
    dawgt:approval dawgt:Proposed ;
    mf:name        "codepoint-esc-07.rq" ;
-   rdfs:comment   "codepoint escape for whitespace separating the projection tokens: SELECT * WHERE" ;
+   rdfs:comment   "Codepoint escape in string - singe quoted string" ;
    mf:action      <codepoint-esc-07.rq> .
-
-:codepoint-esc-08 rdf:type   mf:PositiveSyntaxTest ;
-   dawgt:approval dawgt:Proposed ;
-   mf:name        "codepoint-esc-08.rq" ;
-   rdfs:comment   "codepoint escape for the starting double-quote of a literal" ;
-   mf:action      <codepoint-esc-08.rq> .
-

--- a/sparql/sparql12/codepoint-escapes/surrogate-esc-01-bad.rq
+++ b/sparql/sparql12/codepoint-escapes/surrogate-esc-01-bad.rq
@@ -1,0 +1,5 @@
+## Surrogate pair. Not legal.
+
+SELECT * {
+    ?s ?p "\uD83C\uDCA1" .
+}

--- a/sparql/sparql12/codepoint-escapes/surrogate-esc-02-bad.rq
+++ b/sparql/sparql12/codepoint-escapes/surrogate-esc-02-bad.rq
@@ -1,0 +1,5 @@
+## Surrogates. Low-high (not a pair). Not legal.
+
+SELECT * {
+    ?s ?p "\uDCA1\uD83C" .
+}

--- a/sparql/sparql12/codepoint-escapes/surrogate-esc-03-bad.rq
+++ b/sparql/sparql12/codepoint-escapes/surrogate-esc-03-bad.rq
@@ -1,0 +1,5 @@
+## High surrogate. Not legal.
+
+SELECT * {
+    ?s ?p "Single high surrogate (\uD83C)"
+}

--- a/sparql/sparql12/codepoint-escapes/surrogate-esc-04-bad.rq
+++ b/sparql/sparql12/codepoint-escapes/surrogate-esc-04-bad.rq
@@ -1,0 +1,5 @@
+## Low surrogate. Not legal.
+
+SELECT * {
+    ?s ?p "Single low surrogate (\uDCA1)"
+}

--- a/sparql/sparql12/codepoint-escapes/surrogate-esc-05-bad.rq
+++ b/sparql/sparql12/codepoint-escapes/surrogate-esc-05-bad.rq
@@ -1,0 +1,5 @@
+## Surrogate pair in IRI. Not legal.
+
+SELECT * {
+    ?s ?p <http://example/\uD83C\uDCA1>
+}


### PR DESCRIPTION
Test changes for https://github.com/w3c/sparql-query/issues/382

Bonus: in the same directory, bad syntax tests for the use of surrogates (pairs and broken).
