### PR TITLE
SPARQL 1.1: Remove the Test11  type variants

### DIFF
--- a/ns/test-manifest.ttl
+++ b/ns/test-manifest.ttl
@@ -112,14 +112,6 @@
       rdfs:label "Positive Syntax Test for SPARQL Update" ;
       rdfs:comment "A type of test specifically for syntax testing of SPARQL Update. Syntax tests are not required to have an associated result, only an action. Tests are expected to define their spec version." .
 
-:PositiveSyntaxTest11 rdf:type rdfs:Class ;
-      rdfs:label "Positive Syntax Test for SPARQL 1.1 Query" ;
-      rdfs:comment "A type of test specifically for syntax testing of new features in the SPARQL 1.1 Query Language. Syntax tests are not required to have an associated result, only an action." .
-
-:PositiveUpdateSyntaxTest11 rdf:type rdfs:Class ;
-      rdfs:label "Positive Syntax Test for SPARQL 1.1 Update" ;
-      rdfs:comment "A type of test specifically for syntax testing of SPARQL 1.1 Update. Syntax tests are not required to have an associated result, only an action." .
-
 
 :NegativeSyntaxTest rdf:type rdfs:Class ;
       rdfs:label "Negative Syntax Test" ;
@@ -128,14 +120,6 @@
 :NegativeUpdateSyntaxTest rdf:type rdfs:Class ;
       rdfs:label "Negative Syntax Test for SPARQL Update" ;
       rdfs:comment "A type of test specifically for syntax testing of SPARQL Update. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error. Tests are expected to define their spec version." .
-
-:NegativeSyntaxTest11 rdf:type rdfs:Class ;
-      rdfs:label "Negative Syntax Test for SPARQL 1.1 Query" ;
-      rdfs:comment "A type of test specifically for syntax testing of new features in the SPARQL 1.1 Query Language. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error." .
-
-:NegativeUpdateSyntaxTest11 rdf:type rdfs:Class ;
-      rdfs:label "Negative Syntax Test for SPARQL 1.1 Update" ;
-      rdfs:comment "A type of test specifically for syntax testing of SPARQL 1.1 Update. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error." .
 
 
 :QueryEvaluationTest rdf:type rdfs:Class ;

--- a/sparql/sparql11/aggregates/manifest.ttl
+++ b/sparql/sparql11/aggregates/manifest.ttl
@@ -145,7 +145,8 @@
     mf:result  <agg07.srx>
     .
 
-:agg08 rdf:type  mf:NegativeSyntaxTest11;
+:agg08 rdf:type  mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1";
     mf:name    "COUNT 8" ;
 	mf:feature sparql:count ;
     rdfs:comment "grouping by expression, done wrong";
@@ -164,7 +165,8 @@
            qt:data   <agg08.ttl> ] ;
     mf:result  <agg08b.srx> .
 
-:agg09 rdf:type  mf:NegativeSyntaxTest11;
+:agg09 rdf:type  mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1";
     mf:name    "COUNT 9" ;
 	mf:feature sparql:count ;
     rdfs:comment "Projection of an ungrouped variable (not appearing in the GROUP BY expression)";
@@ -172,7 +174,8 @@
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action  <agg09.rq> .
 
-:agg10 rdf:type  mf:NegativeSyntaxTest11;
+:agg10 rdf:type  mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1";
     mf:name    "COUNT 10" ;
 	mf:feature sparql:count ;
     rdfs:comment "Projection of an ungrouped variable (no GROUP BY expression at all)";
@@ -180,7 +183,8 @@
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action  <agg10.rq> .
 
-:agg11 rdf:type  mf:NegativeSyntaxTest11;
+:agg11 rdf:type  mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1";
     mf:name    "COUNT 11" ;
 	mf:feature sparql:count ;
     rdfs:comment "Use of an ungrouped variable in a project expression";
@@ -188,7 +192,8 @@
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action  <agg11.rq> .
 
-:agg12 rdf:type  mf:NegativeSyntaxTest11;
+:agg12 rdf:type  mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1";
     mf:name    "COUNT 12" ;
 	mf:feature sparql:count ;
     rdfs:comment "Use of an ungrouped variable in a project expression, where the variable appears in a GROUP BY expression";

--- a/sparql/sparql11/construct/manifest.ttl
+++ b/sparql/sparql11/construct/manifest.ttl
@@ -61,14 +61,16 @@
     mf:result  <constructwhere04result.ttl>
     .
 
-:constructwhere05 rdf:type mf:NegativeSyntaxTest11 ;
+:constructwhere05 rdf:type mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
     mf:name    "constructwhere05 - CONSTRUCT WHERE" ;
     rdfs:comment "CONSTRUCT WHERE  with FILTER";
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-02-01#resolution_3> ;
     mf:action <constructwhere05.rq> .
 
-:constructwhere06 rdf:type mf:NegativeSyntaxTest11 ;
+:constructwhere06 rdf:type mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
     mf:name    "constructwhere06 - CONSTRUCT WHERE" ;
     mf:description "CONSTRUCT WHERE  with GRAPH";
     dawgt:approval dawgt:Approved ;

--- a/sparql/sparql11/delete-insert/manifest.ttl
+++ b/sparql/sparql11/delete-insert/manifest.ttl
@@ -76,7 +76,8 @@
               ] .
 
 :dawg-delete-insert-03
-    a mf:NegativeSyntaxTest11 ;
+    a mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1" ;
     mf:name    "DELETE INSERT 3" ;
     rdfs:comment "This deletes all foaf:knows relations from anyone named 'Alan' using an unnamed bnode as wildcard" ;
     dawgt:approval dawgt:Approved;
@@ -84,7 +85,8 @@
     mf:action <delete-insert-03.ru> .
 
 :dawg-delete-insert-03b
-    a mf:NegativeSyntaxTest11 ;
+    a mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1" ;
     mf:name    "DELETE INSERT 3b" ;
     rdfs:comment "This deletes all foaf:knows relations from anyone named 'Alan' using a named bnode as wildcard" ;
     dawgt:approval dawgt:Approved;
@@ -114,7 +116,8 @@
               ] .
 
 :dawg-delete-insert-05
-    a mf:NegativeSyntaxTest11 ;
+    a mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1" ;
     mf:name    "DELETE INSERT 5" ;
     rdfs:comment "This deletes all foaf:knows relations from anyone named 'Alan' and inserts that all 'Alans' know themselves only." ;
     dawgt:approval dawgt:Approved;
@@ -133,7 +136,8 @@
               ] .
 
 :dawg-delete-insert-06
-    a mf:NegativeSyntaxTest11 ;
+    a mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1" ;
     mf:name    "DELETE INSERT 6" ;
     rdfs:comment "dawg-delete-insert-06 and dawg-delete-insert-06b show that the rewriting in dawg-delete-insert-05b.ru isn't equivalent to dawg-delete-insert-05.ru in case Alan doesn't know anybody." ;
     dawgt:approval dawgt:Approved;
@@ -152,7 +156,8 @@
               ] .
 
 :dawg-delete-insert-07
-    a mf:NegativeSyntaxTest11 ;
+    a mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1" ;
     mf:name    "DELETE INSERT 7" ;
     rdfs:comment "This deletes all foaf:knows relations from anyone named 'Alan' and inserts a single foaf:knows triple with a blank node as object for 'Alan'. This shows the different behavior of bnodes in INSERT (similar to CONSTRUCT) and DELETE (bnodes act as wildcards) templates." ;
     dawgt:approval dawgt:Approved;
@@ -160,7 +165,8 @@
     mf:action <delete-insert-07.ru> .
 
 :dawg-delete-insert-07b 
-    a mf:NegativeSyntaxTest11 ;
+    a mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1" ;
     mf:name    "DELETE INSERT 7b" ;
     rdfs:comment "This deletes all foaf:knows relations from anyone named 'Alan' and replaces them by bnodes. This shows the different behavior of bnodes in INSERT (similar to CONSTRUCT) and DELETE (bnodes act as wildcards) templates. As opposed to test case dawg-delete-insert-7, note that the result graph in this example is non-lean." ;
     dawgt:approval dawgt:Approved;
@@ -169,7 +175,8 @@
 
 
 :dawg-delete-insert-08
-    a mf:NegativeSyntaxTest11 ;
+    a mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1" ;
     mf:name    "DELETE INSERT 8" ;
     rdfs:comment "This DELETE test was first brought up in http://lists.w3.org/Archives/Public/public-rdf-dawg/2011JanMar/0290.html. It demonstrates how unbound variables (from an OPTIONAL) are handled in DELETE templates" ;
     dawgt:approval dawgt:Approved;
@@ -177,7 +184,8 @@
     mf:action <delete-insert-08.ru> .
 
 :dawg-delete-insert-09
-    a mf:NegativeSyntaxTest11 ;
+    a mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1" ;
     mf:name    "DELETE INSERT 9" ;
     rdfs:comment "This DELETE test was first brought up in http://lists.w3.org/Archives/Public/public-rdf-dawg/2011JanMar/0317.html. It demonstrates the behavior of shared bnodes in a DELETE template." ;
     dawgt:approval dawgt:Approved;

--- a/sparql/sparql11/grouping/manifest.ttl
+++ b/sparql/sparql11/grouping/manifest.ttl
@@ -62,14 +62,16 @@
     mf:result  <group05.srx>
     .
 
-:group06 rdf:type  mf:NegativeSyntaxTest11;
+:group06 rdf:type  mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1";
     mf:name    "Group-6" ;
     rdfs:comment "projection of ungrouped variable";
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
     mf:action <group06.rq> .
 
-:group07 rdf:type  mf:NegativeSyntaxTest11;
+:group07 rdf:type  mf:NegativeSyntaxTest ;
+    mf:specVersion "sparql-1.1";
     mf:name    "Group-7" ;
     rdfs:comment "projection of ungrouped variable, more complex example than Group-6";
     dawgt:approval dawgt:Approved ;

--- a/sparql/sparql11/syntax-fed/manifest.ttl
+++ b/sparql/sparql11/syntax-fed/manifest.ttl
@@ -15,19 +15,22 @@
 :test_3
 ) .
 
-:test_1 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_1 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-service-01.rq" ;
    mf:action  <syntax-service-01.rq> ;.
 
-:test_2 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_2 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-service-02.rq" ;
    mf:action  <syntax-service-02.rq> ;.
 
-:test_3 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_3 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-service-03.rq" ;

--- a/sparql/sparql11/syntax-query/manifest.ttl
+++ b/sparql/sparql11/syntax-query/manifest.ttl
@@ -114,561 +114,655 @@
 :test_bad_values_too_many
 ) .
 
-:test_1 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_1 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-select-expr-01.rq" ;
    mf:action  <syntax-select-expr-01.rq> ;.
 
-:test_2 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_2 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-select-expr-02.rq" ;
    mf:action  <syntax-select-expr-02.rq> ;.
 
-:test_3 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_3 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-select-expr-03.rq" ;
    mf:action  <syntax-select-expr-03.rq> ;.
 
-:test_4 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_4 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-select-expr-04.rq" ;
    mf:action  <syntax-select-expr-04.rq> ;.
 
-:test_5 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_5 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-select-expr-05.rq" ;
    mf:action  <syntax-select-expr-05.rq> ;.
 
-:test_6 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_6 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-01.rq" ;
    mf:action  <syntax-aggregate-01.rq> ;.
 
-:test_7 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_7 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-02.rq" ;
    mf:action  <syntax-aggregate-02.rq> ;.
 
-:test_8 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_8 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-03.rq" ;
    mf:action  <syntax-aggregate-03.rq> ;.
 
-:test_9 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_9 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-04.rq" ;
    mf:action  <syntax-aggregate-04.rq> ;.
 
-:test_10 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_10 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-05.rq" ;
    mf:action  <syntax-aggregate-05.rq> ;.
 
-:test_11 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_11 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-06.rq" ;
    mf:action  <syntax-aggregate-06.rq> ;.
 
-:test_12 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_12 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-07.rq" ;
    mf:action  <syntax-aggregate-07.rq> ;.
 
-:test_13 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_13 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-08.rq" ;
    mf:action  <syntax-aggregate-08.rq> ;.
 
-:test_14 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_14 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-09.rq" ;
    mf:action  <syntax-aggregate-09.rq> ;.
 
-:test_15 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_15 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-10.rq" ;
    mf:action  <syntax-aggregate-10.rq> ;.
 
-:test_16 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_16 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-11.rq" ;
    mf:action  <syntax-aggregate-11.rq> ;.
 
-:test_17 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_17 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-12.rq" ;
    mf:action  <syntax-aggregate-12.rq> ;.
 
-:test_18 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_18 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-13.rq" ;
    mf:action  <syntax-aggregate-13.rq> ;.
 
-:test_19 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_19 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-14.rq" ;
    mf:action  <syntax-aggregate-14.rq> ;.
 
-:test_20 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_20 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-aggregate-15.rq" ;
    mf:action  <syntax-aggregate-15.rq> ;.
 
-:test_21 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_21 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-subquery-01.rq" ;
    mf:action  <syntax-subquery-01.rq> ;.
 
-:test_22 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_22 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-subquery-02.rq" ;
    mf:action  <syntax-subquery-02.rq> ;.
 
-:test_23 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_23 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-subquery-03.rq" ;
    mf:action  <syntax-subquery-03.rq> ;.
 
-:test_24 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_24 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-not-exists-01.rq" ;
    mf:action  <syntax-not-exists-01.rq> ;.
 
-:test_25 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_25 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-not-exists-02.rq" ;
    mf:action  <syntax-not-exists-02.rq> ;.
 
-:test_26 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_26 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-not-exists-03.rq" ;
    mf:action  <syntax-not-exists-03.rq> ;.
 
-:test_27 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_27 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-exists-01.rq" ;
    mf:action  <syntax-exists-01.rq> ;.
 
-:test_28 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_28 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-exists-02.rq" ;
    mf:action  <syntax-exists-02.rq> ;.
 
-:test_29 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_29 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-exists-03.rq" ;
    mf:action  <syntax-exists-03.rq> ;.
 
-:test_30 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_30 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-minus-01.rq" ;
    mf:action  <syntax-minus-01.rq> ;.
 
-:test_31 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_31 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-oneof-01.rq" ;
    mf:action  <syntax-oneof-01.rq> ;.
 
-:test_32 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_32 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-oneof-02.rq" ;
    mf:action  <syntax-oneof-02.rq> ;.
 
-:test_33 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_33 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-oneof-03.rq" ;
    mf:action  <syntax-oneof-03.rq> ;.
 
-:test_34 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_34 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-bindingBINDscopes-01.rq" ;
    mf:action  <syntax-bindings-01.rq> ;.
 
-:test_35a rdf:type   mf:PositiveSyntaxTest11 ;
+:test_35a rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
 
    mf:name    "syntax-bindings-02a.rq with VALUES clause" ;
    mf:action  <syntax-bindings-02a.rq> ;.
 
-:test_36a rdf:type   mf:PositiveSyntaxTest11 ;
+:test_36a rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-bindings-03a.rq with VALUES clause" ;
    mf:action  <syntax-bindings-03a.rq> ;.
 
-:test_38a rdf:type   mf:PositiveSyntaxTest11 ;
+:test_38a rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-bindings-05a.rq with VALUES clause" ;
    mf:action  <syntax-bindings-05a.rq> ;.
 
-:test_40 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_40 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-bind-02.rq" ;
    mf:action  <syntax-bind-02.rq> ;.
 
-:test_41 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_41 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-construct-where-01.rq" ;
    mf:action  <syntax-construct-where-01.rq> ;.
 
-:test_42 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_42 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-construct-where-02.rq" ;
    mf:action  <syntax-construct-where-02.rq> ;.
 
-:test_43 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_43 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syn-bad-01.rq" ;
    mf:action  <syn-bad-01.rq> ;.
 
-:test_44 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_44 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syn-bad-02.rq" ;
    mf:action  <syn-bad-02.rq> ;.
 
-:test_45 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_45 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syn-bad-03.rq" ;
    mf:action  <syn-bad-03.rq> ;.
 
-:test_46 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_46 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syn-bad-04.rq" ;
    mf:action  <syn-bad-04.rq> ;.
 
-:test_47 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_47 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syn-bad-05.rq" ;
    mf:action  <syn-bad-05.rq> ;.
 
-:test_48 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_48 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syn-bad-06.rq" ;
    mf:action  <syn-bad-06.rq> ;.
 
-:test_49 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_49 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syn-bad-07.rq" ;
    mf:action  <syn-bad-07.rq> ;.
 
-:test_50 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_50 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syn-bad-08.rq" ;
    mf:action  <syn-bad-08.rq> ;.
 
-:test_51 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_51 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-bindings-09.rq" ;
    mf:action  <syntax-bindings-09.rq> ;.
 
-:test_53 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_53 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-01-31#resolution_3> ;
    mf:name    "PrefixName with hex-encoded colons" ;
    mf:action  <qname-escape-02.rq> ;.
 
-:test_54 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_54 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "PrefixName with unescaped colons" ;
    mf:action  <qname-escape-03.rq> ;.
 
-:test_55 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_55 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-BINDscope1.rq" ;
    mf:action  <syntax-BINDscope1.rq> ;.
 
-:test_56 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_56 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-BINDscope2.rq" ;
    mf:action  <syntax-BINDscope2.rq> ;.
 
-:test_57 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_57 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-BINDscope3.rq" ;
    mf:action  <syntax-BINDscope3.rq> ;.
 
-:test_58 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_58 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-BINDscope4.rq" ;
    mf:action  <syntax-BINDscope4.rq> ;.
 
-:test_59 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_59 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-BINDscope5.rq" ;
    mf:action  <syntax-BINDscope5.rq> ;.
 
-:test_60 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_60 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-BINDscope6.rq" ;
    mf:action  <syntax-BINDscope6.rq> ;.
 
-:test_61a rdf:type   mf:NegativeSyntaxTest11 ;
+:test_61a rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-09-25#resolution_2> ;
     mf:name    "syntax-BINDscope7.rq" ;
     mf:action  <syntax-BINDscope7.rq> ;.
 
-:test_62a rdf:type   mf:NegativeSyntaxTest11 ;
+:test_62a rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-09-25#resolution_2> ;
     mf:name    "syntax-BINDscope8.rq" ;
     mf:action  <syntax-BINDscope8.rq> ;.
 
-:test_63 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_63 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-propertyPaths-01.rq" ;
    mf:action  <syntax-propertyPaths-01.rq> ;.
 
-:test_64 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_64 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-SELECTscope1.rq" ;
    mf:action  <syntax-SELECTscope1.rq> ;.
 
-:test_65 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_65 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-SELECTscope2" ;
    mf:action  <syntax-SELECTscope2.rq> ;.
 
-:test_66 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_66 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syntax-SELECTscope3.rq" ;
    mf:action  <syntax-SELECTscope3.rq> ;.
 
-:test_pn_01 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_pn_01 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-pname-01" ;
    mf:action  <syn-pname-01.rq> ;.
 
-:test_pn_02 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_pn_02 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-pname-02" ;
    mf:action  <syn-pname-02.rq> ;.
 
-:test_pn_03 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_pn_03 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-pname-03" ;
    mf:action  <syn-pname-03.rq> ;.
 
-:test_pn_04 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_pn_04 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-pname-04" ;
    mf:action  <syn-pname-04.rq> ;.
 
-:test_pn_05 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_pn_05 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-pname-05" ;
    mf:action  <syn-pname-05.rq> ;.
 
-:test_pn_06 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_pn_06 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-pname-06" ;
    mf:action  <syn-pname-06.rq> ;.
 
-:test_pn_07 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_pn_07 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-pname-07" ;
    mf:action  <syn-pname-07.rq> ;.
 
-:test_pn_08 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_pn_08 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-pname-08" ;
    mf:action  <syn-pname-08.rq> ;.
 
-:test_pn_09 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_pn_09 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-pname-09" ;
    mf:action  <syn-pname-09.rq> ;.
 
 
-:test_pn_bad_01 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_01 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-01" ;
    mf:action  <syn-bad-pname-01.rq> ;.
 
-:test_pn_bad_02 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_02 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-02" ;
    mf:action  <syn-bad-pname-02.rq> ;.
 
-:test_pn_bad_03 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_03 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-03" ;
    mf:action  <syn-bad-pname-03.rq> ;.
 
-:test_pn_bad_04 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_04 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-04" ;
    mf:action  <syn-bad-pname-04.rq> ;.
 
-:test_pn_bad_05 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_05 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-05" ;
    mf:action  <syn-bad-pname-05.rq> ;.
 
-:test_pn_bad_06 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_06 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-06" ;
    mf:action  <syn-bad-pname-06.rq> ;.
 
-:test_pn_bad_07 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_07 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-07" ;
    mf:action  <syn-bad-pname-07.rq> ;.
 
-:test_pn_bad_08 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_08 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-08" ;
    mf:action  <syn-bad-pname-08.rq> ;.
 
-:test_pn_bad_09 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_09 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-09" ;
    mf:action  <syn-bad-pname-09.rq> ;.
 
-:test_pn_bad_10 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_10 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-10" ;
    mf:action  <syn-bad-pname-10.rq> ;.
 
-:test_pn_bad_11 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_11 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-11" ;
    mf:action  <syn-bad-pname-11.rq> ;.
 
-:test_pn_bad_12 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_12 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-12" ;
    mf:action  <syn-bad-pname-12.rq> ;.
 
-:test_pn_bad_13 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_pn_bad_13 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-bad-pname-13" ;
    mf:action  <syn-bad-pname-13.rq> ;.
 
-:test_pp_coll rdf:type   mf:PositiveSyntaxTest11 ;
+:test_pp_coll rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_2> ;
    mf:name    "syn-pp-in-collection" ;
    mf:action  <syn-pp-in-collection.rq> ;.
 
-:test_codepoint_escape_01 rdf:type   mf:PositiveSyntaxTest11 ;
+:test_codepoint_escape_01 rdf:type   mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Proposed ;
    mf:name    "\\U unicode codepoint escaping in literal" ;
    mf:action  <syn-codepoint-escape-01.rq> ;.
 
-:test_codepoint_escape_bad_02 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_codepoint_escape_bad_02 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Proposed ;
    mf:name    "Invalid multi-pass codepoint escaping (\\u then \\U)" ;
    mf:description "Unescaping one escape sequence must not produce content that is used in another escape sequence" ;
    mf:action  <syn-codepoint-escape-bad-04.rq> ;.
 
-:test_codepoint_escape_bad_03 rdf:type   mf:NegativeSyntaxTest11 ;
+:test_codepoint_escape_bad_03 rdf:type   mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Proposed ;
    mf:name    "Invalid multi-pass codepoint escaping (\\U then \\u)" ;
    mf:description "Unescaping one escape sequence must not produce content that is used in another escape sequence" ;
    mf:action  <syn-codepoint-escape-bad-05.rq> ;.
 
-:test_codepoint_boundaries_04 rdf:type mf:PositiveSyntaxTest11 ;
+:test_codepoint_boundaries_04 rdf:type mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Proposed ;
    mf:name    "utf8 literal using codepoints at notable unicode boundaries" ;
    mf:action  <1val1STRING_LITERAL1_with_UTF8_boundaries.rq> ;.
 
-:test_codepoint_boundaries_escaped_05 rdf:type mf:PositiveSyntaxTest11 ;
+:test_codepoint_boundaries_escaped_05 rdf:type mf:PositiveSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Proposed ;
    mf:name    "\\U and \\u unicode codepoint escaping in literal using codepoints at notable unicode boundaries" ;
    mf:action  <1val1STRING_LITERAL1_with_UTF8_boundaries_escaped.rq> ;.
 
-:test_codepoint_invalid_escaped_bad_06 rdf:type mf:NegativeSyntaxTest11 ;
+:test_codepoint_invalid_escaped_bad_06 rdf:type mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Proposed ;
    mf:name    "\\u unicode codepoint escaping in literal using partial surrogate pair" ;
    mf:description "Using a codepoint that is half of a surrogate pair (in the range U+D800–U+DFFF) without a corresponding codepoint is illegal" ;
    mf:action  <syn-invalid-codepoint-escaped-bad-01.rq> ;.
 
-:test_bad_values_too_many rdf:type mf:NegativeSyntaxTest11 ;
+:test_bad_values_too_many rdf:type mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
     mf:name "Too many values in a VALUE clause compared to the number of variables" ;
     mf:action <syn-bad-values-too-many.rq> .
 
-:test_bad_values_too_few rdf:type mf:NegativeSyntaxTest11 ;
+:test_bad_values_too_few rdf:type mf:NegativeSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
     mf:name "Too few values in a VALUE clause compared to the number of variables" ;
     mf:action <syn-bad-values-too-few.rq> .

--- a/sparql/sparql11/syntax-update-1/manifest.ttl
+++ b/sparql/sparql11/syntax-update-1/manifest.ttl
@@ -67,325 +67,379 @@
 :test_54
 ) .
 
-:test_1 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_1 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-01.ru" ;
    mf:action  <syntax-update-01.ru> ;.
 
-:test_2 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_2 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-02.ru" ;
    mf:action  <syntax-update-02.ru> ;.
 
-:test_3 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_3 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-03.ru" ;
    mf:action  <syntax-update-03.ru> ;.
 
-:test_4 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_4 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-04.ru" ;
    mf:action  <syntax-update-04.ru> ;.
 
-:test_5 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_5 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-05.ru" ;
    mf:action  <syntax-update-05.ru> ;.
 
-:test_6 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_6 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-06.ru" ;
    mf:action  <syntax-update-06.ru> ;.
 
-:test_7 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_7 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-07.ru" ;
    mf:action  <syntax-update-07.ru> ;.
 
-:test_8 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_8 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-08.ru" ;
    mf:action  <syntax-update-08.ru> ;.
 
-:test_9 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_9 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-09.ru" ;
    mf:action  <syntax-update-09.ru> ;.
 
-:test_10 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_10 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-10.ru" ;
    mf:action  <syntax-update-10.ru> ;.
 
-:test_11 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_11 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-11.ru" ;
    mf:action  <syntax-update-11.ru> ;.
 
-:test_12 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_12 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-12.ru" ;
    mf:action  <syntax-update-12.ru> ;.
 
-:test_13 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_13 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-13.ru" ;
    mf:action  <syntax-update-13.ru> ;.
 
-:test_14 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_14 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-14.ru" ;
    mf:action  <syntax-update-14.ru> ;.
 
-:test_15 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_15 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-15.ru" ;
    mf:action  <syntax-update-15.ru> ;.
 
-:test_16 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_16 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-16.ru" ;
    mf:action  <syntax-update-16.ru> ;.
 
-:test_17 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_17 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-17.ru" ;
    mf:action  <syntax-update-17.ru> ;.
 
-:test_18 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_18 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-18.ru" ;
    mf:action  <syntax-update-18.ru> ;.
 
-:test_19 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_19 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-19.ru" ;
    mf:action  <syntax-update-19.ru> ;.
 
-:test_20 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_20 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-20.ru" ;
    mf:action  <syntax-update-20.ru> ;.
 
-:test_21 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_21 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-21.ru" ;
    mf:action  <syntax-update-21.ru> ;.
 
-:test_22 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_22 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-22.ru" ;
    mf:action  <syntax-update-22.ru> ;.
 
-:test_23 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_23 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-23.ru" ;
    mf:action  <syntax-update-23.ru> ;.
 
-:test_24 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_24 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-24.ru" ;
    mf:action  <syntax-update-24.ru> ;.
 
-:test_25 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_25 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-25.ru" ;
    mf:action  <syntax-update-25.ru> ;.
 
-:test_26 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_26 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-26.ru" ;
    mf:action  <syntax-update-26.ru> ;.
 
-:test_27 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_27 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-27.ru" ;
    mf:action  <syntax-update-27.ru> ;.
 
-:test_28 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_28 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-28.ru" ;
    mf:action  <syntax-update-28.ru> ;.
 
-:test_29 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_29 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-29.ru" ;
    mf:action  <syntax-update-29.ru> ;.
 
-:test_30 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_30 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-30.ru" ;
    mf:action  <syntax-update-30.ru> ;.
 
-:test_31 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_31 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-31.ru" ;
    mf:action  <syntax-update-31.ru> ;.
 
-:test_32 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_32 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-32.ru" ;
    mf:action  <syntax-update-32.ru> ;.
 
-:test_33 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_33 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-33.ru" ;
    mf:action  <syntax-update-33.ru> ;.
 
-:test_34 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_34 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-34.ru" ;
    mf:action  <syntax-update-34.ru> ;.
 
-:test_35 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_35 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-35.ru" ;
    mf:action  <syntax-update-35.ru> ;.
 
-:test_36 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_36 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-36.ru" ;
    mf:action  <syntax-update-36.ru> ;.
 
-:test_37 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_37 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-37.ru" ;
    mf:action  <syntax-update-37.ru> ;.
 
-:test_38 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_38 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-38.ru" ;
    mf:action  <syntax-update-38.ru> ;.
 
-:test_39 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_39 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-39.ru" ;
    mf:action  <syntax-update-39.ru> ;.
 
-:test_40 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_40 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-40.ru" ;
    mf:action  <syntax-update-40.ru> ;.
 
-:test_41 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_41 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-01.ru" ;
    mf:action  <syntax-update-bad-01.ru> ;.
 
-:test_42 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_42 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-02.ru" ;
    mf:action  <syntax-update-bad-02.ru> ;.
 
-:test_43 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_43 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-03.ru" ;
    mf:action  <syntax-update-bad-03.ru> ;.
 
-:test_44 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_44 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-04.ru" ;
    mf:action  <syntax-update-bad-04.ru> ;.
 
-:test_45 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_45 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-05.ru" ;
    mf:action  <syntax-update-bad-05.ru> ;.
 
-:test_46 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_46 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-06.ru" ;
    mf:action  <syntax-update-bad-06.ru> ;.
 
-:test_47 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_47 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-07.ru" ;
    mf:action  <syntax-update-bad-07.ru> ;.
 
-:test_48 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_48 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-08.ru" ;
    mf:action  <syntax-update-bad-08.ru> ;.
 
-:test_49 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_49 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-09.ru" ;
    mf:action  <syntax-update-bad-09.ru> ;.
 
-:test_50 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_50 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-10.ru" ;
    mf:action  <syntax-update-bad-10.ru> ;.
 
-:test_51 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_51 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-11.ru" ;
    mf:action  <syntax-update-bad-11.ru> ;.
 
-:test_52 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_52 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
    dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
    mf:name    "syntax-update-bad-12.ru" ;
    mf:action  <syntax-update-bad-12.ru> ;.
 
-:test_53 rdf:type   mf:PositiveUpdateSyntaxTest11 ;
+:test_53 rdf:type   mf:PositiveUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-08-07#resolution_3> ;
    mf:name    "syntax-update-53.ru" ;
    mf:action  <syntax-update-53.ru> ;.
 
-:test_54 rdf:type   mf:NegativeUpdateSyntaxTest11 ;
+:test_54 rdf:type   mf:NegativeUpdateSyntaxTest ;
+   mf:specVersion "sparql-1.1" ;
     dawgt:approval dawgt:Approved ;
     dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2012-12-11#resolution_5> ;
     # Reuse of bNode label across operations.  

--- a/sparql/sparql11/syntax-update-2/manifest.ttl
+++ b/sparql/sparql11/syntax-update-2/manifest.ttl
@@ -17,6 +17,7 @@
 	mf:name        "syntax-update-other-01" ;
 	dawgt:approval dawgt:Approved ;
    dawgt:approvedBy <http://www.w3.org/2009/sparql/meeting/2011-04-05#resolution_2> ;
-	rdf:type       mf:PositiveUpdateSyntaxTest11 ;
+	rdf:type       mf:PositiveUpdateSyntaxTest ;
+    mf:specVersion "sparql-1.1" ;
 	mf:action      <large-request-01.ru> ;
 	.


### PR DESCRIPTION
We have not included new type variants for 1.2 and consensus in #143 seems to suggest we could remove them for 1.1 too