### PR TITLE
SPARQL: Do not require empty named graph support to pass the query tests

### DIFF
--- a/sparql/sparql11/aggregates/agg-empty-group-count-graph.rq
+++ b/sparql/sparql11/aggregates/agg-empty-group-count-graph.rq
@@ -1,5 +1,5 @@
 PREFIX : <http://example/>
 
 SELECT ?g ?c WHERE {
-   GRAPH ?g {SELECT (count(*) AS ?c) WHERE { ?s :p ?x }}
+   GRAPH ?g {SELECT (count(*) AS ?c) WHERE { ?s :p ?x FILTER(?x != :o) }}
 }

--- a/sparql/sparql11/aggregates/agg-empty-group-count-graph.ttl
+++ b/sparql/sparql11/aggregates/agg-empty-group-count-graph.ttl
@@ -6,17 +6,17 @@
 []    rdf:type      rs:ResultSet ;
       rs:resultVariable  "g" ;
       rs:resultVariable  "c" ;
-      rs:solution   [ rs:binding    [ rs:value      <empty.ttl> ;
-                                      rs:variable   "g"
-                                    ] ;
-                      rs:binding    [ rs:value      "0"^^xsd:integer ;
-                                      rs:variable   "c"
-                                    ]
-                    ] ;
       rs:solution   [ rs:binding    [ rs:value      <singleton.ttl> ;
                                       rs:variable   "g"
                                     ] ;
                       rs:binding    [ rs:value      "1"^^xsd:integer ;
+                                      rs:variable   "c"
+                                    ]
+                    ] ;
+      rs:solution   [ rs:binding    [ rs:value      <pair.ttl> ;
+                                      rs:variable   "g"
+                                    ] ;
+                      rs:binding    [ rs:value      "2"^^xsd:integer ;
                                       rs:variable   "c"
                                     ]
                     ] .

--- a/sparql/sparql11/aggregates/agg-empty-group-count-graph.ttl
+++ b/sparql/sparql11/aggregates/agg-empty-group-count-graph.ttl
@@ -9,7 +9,7 @@
       rs:solution   [ rs:binding    [ rs:value      <singleton.ttl> ;
                                       rs:variable   "g"
                                     ] ;
-                      rs:binding    [ rs:value      "1"^^xsd:integer ;
+                      rs:binding    [ rs:value      "0"^^xsd:integer ;
                                       rs:variable   "c"
                                     ]
                     ] ;

--- a/sparql/sparql11/aggregates/manifest.ttl
+++ b/sparql/sparql11/aggregates/manifest.ttl
@@ -425,7 +425,7 @@
 
 :agg-empty-group-count-graph  rdf:type mf:QueryEvaluationTest ;
 	mf:name "COUNT: no GROUP BY inside of GRAPH" ;
-    rdfs:comment "counting no results without grouping always returns a single result per named graph." ;
+    rdfs:comment "counting without grouping always returns a single result per named graph." ;
     mf:action
          [ qt:query     <agg-empty-group-count-graph.rq> ;
            qt:data      <empty.ttl> ;

--- a/sparql/sparql11/aggregates/manifest.ttl
+++ b/sparql/sparql11/aggregates/manifest.ttl
@@ -429,8 +429,8 @@
     mf:action
          [ qt:query     <agg-empty-group-count-graph.rq> ;
            qt:data      <empty.ttl> ;
-           qt:graphData <empty.ttl> ;
-           qt:graphData <singleton.ttl> ] ;
+           qt:graphData <singleton.ttl> ;
+           qt:graphData <pair.ttl> ] ;
     mf:result  <agg-empty-group-count-graph.ttl>
     .
 

--- a/sparql/sparql11/aggregates/pair.ttl
+++ b/sparql/sparql11/aggregates/pair.ttl
@@ -1,0 +1,3 @@
+@prefix ex: <http://example/> .
+
+ex:s ex:p ex:o2 , ex:o3 .

--- a/sparql/sparql11/bindings/graph.rq
+++ b/sparql/sparql11/bindings/graph.rq
@@ -1,5 +1,5 @@
 SELECT ?g ?t {
     GRAPH ?g {
-        VALUES (?g ?t) { (UNDEF "foo") ( <empty.ttl> "bar") }
+        VALUES (?g ?t) { (UNDEF "foo") ( <data01.ttl> "bar") }
     }
 }

--- a/sparql/sparql11/bindings/graph.ttl
+++ b/sparql/sparql11/bindings/graph.ttl
@@ -3,14 +3,14 @@
 []  a rs:ResultSet ;
     rs:resultVariable
                 "g" , "t" ;
-    rs:solution [ rs:binding  [ rs:value    <empty.ttl> ;
+    rs:solution [ rs:binding  [ rs:value    <data01.ttl> ;
                                 rs:variable "g"
                               ] ;
                   rs:binding  [ rs:value    "foo";
                                 rs:variable "t"
                               ]
                 ] ;
-    rs:solution [ rs:binding  [ rs:value    <empty.ttl> ;
+    rs:solution [ rs:binding  [ rs:value    <data01.ttl> ;
                                 rs:variable "g"
                               ] ;
                   rs:binding  [ rs:value    "bar";

--- a/sparql/sparql11/bindings/manifest.ttl
+++ b/sparql/sparql11/bindings/manifest.ttl
@@ -141,7 +141,7 @@
     [
         qt:query  <graph.rq> ;
         qt:data   <empty.ttl> ;
-        qt:graphData   <empty.ttl> ;
+        qt:graphData   <data01.ttl> ;
         qt:graphData   <data02.ttl>
     ] ;
     mf:result  <graph.ttl> .


### PR DESCRIPTION
Change two tests introduced recently to tests GRAPH behavior to not rely on empty named graphs