### PR TITLE
Clean up superficial test output and manifest inconsistencies

### DIFF
--- a/rdf/rdf11/manifest.ttl
+++ b/rdf/rdf11/manifest.ttl
@@ -1,5 +1,5 @@
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX rdfs:	<http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 
 ## Manifest of all RDF 1.1 test suites

--- a/rdf/rdf11/manifest.ttl
+++ b/rdf/rdf11/manifest.ttl
@@ -23,4 +23,4 @@ PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
     <rdf-turtle/manifest.ttl>
     <rdf-trig/manifest.ttl>
     <rdf-xml/manifest.ttl>
-	) .
+  ) .

--- a/rdf/rdf11/manifest.ttl
+++ b/rdf/rdf11/manifest.ttl
@@ -5,8 +5,8 @@ PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 ## Manifest of all RDF 1.1 test suites
 
 <> a mf:Manifest ;
-  rdfs:label "RDF 1.1 tests" ;
-  rdfs:comment """
+    rdfs:label "RDF 1.1 tests" ;
+    rdfs:comment """
     These test suites are a product previous RDF working groups,
     and has been maintained by the
     [RDF Test Curation Community Group](https://www.w3.org/community/rdf-tests/).
@@ -15,12 +15,12 @@ PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
 
     Conformance with RDF 1.1 specifications can be determined via successfully running the
     tests for relevant specifications.
-  """;
-  mf:include (
-    <rdf-n-triples/manifest.ttl>
-    <rdf-n-quads/manifest.ttl>
-    <rdf-mt/manifest.ttl>
-    <rdf-turtle/manifest.ttl>
-    <rdf-trig/manifest.ttl>
-    <rdf-xml/manifest.ttl>
-  ) .
+    """;
+    mf:include (
+        <rdf-n-triples/manifest.ttl>
+        <rdf-n-quads/manifest.ttl>
+        <rdf-mt/manifest.ttl>
+        <rdf-turtle/manifest.ttl>
+        <rdf-trig/manifest.ttl>
+        <rdf-xml/manifest.ttl>
+    ) .

--- a/rdf/rdf11/rdf-mt/manifest.ttl
+++ b/rdf/rdf11/rdf-mt/manifest.ttl
@@ -82,7 +82,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <datatypes-intensional/test001.nt>;
   mf:result false .
-    
+
 <#datatypes-intensional-xsd-integer-string-incompatible> a mf:PositiveEntailmentTest;
   mf:name "datatypes-intensional-xsd-integer-string-incompatible";
   rdfs:comment """
@@ -97,7 +97,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <datatypes-intensional/test002.nt>;
   mf:result false .
-    
+
 <#datatypes-non-well-formed-literal-1> a mf:NegativeEntailmentTest;
   mf:name "datatypes-non-well-formed-literal-1";
   rdfs:comment """
@@ -113,7 +113,7 @@
   mf:unrecognizedDatatypes ( xsd:integer ) ;
   mf:action <datatypes/test002.nt>;
   mf:result false .
-    
+
 <#datatypes-non-well-formed-literal-2> a mf:PositiveEntailmentTest;
   mf:name "datatypes-non-well-formed-literal-2";
   rdfs:comment """
@@ -129,8 +129,8 @@
   mf:recognizedDatatypes ( xsd:integer ) ;
   mf:unrecognizedDatatypes ( ) ;
   mf:action <datatypes/test002.nt>;
-  mf:result false. 
-    
+  mf:result false.
+
 <#datatypes-semantic-equivalence-within-type-1> a mf:PositiveEntailmentTest;
   mf:name "datatypes-semantic-equivalence-within-type-1";
   rdfs:comment """
@@ -143,7 +143,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <datatypes/test003a.nt>;
   mf:result <datatypes/test003b.nt> .
-    
+
 <#datatypes-semantic-equivalence-within-type-2> a mf:PositiveEntailmentTest;
   mf:name "datatypes-semantic-equivalence-within-type-2";
   rdfs:comment """
@@ -156,7 +156,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <datatypes/test003b.nt>;
   mf:result <datatypes/test003a.nt> .
-    
+
 <#datatypes-semantic-equivalence-between-datatypes> a mf:PositiveEntailmentTest;
   mf:name "datatypes-semantic-equivalence-between-datatypes";
   rdfs:comment """
@@ -168,7 +168,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <datatypes/test005a.nt>;
   mf:result <datatypes/test005b.nt> .
-    
+
 <#datatypes-range-clash> a mf:PositiveEntailmentTest;
   mf:name "datatypes-range-clash";
   rdfs:comment """
@@ -181,7 +181,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <datatypes/test006.nt>;
   mf:result false .
-    
+
 <#datatypes-test008> a mf:PositiveEntailmentTest;
   mf:name "datatypes-test008";
   rdfs:comment """
@@ -194,7 +194,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <datatypes/test008a.nt>;
   mf:result <datatypes/test008b.nt> .
-    
+
 <#datatypes-test009> a mf:NegativeEntailmentTest;
   mf:name "datatypes-test009";
   rdfs:comment """
@@ -207,7 +207,7 @@
   mf:unrecognizedDatatypes ( xsd:integer ) ;
   mf:action <datatypes/test009a.nt>;
   mf:result <datatypes/test009b.nt> .
-    
+
 <#datatypes-test010> a mf:PositiveEntailmentTest;
   mf:name "datatypes-test010";
   rdfs:comment """
@@ -220,7 +220,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <datatypes/test010.nt>;
   mf:result false .
-    
+
 <#datatypes-plain-literal-and-xsd-string> a mf:PositiveEntailmentTest;
   mf:name "datatypes-plain-literal-and-xsd-string";
   rdfs:comment """
@@ -233,7 +233,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <datatypes/test011a.nt>;
   mf:result <datatypes/test011b.nt> .
-    
+
 <#horst-01-subClassOf-intensional> a mf:NegativeEntailmentTest;
   mf:name "horst-01-subClassOf-intensional";
   rdfs:comment """
@@ -245,7 +245,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <horst-01/test001.ttl>;
   mf:result <horst-01/test002.ttl> .
-    
+
 <#horst-01-subPropertyOf-intensional> a mf:NegativeEntailmentTest;
   mf:name "horst-01-subPropertyOf-intensional";
   rdfs:comment """
@@ -257,7 +257,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <horst-01/test003.ttl>;
   mf:result <horst-01/test004.ttl> .
-    
+
 <#pfps-10-non-well-formed-literal-1> a mf:PositiveEntailmentTest;
   mf:name "pfps-10-non-well-formed-literal-1";
   rdfs:comment """
@@ -272,7 +272,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <pfps-10/test001a.nt>;
   mf:result <pfps-10/test001b.nt> .
-    
+
 <#rdf-charmod-uris-test003> a mf:NegativeEntailmentTest;
   mf:name "rdf-charmod-uris-test003";
   rdfs:comment """
@@ -286,7 +286,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdf-charmod-uris/test001.ttl>;
   mf:result <rdf-charmod-uris/test002.ttl> .
-    
+
 <#rdf-charmod-uris-test004> a mf:NegativeEntailmentTest;
   mf:name "rdf-charmod-uris-test004";
   rdfs:comment """
@@ -300,7 +300,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdf-charmod-uris/test002.ttl>;
   mf:result <rdf-charmod-uris/test001.ttl> .
-    
+
 <#rdfms-seq-representation-test002> a mf:PositiveEntailmentTest;
   mf:name "rdfms-seq-representation-test002";
   rdfs:comment """
@@ -312,7 +312,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfms-seq-representation/empty.nt>;
   mf:result <rdfms-seq-representation/test002.nt> .
-    
+
 <#rdfms-seq-representation-test003> a mf:PositiveEntailmentTest;
   mf:name "rdfms-seq-representation-test003";
   rdfs:comment """
@@ -324,7 +324,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfms-seq-representation/test003a.nt>;
   mf:result <rdfms-seq-representation/test003b.nt> .
-    
+
 <#rdfms-seq-representation-test004> a mf:PositiveEntailmentTest;
   mf:name "rdfms-seq-representation-test004";
   rdfs:comment """
@@ -336,7 +336,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfms-seq-representation/empty.nt>;
   mf:result <rdfms-seq-representation/test004.nt> .
-    
+
 <#rdfms-xmllang-test007a> a mf:NegativeEntailmentTest;
   mf:name "rdfms-xmllang-test007a";
   rdfs:comment """
@@ -349,7 +349,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfms-xmllang/test007a.nt>;
   mf:result <rdfms-xmllang/test007b.nt> .
-    
+
 <#rdfms-xmllang-test007b> a mf:NegativeEntailmentTest;
   mf:name "rdfms-xmllang-test007b";
   rdfs:comment """
@@ -362,7 +362,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfms-xmllang/test007b.nt>;
   mf:result <rdfms-xmllang/test007c.nt> .
-    
+
 <#rdfms-xmllang-test007c> a mf:NegativeEntailmentTest;
   mf:name "rdfms-xmllang-test007c";
   rdfs:comment """
@@ -375,7 +375,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfms-xmllang/test007c.nt>;
   mf:result <rdfms-xmllang/test007a.nt> .
-    
+
 <#rdfs-container-membership-superProperty-test001> a mf:NegativeEntailmentTest;
   mf:name "rdfs-container-membership-superProperty-test001";
   rdfs:comment """
@@ -388,7 +388,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfs-container-membership-superProperty/not1P.ttl>;
   mf:result <rdfs-container-membership-superProperty/not1C.ttl> .
-    
+
 <#rdfs-domain-and-range-intensionality-range> a mf:NegativeEntailmentTest;
   mf:name "rdfs-domain-and-range-intensionality-range";
   rdfs:comment """
@@ -404,7 +404,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfs-domain-and-range/premises005.ttl>;
   mf:result <rdfs-domain-and-range/nonconclusions005.ttl> .
-    
+
 <#rdfs-domain-and-range-intensionality-domain> a mf:NegativeEntailmentTest;
   mf:name "rdfs-domain-and-range-intensionality-domain";
   rdfs:comment """
@@ -437,7 +437,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfs-entailment/test001.nt>;
   mf:result false .
-    
+
 <#rdfs-entailment-test002> a mf:PositiveEntailmentTest;
   mf:name "rdfs-entailment-test002";
   rdfs:comment """
@@ -454,7 +454,7 @@
   mf:action <rdfs-entailment/test002p.nt> ;
   mf:result false.
 ## was <rdfs-entailment/test002.nt>
-    
+
 <#rdfs-no-cycles-in-subClassOf-test001> a mf:PositiveEntailmentTest;
   mf:name "rdfs-no-cycles-in-subClassOf-test001";
   rdfs:comment """
@@ -467,7 +467,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfs-no-cycles-in-subClassOf/test001.ttl>;
   mf:result <rdfs-no-cycles-in-subClassOf/test001.nt> .
-    
+
 <#rdfs-no-cycles-in-subPropertyOf-test001> a mf:PositiveEntailmentTest;
   mf:name "rdfs-no-cycles-in-subPropertyOf-test001";
   rdfs:comment """
@@ -480,7 +480,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfs-no-cycles-in-subPropertyOf/test001.ttl>;
   mf:result <rdfs-no-cycles-in-subPropertyOf/test001.nt> .
-    
+
 <#rdfs-subClassOf-a-Property-test001> a mf:NegativeEntailmentTest;
   mf:name "rdfs-subClassOf-a-Property-test001";
   rdfs:comment """
@@ -498,7 +498,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfs-subClassOf-a-Property/test001.nt>;
   mf:result false .
-    
+
 <#rdfs-subPropertyOf-semantics-test001> a mf:PositiveEntailmentTest;
   mf:name "rdfs-subPropertyOf-semantics-test001";
   rdfs:comment """
@@ -512,7 +512,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <rdfs-subPropertyOf-semantics/test001.nt>;
   mf:result <rdfs-subPropertyOf-semantics/test002.nt> .
-    
+
 <#statement-entailment-test001> a mf:NegativeEntailmentTest;
   mf:name "statement-entailment-test001";
   rdfs:comment """
@@ -526,7 +526,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <statement-entailment/test001a.nt>;
   mf:result <statement-entailment/test001b.nt> .
-    
+
 <#statement-entailment-test002> a mf:NegativeEntailmentTest;
   mf:name "statement-entailment-test002";
   rdfs:comment """
@@ -540,7 +540,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <statement-entailment/test002a.nt>;
   mf:result <statement-entailment/test002b.nt> .
-    
+
 <#statement-entailment-test003> a mf:NegativeEntailmentTest;
   mf:name "statement-entailment-test003";
   rdfs:comment """
@@ -554,7 +554,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <statement-entailment/test001a.nt>;
   mf:result <statement-entailment/test001b.nt> .
-    
+
 <#statement-entailment-test004> a mf:NegativeEntailmentTest;
   mf:name "statement-entailment-test004";
   rdfs:comment """
@@ -568,7 +568,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <statement-entailment/test002a.nt>;
   mf:result <statement-entailment/test002b.nt> .
-    
+
 <#tex-01-language-tag-case-1> a mf:PositiveEntailmentTest;
   mf:name "tex-01-language-tag-case-1";
   rdfs:comment """
@@ -580,7 +580,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <tex-01/test001.ttl>;
   mf:result <tex-01/test002.ttl> .
-    
+
 <#tex-01-language-tag-case-2> a mf:PositiveEntailmentTest;
   mf:name "tex-01-language-tag-case-2";
   rdfs:comment """
@@ -592,7 +592,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <tex-01/test002.ttl>;
   mf:result <tex-01/test001.ttl> .
-    
+
 <#xmlsch-02-whitespace-facet-1> a mf:NegativeEntailmentTest;
   mf:name "xmlsch-02-whitespace-facet-1";
   rdfs:comment """
@@ -605,7 +605,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <xmlsch-02/test001.ttl>;
   mf:result <xmlsch-02/test002.ttl> .
-    
+
 <#xmlsch-02-whitespace-facet-2> a mf:PositiveEntailmentTest;
   mf:name "xmlsch-02-whitespace-facet-2";
   rdfs:comment """
@@ -622,7 +622,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <xmlsch-02/test002.ttl>;
   mf:result false .
-    
+
 <#xmlsch-02-whitespace-facet-3> a mf:PositiveEntailmentTest;
   mf:name "xmlsch-02-whitespace-facet-3";
   rdfs:comment """
@@ -634,7 +634,7 @@
   mf:unrecognizedDatatypes ( ) ;
   mf:action <xmlsch-02/test001.ttl>;
   mf:result <xmlsch-02/test003.ttl> .
-    
+
 <#xmlsch-02-whitespace-facet-4> a mf:PositiveEntailmentTest;
   mf:name "xmlsch-02-whitespace-facet-4";
   rdfs:comment """
@@ -651,7 +651,7 @@
   mf:action <xmlsch-02/test002.ttl>;
   mf:result false .
 ## was <xmlsch-02/test003.ttl>
-    
+
 <#literal-type> a mf:PositiveEntailmentTest;
   rdfs:comment "Literals denote instances of their datatype.";
   mf:action <datatypes/literal-type1.ttl>;
@@ -741,4 +741,3 @@
   mf:result <datatypes/double-e401.ttl>;
   mf:unrecognizedDatatypes ();
   rdft:approval rdft:NotClassified .
-

--- a/rdf/rdf11/rdf-n-quads/manifest.ttl
+++ b/rdf/rdf11/rdf-n-quads/manifest.ttl
@@ -100,610 +100,610 @@
     ) .
 
 <#nq-syntax-uri-01> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-uri-01" ;
-   rdfs:comment "URI graph with URI triple" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-uri-01.nq> ;
-   .
+    mf:name    "nq-syntax-uri-01" ;
+    rdfs:comment "URI graph with URI triple" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-uri-01.nq> ;
+    .
 
 <#nq-syntax-uri-02> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-uri-02" ;
-   rdfs:comment "URI graph with BNode subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-uri-02.nq> ;
-   .
+    mf:name    "nq-syntax-uri-02" ;
+    rdfs:comment "URI graph with BNode subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-uri-02.nq> ;
+    .
 
 <#nq-syntax-uri-03> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-uri-03" ;
-   rdfs:comment "URI graph with BNode object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-uri-03.nq> ;
-   .
+    mf:name    "nq-syntax-uri-03" ;
+    rdfs:comment "URI graph with BNode object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-uri-03.nq> ;
+    .
 
 <#nq-syntax-uri-04> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-uri-04" ;
-   rdfs:comment "URI graph with simple literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-uri-04.nq> ;
-   .
+    mf:name    "nq-syntax-uri-04" ;
+    rdfs:comment "URI graph with simple literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-uri-04.nq> ;
+    .
 
 <#nq-syntax-uri-05> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-uri-05" ;
-   rdfs:comment "URI graph with language tagged literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-uri-05.nq> ;
-   .
+    mf:name    "nq-syntax-uri-05" ;
+    rdfs:comment "URI graph with language tagged literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-uri-05.nq> ;
+    .
 
 <#nq-syntax-uri-06> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-uri-06" ;
-   rdfs:comment "URI graph with datatyped literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-uri-06.nq> ;
-   .
+    mf:name    "nq-syntax-uri-06" ;
+    rdfs:comment "URI graph with datatyped literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-uri-06.nq> ;
+    .
 
 <#nq-syntax-bnode-01> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-bnode-01" ;
-   rdfs:comment "BNode graph with URI triple" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bnode-01.nq> ;
-   .
+    mf:name    "nq-syntax-bnode-01" ;
+    rdfs:comment "BNode graph with URI triple" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bnode-01.nq> ;
+    .
 
 <#nq-syntax-bnode-02> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-bnode-02" ;
-   rdfs:comment "BNode graph with BNode subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bnode-02.nq> ;
-   .
+    mf:name    "nq-syntax-bnode-02" ;
+    rdfs:comment "BNode graph with BNode subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bnode-02.nq> ;
+    .
 
 <#nq-syntax-bnode-03> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-bnode-03" ;
-   rdfs:comment "BNode graph with BNode object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bnode-03.nq> ;
-   .
+    mf:name    "nq-syntax-bnode-03" ;
+    rdfs:comment "BNode graph with BNode object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bnode-03.nq> ;
+    .
 
 <#nq-syntax-bnode-04> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-bnode-04" ;
-   rdfs:comment "BNode graph with simple literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bnode-04.nq> ;
-   .
+    mf:name    "nq-syntax-bnode-04" ;
+    rdfs:comment "BNode graph with simple literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bnode-04.nq> ;
+    .
 
 <#nq-syntax-bnode-05> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-bnode-05" ;
-   rdfs:comment "BNode graph with language tagged literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bnode-05.nq> ;
-   .
+    mf:name    "nq-syntax-bnode-05" ;
+    rdfs:comment "BNode graph with language tagged literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bnode-05.nq> ;
+    .
 
 <#nq-syntax-bnode-06> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nq-syntax-bnode-06" ;
-   rdfs:comment "BNode graph with datatyped literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bnode-06.nq> ;
-   .
+    mf:name    "nq-syntax-bnode-06" ;
+    rdfs:comment "BNode graph with datatyped literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bnode-06.nq> ;
+    .
 
 <#nq-syntax-bad-literal-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nq-syntax-bad-literal-01" ;
-   rdfs:comment "Graph name may not be a simple literal (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bad-literal-01.nq> ;
-   .
+    mf:name    "nq-syntax-bad-literal-01" ;
+    rdfs:comment "Graph name may not be a simple literal (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bad-literal-01.nq> ;
+    .
 
 <#nq-syntax-bad-literal-02> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nq-syntax-bad-literal-02" ;
-   rdfs:comment "Graph name may not be a language tagged literal (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bad-literal-02.nq> ;
-   .
+    mf:name    "nq-syntax-bad-literal-02" ;
+    rdfs:comment "Graph name may not be a language tagged literal (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bad-literal-02.nq> ;
+    .
 
 <#nq-syntax-bad-literal-03> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nq-syntax-bad-literal-03" ;
-   rdfs:comment "Graph name may not be a datatyped literal (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bad-literal-03.nq> ;
-   .
+    mf:name    "nq-syntax-bad-literal-03" ;
+    rdfs:comment "Graph name may not be a datatyped literal (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bad-literal-03.nq> ;
+    .
 
 <#nq-syntax-bad-uri-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nq-syntax-bad-uri-01" ;
-   rdfs:comment "Graph name URI must be absolute (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bad-uri-01.nq> ;
-   .
+    mf:name    "nq-syntax-bad-uri-01" ;
+    rdfs:comment "Graph name URI must be absolute (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bad-uri-01.nq> ;
+    .
 
 <#nq-syntax-bad-quint-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nq-syntax-bad-quint-01" ;
-   rdfs:comment "N-Quads does not have a fifth element (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nq-syntax-bad-quint-01.nq> ;
-   .
+    mf:name    "nq-syntax-bad-quint-01" ;
+    rdfs:comment "N-Quads does not have a fifth element (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nq-syntax-bad-quint-01.nq> ;
+    .
 
 <#nt-syntax-file-01> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-file-01" ;
-   rdfs:comment "Empty file" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-file-01.nq> ;
-   .
+    mf:name    "nt-syntax-file-01" ;
+    rdfs:comment "Empty file" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-file-01.nq> ;
+    .
 
 <#nt-syntax-file-02> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-file-02" ;
-   rdfs:comment "Only comment" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-file-02.nq> ;
-   .
+    mf:name    "nt-syntax-file-02" ;
+    rdfs:comment "Only comment" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-file-02.nq> ;
+    .
 
 <#nt-syntax-file-03> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-file-03" ;
-   rdfs:comment "One comment, one empty line" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-file-03.nq> ;
-   .
+    mf:name    "nt-syntax-file-03" ;
+    rdfs:comment "One comment, one empty line" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-file-03.nq> ;
+    .
 
 <#nt-syntax-uri-01> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-uri-01" ;
-   rdfs:comment "Only IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-uri-01.nq> ;
-   .
+    mf:name    "nt-syntax-uri-01" ;
+    rdfs:comment "Only IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-uri-01.nq> ;
+    .
 
 <#nt-syntax-uri-02> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-uri-02" ;
-   rdfs:comment "IRIs with Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-uri-02.nq> ;
-   .
+    mf:name    "nt-syntax-uri-02" ;
+    rdfs:comment "IRIs with Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-uri-02.nq> ;
+    .
 
 <#nt-syntax-uri-03> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-uri-03" ;
-   rdfs:comment "IRIs with long Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-uri-03.nq> ;
-   .
+    mf:name    "nt-syntax-uri-03" ;
+    rdfs:comment "IRIs with long Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-uri-03.nq> ;
+    .
 
 <#nt-syntax-uri-04> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-uri-04" ;
-   rdfs:comment "Legal IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-uri-04.nq> ;
-   .
+    mf:name    "nt-syntax-uri-04" ;
+    rdfs:comment "Legal IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-uri-04.nq> ;
+    .
 
 <#nt-syntax-string-01> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-string-01" ;
-   rdfs:comment "string literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-string-01.nq> ;
-   .
+    mf:name    "nt-syntax-string-01" ;
+    rdfs:comment "string literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-string-01.nq> ;
+    .
 
 <#nt-syntax-string-02> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-string-02" ;
-   rdfs:comment "langString literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-string-02.nq> ;
-   .
+    mf:name    "nt-syntax-string-02" ;
+    rdfs:comment "langString literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-string-02.nq> ;
+    .
 
 <#nt-syntax-string-03> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-string-03" ;
-   rdfs:comment "langString literal with region" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-string-03.nq> ;
-   .
+    mf:name    "nt-syntax-string-03" ;
+    rdfs:comment "langString literal with region" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-string-03.nq> ;
+    .
 
 <#nt-syntax-str-esc-01> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-str-esc-01" ;
-   rdfs:comment "string literal with escaped newline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-str-esc-01.nq> ;
-   .
+    mf:name    "nt-syntax-str-esc-01" ;
+    rdfs:comment "string literal with escaped newline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-str-esc-01.nq> ;
+    .
 
 <#nt-syntax-str-esc-02> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-str-esc-02" ;
-   rdfs:comment "string literal with Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-str-esc-02.nq> ;
-   .
+    mf:name    "nt-syntax-str-esc-02" ;
+    rdfs:comment "string literal with Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-str-esc-02.nq> ;
+    .
 
 <#nt-syntax-str-esc-03> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-str-esc-03" ;
-   rdfs:comment "string literal with long Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-str-esc-03.nq> ;
-   .
+    mf:name    "nt-syntax-str-esc-03" ;
+    rdfs:comment "string literal with long Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-str-esc-03.nq> ;
+    .
 
 <#nt-syntax-bnode-01> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-bnode-01" ;
-   rdfs:comment "bnode subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bnode-01.nq> ;
-   .
+    mf:name    "nt-syntax-bnode-01" ;
+    rdfs:comment "bnode subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bnode-01.nq> ;
+    .
 
 <#nt-syntax-bnode-02> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-bnode-02" ;
-   rdfs:comment "bnode object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bnode-02.nq> ;
-   .
+    mf:name    "nt-syntax-bnode-02" ;
+    rdfs:comment "bnode object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bnode-02.nq> ;
+    .
 
 <#nt-syntax-bnode-03> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-bnode-03" ;
-   rdfs:comment "Blank node labels may start with a digit" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bnode-03.nq> ;
-   .
+    mf:name    "nt-syntax-bnode-03" ;
+    rdfs:comment "Blank node labels may start with a digit" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bnode-03.nq> ;
+    .
 
 <#nt-syntax-datatypes-01> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-datatypes-01" ;
-   rdfs:comment "xsd:byte literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-datatypes-01.nq> ;
-   .
+    mf:name    "nt-syntax-datatypes-01" ;
+    rdfs:comment "xsd:byte literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-datatypes-01.nq> ;
+    .
 
 <#nt-syntax-datatypes-02> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-datatypes-02" ;
-   rdfs:comment "integer as xsd:string" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-datatypes-02.nq> ;
-   .
+    mf:name    "nt-syntax-datatypes-02" ;
+    rdfs:comment "integer as xsd:string" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-datatypes-02.nq> ;
+    .
 
 <#nt-syntax-bad-uri-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-01" ;
-   rdfs:comment "Bad IRI : space (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-uri-01.nq> ;
-   .
+    mf:name    "nt-syntax-bad-uri-01" ;
+    rdfs:comment "Bad IRI : space (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-uri-01.nq> ;
+    .
 
 <#nt-syntax-bad-uri-02> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-02" ;
-   rdfs:comment "Bad IRI : bad escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-uri-02.nq> ;
-   .
+    mf:name    "nt-syntax-bad-uri-02" ;
+    rdfs:comment "Bad IRI : bad escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-uri-02.nq> ;
+    .
 
 <#nt-syntax-bad-uri-03> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-03" ;
-   rdfs:comment "Bad IRI : bad long escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-uri-03.nq> ;
-   .
+    mf:name    "nt-syntax-bad-uri-03" ;
+    rdfs:comment "Bad IRI : bad long escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-uri-03.nq> ;
+    .
 
 <#nt-syntax-bad-uri-04> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-04" ;
-   rdfs:comment "Bad IRI : character escapes not allowed (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-uri-04.nq> ;
-   .
+    mf:name    "nt-syntax-bad-uri-04" ;
+    rdfs:comment "Bad IRI : character escapes not allowed (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-uri-04.nq> ;
+    .
 
 <#nt-syntax-bad-uri-05> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-05" ;
-   rdfs:comment "Bad IRI : character escapes not allowed (2) (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-uri-05.nq> ;
-   .
+    mf:name    "nt-syntax-bad-uri-05" ;
+    rdfs:comment "Bad IRI : character escapes not allowed (2) (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-uri-05.nq> ;
+    .
 
 <#nt-syntax-bad-uri-06> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-06" ;
-   rdfs:comment "Bad IRI : relative IRI not allowed in subject (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-uri-06.nq> ;
-   .
+    mf:name    "nt-syntax-bad-uri-06" ;
+    rdfs:comment "Bad IRI : relative IRI not allowed in subject (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-uri-06.nq> ;
+    .
 
 <#nt-syntax-bad-uri-07> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-07" ;
-   rdfs:comment "Bad IRI : relative IRI not allowed in predicate (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-uri-07.nq> ;
-   .
+    mf:name    "nt-syntax-bad-uri-07" ;
+    rdfs:comment "Bad IRI : relative IRI not allowed in predicate (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-uri-07.nq> ;
+    .
 
 <#nt-syntax-bad-uri-08> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-08" ;
-   rdfs:comment "Bad IRI : relative IRI not allowed in object (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-uri-08.nq> ;
-   .
+    mf:name    "nt-syntax-bad-uri-08" ;
+    rdfs:comment "Bad IRI : relative IRI not allowed in object (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-uri-08.nq> ;
+    .
 
 <#nt-syntax-bad-uri-09> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-09" ;
-   rdfs:comment "Bad IRI : relative IRI not allowed in datatype (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-uri-09.nq> ;
-   .
+    mf:name    "nt-syntax-bad-uri-09" ;
+    rdfs:comment "Bad IRI : relative IRI not allowed in datatype (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-uri-09.nq> ;
+    .
 
 <#nt-syntax-bad-prefix-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-prefix-01" ;
-   rdfs:comment "@prefix not allowed in N-Quads (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-prefix-01.nq> ;
-   .
+    mf:name    "nt-syntax-bad-prefix-01" ;
+    rdfs:comment "@prefix not allowed in N-Quads (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-prefix-01.nq> ;
+    .
 
 <#nt-syntax-bad-base-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-base-01" ;
-   rdfs:comment "@base not allowed in N-Quads (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-base-01.nq> ;
-   .
+    mf:name    "nt-syntax-bad-base-01" ;
+    rdfs:comment "@base not allowed in N-Quads (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-base-01.nq> ;
+    .
 
 <#nt-syntax-bad-bnode-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name      "nt-syntax-bad-bnode-01" ;
-   rdfs:comment "Colon in bnode label not allowed (negative test)" ;
-   mf:action    <nt-syntax-bad-bnode-01.nq> ;
-   .
+    mf:name      "nt-syntax-bad-bnode-01" ;
+    rdfs:comment "Colon in bnode label not allowed (negative test)" ;
+    mf:action    <nt-syntax-bad-bnode-01.nq> ;
+    .
 
 <#nt-syntax-bad-bnode-02> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name      "nt-syntax-bad-bnode-02" ;
-   rdfs:comment "Colon in bnode label not allowed (negative test)" ;
-   mf:action    <nt-syntax-bad-bnode-02.nq> ;
-   .
+    mf:name      "nt-syntax-bad-bnode-02" ;
+    rdfs:comment "Colon in bnode label not allowed (negative test)" ;
+    mf:action    <nt-syntax-bad-bnode-02.nq> ;
+    .
 
 <#nt-syntax-bad-struct-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-struct-01" ;
-   rdfs:comment "N-Quads does not have objectList (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-struct-01.nq> ;
-   .
+    mf:name    "nt-syntax-bad-struct-01" ;
+    rdfs:comment "N-Quads does not have objectList (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-struct-01.nq> ;
+    .
 
 <#nt-syntax-bad-struct-02> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-struct-02" ;
-   rdfs:comment "N-Quads does not have predicateObjectList (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-struct-02.nq> ;
-   .
+    mf:name    "nt-syntax-bad-struct-02" ;
+    rdfs:comment "N-Quads does not have predicateObjectList (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-struct-02.nq> ;
+    .
 
 <#nt-syntax-bad-lang-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-lang-01" ;
-   rdfs:comment "langString with bad lang (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-lang-01.nq> ;
-   .
+    mf:name    "nt-syntax-bad-lang-01" ;
+    rdfs:comment "langString with bad lang (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-lang-01.nq> ;
+    .
 
 <#nt-syntax-bad-esc-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-esc-01" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-esc-01.nq> ;
-   .
+    mf:name    "nt-syntax-bad-esc-01" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-esc-01.nq> ;
+    .
 
 <#nt-syntax-bad-esc-02> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-esc-02" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-esc-02.nq> ;
-   .
+    mf:name    "nt-syntax-bad-esc-02" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-esc-02.nq> ;
+    .
 
 <#nt-syntax-bad-esc-03> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-esc-03" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-esc-03.nq> ;
-   .
+    mf:name    "nt-syntax-bad-esc-03" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-esc-03.nq> ;
+    .
 
 <#nt-syntax-bad-string-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-01" ;
-   rdfs:comment "mismatching string literal open/close (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-string-01.nq> ;
-   .
+    mf:name    "nt-syntax-bad-string-01" ;
+    rdfs:comment "mismatching string literal open/close (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-string-01.nq> ;
+    .
 
 <#nt-syntax-bad-string-02> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-02" ;
-   rdfs:comment "mismatching string literal open/close (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-string-02.nq> ;
-   .
+    mf:name    "nt-syntax-bad-string-02" ;
+    rdfs:comment "mismatching string literal open/close (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-string-02.nq> ;
+    .
 
 <#nt-syntax-bad-string-03> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-03" ;
-   rdfs:comment "single quotes (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-string-03.nq> ;
-   .
+    mf:name    "nt-syntax-bad-string-03" ;
+    rdfs:comment "single quotes (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-string-03.nq> ;
+    .
 
 <#nt-syntax-bad-string-04> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-04" ;
-   rdfs:comment "long single string literal (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-string-04.nq> ;
-   .
+    mf:name    "nt-syntax-bad-string-04" ;
+    rdfs:comment "long single string literal (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-string-04.nq> ;
+    .
 
 <#nt-syntax-bad-string-05> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-05" ;
-   rdfs:comment "long double string literal (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-string-05.nq> ;
-   .
+    mf:name    "nt-syntax-bad-string-05" ;
+    rdfs:comment "long double string literal (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-string-05.nq> ;
+    .
 
 <#nt-syntax-bad-string-06> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-06" ;
-   rdfs:comment "string literal with no end (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-string-06.nq> ;
-   .
+    mf:name    "nt-syntax-bad-string-06" ;
+    rdfs:comment "string literal with no end (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-string-06.nq> ;
+    .
 
 <#nt-syntax-bad-string-07> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-07" ;
-   rdfs:comment "string literal with no start (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-string-07.nq> ;
-   .
+    mf:name    "nt-syntax-bad-string-07" ;
+    rdfs:comment "string literal with no start (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-string-07.nq> ;
+    .
 
 <#nt-syntax-bad-num-01> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-num-01" ;
-   rdfs:comment "no numbers in N-Quads (integer) (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-num-01.nq> ;
-   .
+    mf:name    "nt-syntax-bad-num-01" ;
+    rdfs:comment "no numbers in N-Quads (integer) (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-num-01.nq> ;
+    .
 
 <#nt-syntax-bad-num-02> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-num-02" ;
-   rdfs:comment "no numbers in N-Quads (decimal) (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-num-02.nq> ;
-   .
+    mf:name    "nt-syntax-bad-num-02" ;
+    rdfs:comment "no numbers in N-Quads (decimal) (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-num-02.nq> ;
+    .
 
 <#nt-syntax-bad-num-03> a rdft:TestNQuadsNegativeSyntax ;
-   mf:name    "nt-syntax-bad-num-03" ;
-   rdfs:comment "no numbers in N-Quads (float) (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-bad-num-03.nq> ;
-   .
+    mf:name    "nt-syntax-bad-num-03" ;
+    rdfs:comment "no numbers in N-Quads (float) (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-bad-num-03.nq> ;
+    .
 
 <#nt-syntax-subm-01> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "nt-syntax-subm-01" ;
-   rdfs:comment "Submission test from Original RDF Test Cases" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nt-syntax-subm-01.nq> ;
-   .
+    mf:name    "nt-syntax-subm-01" ;
+    rdfs:comment "Submission test from Original RDF Test Cases" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nt-syntax-subm-01.nq> ;
+    .
 
 <#comment_following_triple> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "comment_following_triple" ;
-   rdfs:comment "Tests comments after a triple" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <comment_following_triple.nq> ;
-   .
+    mf:name      "comment_following_triple" ;
+    rdfs:comment "Tests comments after a triple" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <comment_following_triple.nq> ;
+    .
 
 <#literal_ascii_boundaries> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_ascii_boundaries" ;
-   rdfs:comment "literal_ascii_boundaries '\\x00\\x26\\x28...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_ascii_boundaries.nq> ;
-   .
+    mf:name      "literal_ascii_boundaries" ;
+    rdfs:comment "literal_ascii_boundaries '\\x00\\x26\\x28...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_ascii_boundaries.nq> ;
+    .
 
 <#literal_with_UTF8_boundaries> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_UTF8_boundaries" ;
-   rdfs:comment "literal_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_UTF8_boundaries.nq> ;
-   .
+    mf:name      "literal_with_UTF8_boundaries" ;
+    rdfs:comment "literal_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_UTF8_boundaries.nq> ;
+    .
 
 <#literal_all_controls> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_all_controls" ;
-   rdfs:comment "literal_all_controls '\\x00\\x01\\x02\\x03\\x04...'" ;
-   rdft:approval rdft:Approved ;
-   rdft:approval rdft:Approved ;
-   mf:action   <literal_all_controls.nq> ;
-   .
+    mf:name      "literal_all_controls" ;
+    rdfs:comment "literal_all_controls '\\x00\\x01\\x02\\x03\\x04...'" ;
+    rdft:approval rdft:Approved ;
+    rdft:approval rdft:Approved ;
+    mf:action   <literal_all_controls.nq> ;
+    .
 
 <#literal_all_punctuation> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_all_punctuation" ;
-   rdfs:comment "literal_all_punctuation '!\"#$%&()...'" ;
-   rdft:approval rdft:Approved ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_all_punctuation.nq> ;
-   .
+    mf:name      "literal_all_punctuation" ;
+    rdfs:comment "literal_all_punctuation '!\"#$%&()...'" ;
+    rdft:approval rdft:Approved ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_all_punctuation.nq> ;
+    .
 
 <#literal_with_squote> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_squote" ;
-   rdfs:comment "literal with squote \"x'y\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_squote.nq> ;
-   .
+    mf:name      "literal_with_squote" ;
+    rdfs:comment "literal with squote \"x'y\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_squote.nq> ;
+    .
 
 <#literal_with_2_squotes> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_2_squotes" ;
-   rdfs:comment "literal with 2 squotes \"x''y\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_2_squotes.nq> ;
-   .
+    mf:name      "literal_with_2_squotes" ;
+    rdfs:comment "literal with 2 squotes \"x''y\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_2_squotes.nq> ;
+    .
 
 <#literal> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal" ;
-   rdfs:comment "literal \"\"\"x\"\"\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal.nq> ;
-   .
+    mf:name      "literal" ;
+    rdfs:comment "literal \"\"\"x\"\"\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal.nq> ;
+    .
 
 <#literal_with_dquote> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_dquote" ;
-   rdfs:comment 'literal with dquote "x\"y"' ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_dquote.nq> ;
-   .
+    mf:name      "literal_with_dquote" ;
+    rdfs:comment 'literal with dquote "x\"y"' ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_dquote.nq> ;
+    .
 
 <#literal_with_2_dquotes> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_2_dquotes" ;
-   rdfs:comment "literal with 2 squotes \"\"\"a\"\"b\"\"\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_2_dquotes.nq> ;
-   .
+    mf:name      "literal_with_2_dquotes" ;
+    rdfs:comment "literal with 2 squotes \"\"\"a\"\"b\"\"\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_2_dquotes.nq> ;
+    .
 
 <#literal_with_REVERSE_SOLIDUS2> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name    "literal_with_REVERSE_SOLIDUS2" ;
-   rdfs:comment "REVERSE SOLIDUS at end of literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_REVERSE_SOLIDUS2.nq> ;
-   .
+    mf:name    "literal_with_REVERSE_SOLIDUS2" ;
+    rdfs:comment "REVERSE SOLIDUS at end of literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_REVERSE_SOLIDUS2.nq> ;
+    .
 
 <#literal_with_CHARACTER_TABULATION> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_CHARACTER_TABULATION" ;
-   rdfs:comment "literal with CHARACTER TABULATION" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_CHARACTER_TABULATION.nq> ;
-   .
+    mf:name      "literal_with_CHARACTER_TABULATION" ;
+    rdfs:comment "literal with CHARACTER TABULATION" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_CHARACTER_TABULATION.nq> ;
+    .
 
 <#literal_with_BACKSPACE> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_BACKSPACE" ;
-   rdfs:comment "literal with BACKSPACE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_BACKSPACE.nq> ;
-   .
+    mf:name      "literal_with_BACKSPACE" ;
+    rdfs:comment "literal with BACKSPACE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_BACKSPACE.nq> ;
+    .
 
 <#literal_with_LINE_FEED> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_LINE_FEED" ;
-   rdfs:comment "literal with LINE FEED" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_LINE_FEED.nq> ;
-   .
+    mf:name      "literal_with_LINE_FEED" ;
+    rdfs:comment "literal with LINE FEED" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_LINE_FEED.nq> ;
+    .
 
 <#literal_with_CARRIAGE_RETURN> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_CARRIAGE_RETURN" ;
-   rdfs:comment "literal with CARRIAGE RETURN" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_CARRIAGE_RETURN.nq> ;
-   .
+    mf:name      "literal_with_CARRIAGE_RETURN" ;
+    rdfs:comment "literal with CARRIAGE RETURN" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_CARRIAGE_RETURN.nq> ;
+    .
 
 <#literal_with_FORM_FEED> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_FORM_FEED" ;
-   rdfs:comment "literal with FORM FEED" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_FORM_FEED.nq> ;
-   .
+    mf:name      "literal_with_FORM_FEED" ;
+    rdfs:comment "literal with FORM FEED" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_FORM_FEED.nq> ;
+    .
 
 <#literal_with_REVERSE_SOLIDUS> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_REVERSE_SOLIDUS" ;
-   rdfs:comment "literal with REVERSE SOLIDUS" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_REVERSE_SOLIDUS.nq> ;
-   .
+    mf:name      "literal_with_REVERSE_SOLIDUS" ;
+    rdfs:comment "literal with REVERSE SOLIDUS" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_REVERSE_SOLIDUS.nq> ;
+    .
 
 <#literal_with_numeric_escape4> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_numeric_escape4" ;
-   rdfs:comment "literal with numeric escape4 \\u" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_numeric_escape4.nq> ;
-   .
+    mf:name      "literal_with_numeric_escape4" ;
+    rdfs:comment "literal with numeric escape4 \\u" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_numeric_escape4.nq> ;
+    .
 
 <#literal_with_numeric_escape8> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "literal_with_numeric_escape8" ;
-   rdfs:comment "literal with numeric escape8 \\U" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_numeric_escape8.nq> ;
-   .
+    mf:name      "literal_with_numeric_escape8" ;
+    rdfs:comment "literal with numeric escape8 \\U" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_numeric_escape8.nq> ;
+    .
 
 <#langtagged_string> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "langtagged_string" ;
-   rdfs:comment "langtagged string \"x\"@en" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <langtagged_string.nq> ;
-   .
+    mf:name      "langtagged_string" ;
+    rdfs:comment "langtagged string \"x\"@en" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <langtagged_string.nq> ;
+    .
 
 <#lantag_with_subtag> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "lantag_with_subtag" ;
-   rdfs:comment "lantag with subtag \"x\"@en-us" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <lantag_with_subtag.nq> ;
-   .
+    mf:name      "lantag_with_subtag" ;
+    rdfs:comment "lantag with subtag \"x\"@en-us" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <lantag_with_subtag.nq> ;
+    .
 
 <#minimal_whitespace> a rdft:TestNQuadsPositiveSyntax ;
-   mf:name      "minimal_whitespace" ;
-   rdfs:comment "tests absense of whitespace between subject, predicate, object and end-of-statement" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <minimal_whitespace.nq> ;
-   .
+    mf:name      "minimal_whitespace" ;
+    rdfs:comment "tests absense of whitespace between subject, predicate, object and end-of-statement" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <minimal_whitespace.nq> ;
+    .

--- a/rdf/rdf11/rdf-n-triples/manifest.ttl
+++ b/rdf/rdf11/rdf-n-triples/manifest.ttl
@@ -84,443 +84,443 @@
     ) .
 
 <#nt-syntax-file-01> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-file-01" ;
-   rdfs:comment "Empty file" ;
-   mf:action    <nt-syntax-file-01.nt> ;
-   .
+    mf:name    "nt-syntax-file-01" ;
+    rdfs:comment "Empty file" ;
+    mf:action    <nt-syntax-file-01.nt> ;
+    .
 
 <#nt-syntax-file-02> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-file-02" ;
-   rdfs:comment "Only comment" ;
-   mf:action    <nt-syntax-file-02.nt> ;
-   .
+    mf:name    "nt-syntax-file-02" ;
+    rdfs:comment "Only comment" ;
+    mf:action    <nt-syntax-file-02.nt> ;
+    .
 
 <#nt-syntax-file-03> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-file-03" ;
-   rdfs:comment "One comment, one empty line" ;
-   mf:action    <nt-syntax-file-03.nt> ;
-   .
+    mf:name    "nt-syntax-file-03" ;
+    rdfs:comment "One comment, one empty line" ;
+    mf:action    <nt-syntax-file-03.nt> ;
+    .
 
 <#nt-syntax-uri-01> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-uri-01" ;
-   rdfs:comment "Only IRIs" ;
-   mf:action    <nt-syntax-uri-01.nt> ;
-   .
+    mf:name    "nt-syntax-uri-01" ;
+    rdfs:comment "Only IRIs" ;
+    mf:action    <nt-syntax-uri-01.nt> ;
+    .
 
 <#nt-syntax-uri-02> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-uri-02" ;
-   rdfs:comment "IRIs with Unicode escape" ;
-   mf:action    <nt-syntax-uri-02.nt> ;
-   .
+    mf:name    "nt-syntax-uri-02" ;
+    rdfs:comment "IRIs with Unicode escape" ;
+    mf:action    <nt-syntax-uri-02.nt> ;
+    .
 
 <#nt-syntax-uri-03> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-uri-03" ;
-   rdfs:comment "IRIs with long Unicode escape" ;
-   mf:action    <nt-syntax-uri-03.nt> ;
-   .
+    mf:name    "nt-syntax-uri-03" ;
+    rdfs:comment "IRIs with long Unicode escape" ;
+    mf:action    <nt-syntax-uri-03.nt> ;
+    .
 
 <#nt-syntax-uri-04> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-uri-04" ;
-   rdfs:comment "Legal IRIs" ;
-   mf:action    <nt-syntax-uri-04.nt> ;
-   .
+    mf:name    "nt-syntax-uri-04" ;
+    rdfs:comment "Legal IRIs" ;
+    mf:action    <nt-syntax-uri-04.nt> ;
+    .
 
 <#nt-syntax-string-01> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-string-01" ;
-   rdfs:comment "string literal" ;
-   mf:action    <nt-syntax-string-01.nt> ;
-   .
+    mf:name    "nt-syntax-string-01" ;
+    rdfs:comment "string literal" ;
+    mf:action    <nt-syntax-string-01.nt> ;
+    .
 
 <#nt-syntax-string-02> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-string-02" ;
-   rdfs:comment "langString literal" ;
-   mf:action    <nt-syntax-string-02.nt> ;
-   .
+    mf:name    "nt-syntax-string-02" ;
+    rdfs:comment "langString literal" ;
+    mf:action    <nt-syntax-string-02.nt> ;
+    .
 
 <#nt-syntax-string-03> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-string-03" ;
-   rdfs:comment "langString literal with region" ;
-   mf:action    <nt-syntax-string-03.nt> ;
-   .
+    mf:name    "nt-syntax-string-03" ;
+    rdfs:comment "langString literal with region" ;
+    mf:action    <nt-syntax-string-03.nt> ;
+    .
 
 <#nt-syntax-str-esc-01> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-str-esc-01" ;
-   rdfs:comment "string literal with escaped newline" ;
-   mf:action    <nt-syntax-str-esc-01.nt> ;
-   .
+    mf:name    "nt-syntax-str-esc-01" ;
+    rdfs:comment "string literal with escaped newline" ;
+    mf:action    <nt-syntax-str-esc-01.nt> ;
+    .
 
 <#nt-syntax-str-esc-02> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-str-esc-02" ;
-   rdfs:comment "string literal with Unicode escape" ;
-   mf:action    <nt-syntax-str-esc-02.nt> ;
-   .
+    mf:name    "nt-syntax-str-esc-02" ;
+    rdfs:comment "string literal with Unicode escape" ;
+    mf:action    <nt-syntax-str-esc-02.nt> ;
+    .
 
 <#nt-syntax-str-esc-03> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-str-esc-03" ;
-   rdfs:comment "string literal with long Unicode escape" ;
-   mf:action    <nt-syntax-str-esc-03.nt> ;
-   .
+    mf:name    "nt-syntax-str-esc-03" ;
+    rdfs:comment "string literal with long Unicode escape" ;
+    mf:action    <nt-syntax-str-esc-03.nt> ;
+    .
 
 <#nt-syntax-bnode-01> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-bnode-01" ;
-   rdfs:comment "bnode subject" ;
-   mf:action    <nt-syntax-bnode-01.nt> ;
-   .
+    mf:name    "nt-syntax-bnode-01" ;
+    rdfs:comment "bnode subject" ;
+    mf:action    <nt-syntax-bnode-01.nt> ;
+    .
 
 <#nt-syntax-bnode-02> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-bnode-02" ;
-   rdfs:comment "bnode object" ;
-   mf:action    <nt-syntax-bnode-02.nt> ;
-   .
+    mf:name    "nt-syntax-bnode-02" ;
+    rdfs:comment "bnode object" ;
+    mf:action    <nt-syntax-bnode-02.nt> ;
+    .
 
 <#nt-syntax-bnode-03> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-bnode-03" ;
-   rdfs:comment "Blank node labels may start with a digit" ;
-   mf:action    <nt-syntax-bnode-03.nt> ;
-   .
+    mf:name    "nt-syntax-bnode-03" ;
+    rdfs:comment "Blank node labels may start with a digit" ;
+    mf:action    <nt-syntax-bnode-03.nt> ;
+    .
 
 <#nt-syntax-datatypes-01> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-datatypes-01" ;
-   rdfs:comment "xsd:byte literal" ;
-   mf:action    <nt-syntax-datatypes-01.nt> ;
-   .
+    mf:name    "nt-syntax-datatypes-01" ;
+    rdfs:comment "xsd:byte literal" ;
+    mf:action    <nt-syntax-datatypes-01.nt> ;
+    .
 
 <#nt-syntax-datatypes-02> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-datatypes-02" ;
-   rdfs:comment "integer as xsd:string" ;
-   mf:action    <nt-syntax-datatypes-02.nt> ;
-   .
+    mf:name    "nt-syntax-datatypes-02" ;
+    rdfs:comment "integer as xsd:string" ;
+    mf:action    <nt-syntax-datatypes-02.nt> ;
+    .
 
 <#nt-syntax-bad-uri-01> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-01" ;
-   rdfs:comment "Bad IRI : space (negative test)" ;
-   mf:action    <nt-syntax-bad-uri-01.nt> ;
-   .
+    mf:name    "nt-syntax-bad-uri-01" ;
+    rdfs:comment "Bad IRI : space (negative test)" ;
+    mf:action    <nt-syntax-bad-uri-01.nt> ;
+    .
 
 <#nt-syntax-bad-uri-02> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-02" ;
-   rdfs:comment "Bad IRI : bad escape (negative test)" ;
-   mf:action    <nt-syntax-bad-uri-02.nt> ;
-   .
+    mf:name    "nt-syntax-bad-uri-02" ;
+    rdfs:comment "Bad IRI : bad escape (negative test)" ;
+    mf:action    <nt-syntax-bad-uri-02.nt> ;
+    .
 
 <#nt-syntax-bad-uri-03> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-03" ;
-   rdfs:comment "Bad IRI : bad long escape (negative test)" ;
-   mf:action    <nt-syntax-bad-uri-03.nt> ;
-   .
+    mf:name    "nt-syntax-bad-uri-03" ;
+    rdfs:comment "Bad IRI : bad long escape (negative test)" ;
+    mf:action    <nt-syntax-bad-uri-03.nt> ;
+    .
 
 <#nt-syntax-bad-uri-04> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-04" ;
-   rdfs:comment "Bad IRI : character escapes not allowed (negative test)" ;
-   mf:action    <nt-syntax-bad-uri-04.nt> ;
-   .
+    mf:name    "nt-syntax-bad-uri-04" ;
+    rdfs:comment "Bad IRI : character escapes not allowed (negative test)" ;
+    mf:action    <nt-syntax-bad-uri-04.nt> ;
+    .
 
 <#nt-syntax-bad-uri-05> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-05" ;
-   rdfs:comment "Bad IRI : character escapes not allowed (2) (negative test)" ;
-   mf:action    <nt-syntax-bad-uri-05.nt> ;
-   .
+    mf:name    "nt-syntax-bad-uri-05" ;
+    rdfs:comment "Bad IRI : character escapes not allowed (2) (negative test)" ;
+    mf:action    <nt-syntax-bad-uri-05.nt> ;
+    .
 
 <#nt-syntax-bad-uri-06> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-06" ;
-   rdfs:comment "Bad IRI : relative IRI not allowed in subject (negative test)" ;
-   mf:action    <nt-syntax-bad-uri-06.nt> ;
-   .
+    mf:name    "nt-syntax-bad-uri-06" ;
+    rdfs:comment "Bad IRI : relative IRI not allowed in subject (negative test)" ;
+    mf:action    <nt-syntax-bad-uri-06.nt> ;
+    .
 
 <#nt-syntax-bad-uri-07> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-07" ;
-   rdfs:comment "Bad IRI : relative IRI not allowed in predicate (negative test)" ;
-   mf:action    <nt-syntax-bad-uri-07.nt> ;
-   .
+    mf:name    "nt-syntax-bad-uri-07" ;
+    rdfs:comment "Bad IRI : relative IRI not allowed in predicate (negative test)" ;
+    mf:action    <nt-syntax-bad-uri-07.nt> ;
+    .
 
 <#nt-syntax-bad-uri-08> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-08" ;
-   rdfs:comment "Bad IRI : relative IRI not allowed in object (negative test)" ;
-   mf:action    <nt-syntax-bad-uri-08.nt> ;
-   .
+    mf:name    "nt-syntax-bad-uri-08" ;
+    rdfs:comment "Bad IRI : relative IRI not allowed in object (negative test)" ;
+    mf:action    <nt-syntax-bad-uri-08.nt> ;
+    .
 
 <#nt-syntax-bad-uri-09> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-uri-09" ;
-   rdfs:comment "Bad IRI : relative IRI not allowed in datatype (negative test)" ;
-   mf:action    <nt-syntax-bad-uri-09.nt> ;
-   .
+    mf:name    "nt-syntax-bad-uri-09" ;
+    rdfs:comment "Bad IRI : relative IRI not allowed in datatype (negative test)" ;
+    mf:action    <nt-syntax-bad-uri-09.nt> ;
+    .
 
 <#nt-syntax-bad-prefix-01> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-prefix-01" ;
-   rdfs:comment "@prefix not allowed in n-triples (negative test)" ;
-   mf:action    <nt-syntax-bad-prefix-01.nt> ;
-   .
+    mf:name    "nt-syntax-bad-prefix-01" ;
+    rdfs:comment "@prefix not allowed in n-triples (negative test)" ;
+    mf:action    <nt-syntax-bad-prefix-01.nt> ;
+    .
 
 <#nt-syntax-bad-base-01> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-base-01" ;
-   rdfs:comment "@base not allowed in N-Triples (negative test)" ;
-   mf:action    <nt-syntax-bad-base-01.nt> ;
-   .
+    mf:name    "nt-syntax-bad-base-01" ;
+    rdfs:comment "@base not allowed in N-Triples (negative test)" ;
+    mf:action    <nt-syntax-bad-base-01.nt> ;
+    .
 
 <#nt-syntax-bad-bnode-01> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name      "nt-syntax-bad-bnode-01" ;
-   rdfs:comment "Colon in bnode label not allowed (negative test)" ;
-   mf:action    <nt-syntax-bad-bnode-01.nt> ;
-   .
+    mf:name      "nt-syntax-bad-bnode-01" ;
+    rdfs:comment "Colon in bnode label not allowed (negative test)" ;
+    mf:action    <nt-syntax-bad-bnode-01.nt> ;
+    .
 
 <#nt-syntax-bad-bnode-02> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name      "nt-syntax-bad-bnode-02" ;
-   rdfs:comment "Colon in bnode label not allowed (negative test)" ;
-   mf:action    <nt-syntax-bad-bnode-02.nt> ;
-   .
+    mf:name      "nt-syntax-bad-bnode-02" ;
+    rdfs:comment "Colon in bnode label not allowed (negative test)" ;
+    mf:action    <nt-syntax-bad-bnode-02.nt> ;
+    .
 
 <#nt-syntax-bad-struct-01> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-struct-01" ;
-   rdfs:comment "N-Triples does not have objectList (negative test)" ;
-   mf:action    <nt-syntax-bad-struct-01.nt> ;
-   .
+    mf:name    "nt-syntax-bad-struct-01" ;
+    rdfs:comment "N-Triples does not have objectList (negative test)" ;
+    mf:action    <nt-syntax-bad-struct-01.nt> ;
+    .
 
 <#nt-syntax-bad-struct-02> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-struct-02" ;
-   rdfs:comment "N-Triples does not have predicateObjectList (negative test)" ;
-   mf:action    <nt-syntax-bad-struct-02.nt> ;
-   .
+    mf:name    "nt-syntax-bad-struct-02" ;
+    rdfs:comment "N-Triples does not have predicateObjectList (negative test)" ;
+    mf:action    <nt-syntax-bad-struct-02.nt> ;
+    .
 
 <#nt-syntax-bad-lang-01> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-lang-01" ;
-   rdfs:comment "langString with bad lang (negative test)" ;
-   mf:action    <nt-syntax-bad-lang-01.nt> ;
-   .
+    mf:name    "nt-syntax-bad-lang-01" ;
+    rdfs:comment "langString with bad lang (negative test)" ;
+    mf:action    <nt-syntax-bad-lang-01.nt> ;
+    .
 
 <#nt-syntax-bad-esc-01> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-esc-01" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   mf:action    <nt-syntax-bad-esc-01.nt> ;
-   .
+    mf:name    "nt-syntax-bad-esc-01" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    mf:action    <nt-syntax-bad-esc-01.nt> ;
+    .
 
 <#nt-syntax-bad-esc-02> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-esc-02" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   mf:action    <nt-syntax-bad-esc-02.nt> ;
-   .
+    mf:name    "nt-syntax-bad-esc-02" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    mf:action    <nt-syntax-bad-esc-02.nt> ;
+    .
 
 <#nt-syntax-bad-esc-03> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-esc-03" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   mf:action    <nt-syntax-bad-esc-03.nt> ;
-   .
+    mf:name    "nt-syntax-bad-esc-03" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    mf:action    <nt-syntax-bad-esc-03.nt> ;
+    .
 
 <#nt-syntax-bad-string-01> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-01" ;
-   rdfs:comment "mismatching string literal open/close (negative test)" ;
-   mf:action    <nt-syntax-bad-string-01.nt> ;
-   .
+    mf:name    "nt-syntax-bad-string-01" ;
+    rdfs:comment "mismatching string literal open/close (negative test)" ;
+    mf:action    <nt-syntax-bad-string-01.nt> ;
+    .
 
 <#nt-syntax-bad-string-02> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-02" ;
-   rdfs:comment "mismatching string literal open/close (negative test)" ;
-   mf:action    <nt-syntax-bad-string-02.nt> ;
-   .
+    mf:name    "nt-syntax-bad-string-02" ;
+    rdfs:comment "mismatching string literal open/close (negative test)" ;
+    mf:action    <nt-syntax-bad-string-02.nt> ;
+    .
 
 <#nt-syntax-bad-string-03> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-03" ;
-   rdfs:comment "single quotes (negative test)" ;
-   mf:action    <nt-syntax-bad-string-03.nt> ;
-   .
+    mf:name    "nt-syntax-bad-string-03" ;
+    rdfs:comment "single quotes (negative test)" ;
+    mf:action    <nt-syntax-bad-string-03.nt> ;
+    .
 
 <#nt-syntax-bad-string-04> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-04" ;
-   rdfs:comment "long single string literal (negative test)" ;
-   mf:action    <nt-syntax-bad-string-04.nt> ;
-   .
+    mf:name    "nt-syntax-bad-string-04" ;
+    rdfs:comment "long single string literal (negative test)" ;
+    mf:action    <nt-syntax-bad-string-04.nt> ;
+    .
 
 <#nt-syntax-bad-string-05> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-05" ;
-   rdfs:comment "long double string literal (negative test)" ;
-   mf:action    <nt-syntax-bad-string-05.nt> ;
-   .
+    mf:name    "nt-syntax-bad-string-05" ;
+    rdfs:comment "long double string literal (negative test)" ;
+    mf:action    <nt-syntax-bad-string-05.nt> ;
+    .
 
 <#nt-syntax-bad-string-06> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-06" ;
-   rdfs:comment "string literal with no end (negative test)" ;
-   mf:action    <nt-syntax-bad-string-06.nt> ;
-   .
+    mf:name    "nt-syntax-bad-string-06" ;
+    rdfs:comment "string literal with no end (negative test)" ;
+    mf:action    <nt-syntax-bad-string-06.nt> ;
+    .
 
 <#nt-syntax-bad-string-07> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-string-07" ;
-   rdfs:comment "string literal with no start (negative test)" ;
-   mf:action    <nt-syntax-bad-string-07.nt> ;
-   .
+    mf:name    "nt-syntax-bad-string-07" ;
+    rdfs:comment "string literal with no start (negative test)" ;
+    mf:action    <nt-syntax-bad-string-07.nt> ;
+    .
 
 <#nt-syntax-bad-num-01> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-num-01" ;
-   rdfs:comment "no numbers in N-Triples (integer) (negative test)" ;
-   mf:action    <nt-syntax-bad-num-01.nt> ;
-   .
+    mf:name    "nt-syntax-bad-num-01" ;
+    rdfs:comment "no numbers in N-Triples (integer) (negative test)" ;
+    mf:action    <nt-syntax-bad-num-01.nt> ;
+    .
 
 <#nt-syntax-bad-num-02> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-num-02" ;
-   rdfs:comment "no numbers in N-Triples (decimal) (negative test)" ;
-   mf:action    <nt-syntax-bad-num-02.nt> ;
-   .
+    mf:name    "nt-syntax-bad-num-02" ;
+    rdfs:comment "no numbers in N-Triples (decimal) (negative test)" ;
+    mf:action    <nt-syntax-bad-num-02.nt> ;
+    .
 
 <#nt-syntax-bad-num-03> rdf:type rdft:TestNTriplesNegativeSyntax ;
-   mf:name    "nt-syntax-bad-num-03" ;
-   rdfs:comment "no numbers in N-Triples (float) (negative test)" ;
-   mf:action    <nt-syntax-bad-num-03.nt> ;
-   .
+    mf:name    "nt-syntax-bad-num-03" ;
+    rdfs:comment "no numbers in N-Triples (float) (negative test)" ;
+    mf:action    <nt-syntax-bad-num-03.nt> ;
+    .
 
 <#nt-syntax-subm-01> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "nt-syntax-subm-01" ;
-   rdfs:comment "Submission test from Original RDF Test Cases" ;
-   mf:action    <nt-syntax-subm-01.nt> ;
-   .
+    mf:name    "nt-syntax-subm-01" ;
+    rdfs:comment "Submission test from Original RDF Test Cases" ;
+    mf:action    <nt-syntax-subm-01.nt> ;
+    .
 
 <#comment_following_triple> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "comment_following_triple" ;
-   rdfs:comment "Tests comments after a triple" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <comment_following_triple.nt> ;
-   .
+    mf:name      "comment_following_triple" ;
+    rdfs:comment "Tests comments after a triple" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <comment_following_triple.nt> ;
+    .
 
 <#literal_ascii_boundaries> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_ascii_boundaries" ;
-   rdfs:comment "literal_ascii_boundaries '\\x00\\x26\\x28...'" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_ascii_boundaries.nt> ;
-   .
+    mf:name      "literal_ascii_boundaries" ;
+    rdfs:comment "literal_ascii_boundaries '\\x00\\x26\\x28...'" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_ascii_boundaries.nt> ;
+    .
 
 <#literal_with_UTF8_boundaries> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_UTF8_boundaries" ;
-   rdfs:comment "literal_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_UTF8_boundaries.nt> ;
-   .
+    mf:name      "literal_with_UTF8_boundaries" ;
+    rdfs:comment "literal_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_UTF8_boundaries.nt> ;
+    .
 
 <#literal_all_controls> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_all_controls" ;
-   rdfs:comment "literal_all_controls '\\x00\\x01\\x02\\x03\\x04...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action   <literal_all_controls.nt> ;
-   .
+    mf:name      "literal_all_controls" ;
+    rdfs:comment "literal_all_controls '\\x00\\x01\\x02\\x03\\x04...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action   <literal_all_controls.nt> ;
+    .
 
 <#literal_all_punctuation> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_all_punctuation" ;
-   rdfs:comment "literal_all_punctuation '!\"#$%&()...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_all_punctuation.nt> ;
-   .
+    mf:name      "literal_all_punctuation" ;
+    rdfs:comment "literal_all_punctuation '!\"#$%&()...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_all_punctuation.nt> ;
+    .
 
 <#literal_with_squote> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_squote" ;
-   rdfs:comment "literal with squote \"x'y\"" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_squote.nt> ;
-   .
+    mf:name      "literal_with_squote" ;
+    rdfs:comment "literal with squote \"x'y\"" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_squote.nt> ;
+    .
 
 <#literal_with_2_squotes> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_2_squotes" ;
-   rdfs:comment "literal with 2 squotes \"x''y\"" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_2_squotes.nt> ;
-   .
+    mf:name      "literal_with_2_squotes" ;
+    rdfs:comment "literal with 2 squotes \"x''y\"" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_2_squotes.nt> ;
+    .
 
 <#literal> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal" ;
-   rdfs:comment "literal \"\"\"x\"\"\"" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal.nt> ;
-   .
+    mf:name      "literal" ;
+    rdfs:comment "literal \"\"\"x\"\"\"" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal.nt> ;
+    .
 
 <#literal_with_dquote> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_dquote" ;
-   rdfs:comment 'literal with dquote "x\"y"' ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_dquote.nt> ;
-   .
+    mf:name      "literal_with_dquote" ;
+    rdfs:comment 'literal with dquote "x\"y"' ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_dquote.nt> ;
+    .
 
 <#literal_with_2_dquotes> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_2_dquotes" ;
-   rdfs:comment "literal with 2 dquotes \"\"\"a\"\"b\"\"\"" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_2_dquotes.nt> ;
-   .
+    mf:name      "literal_with_2_dquotes" ;
+    rdfs:comment "literal with 2 dquotes \"\"\"a\"\"b\"\"\"" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_2_dquotes.nt> ;
+    .
 
 <#literal_with_REVERSE_SOLIDUS2> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name    "literal_with_REVERSE_SOLIDUS2" ;
-   rdfs:comment "REVERSE SOLIDUS at end of literal" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_REVERSE_SOLIDUS2.nt> ;
-   .
+    mf:name    "literal_with_REVERSE_SOLIDUS2" ;
+    rdfs:comment "REVERSE SOLIDUS at end of literal" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_REVERSE_SOLIDUS2.nt> ;
+    .
 
 <#literal_with_CHARACTER_TABULATION> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_CHARACTER_TABULATION" ;
-   rdfs:comment "literal with CHARACTER TABULATION" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_CHARACTER_TABULATION.nt> ;
-   .
+    mf:name      "literal_with_CHARACTER_TABULATION" ;
+    rdfs:comment "literal with CHARACTER TABULATION" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_CHARACTER_TABULATION.nt> ;
+    .
 
 <#literal_with_BACKSPACE> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_BACKSPACE" ;
-   rdfs:comment "literal with BACKSPACE" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_BACKSPACE.nt> ;
-   .
+    mf:name      "literal_with_BACKSPACE" ;
+    rdfs:comment "literal with BACKSPACE" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_BACKSPACE.nt> ;
+    .
 
 <#literal_with_LINE_FEED> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_LINE_FEED" ;
-   rdfs:comment "literal with LINE FEED" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_LINE_FEED.nt> ;
-   .
+    mf:name      "literal_with_LINE_FEED" ;
+    rdfs:comment "literal with LINE FEED" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_LINE_FEED.nt> ;
+    .
 
 <#literal_with_CARRIAGE_RETURN> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_CARRIAGE_RETURN" ;
-   rdfs:comment "literal with CARRIAGE RETURN" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_CARRIAGE_RETURN.nt> ;
-   .
+    mf:name      "literal_with_CARRIAGE_RETURN" ;
+    rdfs:comment "literal with CARRIAGE RETURN" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_CARRIAGE_RETURN.nt> ;
+    .
 
 <#literal_with_FORM_FEED> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_FORM_FEED" ;
-   rdfs:comment "literal with FORM FEED" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_FORM_FEED.nt> ;
-   .
+    mf:name      "literal_with_FORM_FEED" ;
+    rdfs:comment "literal with FORM FEED" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_FORM_FEED.nt> ;
+    .
 
 <#literal_with_REVERSE_SOLIDUS> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_REVERSE_SOLIDUS" ;
-   rdfs:comment "literal with REVERSE SOLIDUS" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_REVERSE_SOLIDUS.nt> ;
-   .
+    mf:name      "literal_with_REVERSE_SOLIDUS" ;
+    rdfs:comment "literal with REVERSE SOLIDUS" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_REVERSE_SOLIDUS.nt> ;
+    .
 
 <#literal_with_numeric_escape4> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_numeric_escape4" ;
-   rdfs:comment "literal with numeric escape4 \\u" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_numeric_escape4.nt> ;
-   .
+    mf:name      "literal_with_numeric_escape4" ;
+    rdfs:comment "literal with numeric escape4 \\u" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_numeric_escape4.nt> ;
+    .
 
 <#literal_with_numeric_escape8> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "literal_with_numeric_escape8" ;
-   rdfs:comment "literal with numeric escape8 \\U" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <literal_with_numeric_escape8.nt> ;
-   .
+    mf:name      "literal_with_numeric_escape8" ;
+    rdfs:comment "literal with numeric escape8 \\U" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <literal_with_numeric_escape8.nt> ;
+    .
 
 <#langtagged_string> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "langtagged_string" ;
-   rdfs:comment "langtagged string \"x\"@en" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <langtagged_string.nt> ;
-   .
+    mf:name      "langtagged_string" ;
+    rdfs:comment "langtagged string \"x\"@en" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <langtagged_string.nt> ;
+    .
 
 <#lantag_with_subtag> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "lantag_with_subtag" ;
-   rdfs:comment "lantag with subtag \"x\"@en-us" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <lantag_with_subtag.nt> ;
-   .
+    mf:name      "lantag_with_subtag" ;
+    rdfs:comment "lantag with subtag \"x\"@en-us" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <lantag_with_subtag.nt> ;
+    .
 
 <#minimal_whitespace> rdf:type rdft:TestNTriplesPositiveSyntax ;
-   mf:name      "minimal_whitespace" ;
-   rdfs:comment "tests absense of whitespace between subject, predicate, object and end-of-statement" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <minimal_whitespace.nt> ;
-   .
+    mf:name      "minimal_whitespace" ;
+    rdfs:comment "tests absense of whitespace between subject, predicate, object and end-of-statement" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <minimal_whitespace.nt> ;
+    .

--- a/rdf/rdf11/rdf-trig/IRI-resolution-01.nq
+++ b/rdf/rdf11/rdf-trig/IRI-resolution-01.nq
@@ -1,42 +1,42 @@
-<urn:ex:s001> <urn:ex:p> <g:h>.
-<urn:ex:s002> <urn:ex:p> <http://a/bb/ccc/g>.
-<urn:ex:s003> <urn:ex:p> <http://a/bb/ccc/g>.
-<urn:ex:s004> <urn:ex:p> <http://a/bb/ccc/g/>.
-<urn:ex:s005> <urn:ex:p> <http://a/g>.
-<urn:ex:s006> <urn:ex:p> <http://g>.
-<urn:ex:s007> <urn:ex:p> <http://a/bb/ccc/d;p?y>.
-<urn:ex:s008> <urn:ex:p> <http://a/bb/ccc/g?y>.
-<urn:ex:s009> <urn:ex:p> <http://a/bb/ccc/d;p?q#s>.
-<urn:ex:s010> <urn:ex:p> <http://a/bb/ccc/g#s>.
-<urn:ex:s011> <urn:ex:p> <http://a/bb/ccc/g?y#s>.
-<urn:ex:s012> <urn:ex:p> <http://a/bb/ccc/;x>.
-<urn:ex:s013> <urn:ex:p> <http://a/bb/ccc/g;x>.
-<urn:ex:s014> <urn:ex:p> <http://a/bb/ccc/g;x?y#s>.
-<urn:ex:s015> <urn:ex:p> <http://a/bb/ccc/d;p?q>.
-<urn:ex:s016> <urn:ex:p> <http://a/bb/ccc/>.
-<urn:ex:s017> <urn:ex:p> <http://a/bb/ccc/>.
-<urn:ex:s018> <urn:ex:p> <http://a/bb/>.
-<urn:ex:s019> <urn:ex:p> <http://a/bb/>.
-<urn:ex:s020> <urn:ex:p> <http://a/bb/g>.
-<urn:ex:s021> <urn:ex:p> <http://a/>.
-<urn:ex:s022> <urn:ex:p> <http://a/>.
-<urn:ex:s023> <urn:ex:p> <http://a/g>.
+<urn:ex:s001> <urn:ex:p> <g:h> .
+<urn:ex:s002> <urn:ex:p> <http://a/bb/ccc/g> .
+<urn:ex:s003> <urn:ex:p> <http://a/bb/ccc/g> .
+<urn:ex:s004> <urn:ex:p> <http://a/bb/ccc/g/> .
+<urn:ex:s005> <urn:ex:p> <http://a/g> .
+<urn:ex:s006> <urn:ex:p> <http://g> .
+<urn:ex:s007> <urn:ex:p> <http://a/bb/ccc/d;p?y> .
+<urn:ex:s008> <urn:ex:p> <http://a/bb/ccc/g?y> .
+<urn:ex:s009> <urn:ex:p> <http://a/bb/ccc/d;p?q#s> .
+<urn:ex:s010> <urn:ex:p> <http://a/bb/ccc/g#s> .
+<urn:ex:s011> <urn:ex:p> <http://a/bb/ccc/g?y#s> .
+<urn:ex:s012> <urn:ex:p> <http://a/bb/ccc/;x> .
+<urn:ex:s013> <urn:ex:p> <http://a/bb/ccc/g;x> .
+<urn:ex:s014> <urn:ex:p> <http://a/bb/ccc/g;x?y#s> .
+<urn:ex:s015> <urn:ex:p> <http://a/bb/ccc/d;p?q> .
+<urn:ex:s016> <urn:ex:p> <http://a/bb/ccc/> .
+<urn:ex:s017> <urn:ex:p> <http://a/bb/ccc/> .
+<urn:ex:s018> <urn:ex:p> <http://a/bb/> .
+<urn:ex:s019> <urn:ex:p> <http://a/bb/> .
+<urn:ex:s020> <urn:ex:p> <http://a/bb/g> .
+<urn:ex:s021> <urn:ex:p> <http://a/> .
+<urn:ex:s022> <urn:ex:p> <http://a/> .
+<urn:ex:s023> <urn:ex:p> <http://a/g> .
 
-<urn:ex:s024> <urn:ex:p> <http://a/g>.
-<urn:ex:s025> <urn:ex:p> <http://a/g>.
-<urn:ex:s026> <urn:ex:p> <http://a/g>.
-<urn:ex:s027> <urn:ex:p> <http://a/g>.
-<urn:ex:s028> <urn:ex:p> <http://a/bb/ccc/g.>.
-<urn:ex:s029> <urn:ex:p> <http://a/bb/ccc/.g>.
-<urn:ex:s030> <urn:ex:p> <http://a/bb/ccc/g..>.
-<urn:ex:s031> <urn:ex:p> <http://a/bb/ccc/..g>.
-<urn:ex:s032> <urn:ex:p> <http://a/bb/g>.
-<urn:ex:s033> <urn:ex:p> <http://a/bb/ccc/g/>.
-<urn:ex:s034> <urn:ex:p> <http://a/bb/ccc/g/h>.
-<urn:ex:s035> <urn:ex:p> <http://a/bb/ccc/h>.
-<urn:ex:s036> <urn:ex:p> <http://a/bb/ccc/g;x=1/y>.
-<urn:ex:s037> <urn:ex:p> <http://a/bb/ccc/y>.
-<urn:ex:s038> <urn:ex:p> <http://a/bb/ccc/g?y/./x>.
-<urn:ex:s039> <urn:ex:p> <http://a/bb/ccc/g?y/../x>.
-<urn:ex:s040> <urn:ex:p> <http://a/bb/ccc/g#s/./x>.
-<urn:ex:s041> <urn:ex:p> <http://a/bb/ccc/g#s/../x>.
+<urn:ex:s024> <urn:ex:p> <http://a/g> .
+<urn:ex:s025> <urn:ex:p> <http://a/g> .
+<urn:ex:s026> <urn:ex:p> <http://a/g> .
+<urn:ex:s027> <urn:ex:p> <http://a/g> .
+<urn:ex:s028> <urn:ex:p> <http://a/bb/ccc/g.> .
+<urn:ex:s029> <urn:ex:p> <http://a/bb/ccc/.g> .
+<urn:ex:s030> <urn:ex:p> <http://a/bb/ccc/g..> .
+<urn:ex:s031> <urn:ex:p> <http://a/bb/ccc/..g> .
+<urn:ex:s032> <urn:ex:p> <http://a/bb/g> .
+<urn:ex:s033> <urn:ex:p> <http://a/bb/ccc/g/> .
+<urn:ex:s034> <urn:ex:p> <http://a/bb/ccc/g/h> .
+<urn:ex:s035> <urn:ex:p> <http://a/bb/ccc/h> .
+<urn:ex:s036> <urn:ex:p> <http://a/bb/ccc/g;x=1/y> .
+<urn:ex:s037> <urn:ex:p> <http://a/bb/ccc/y> .
+<urn:ex:s038> <urn:ex:p> <http://a/bb/ccc/g?y/./x> .
+<urn:ex:s039> <urn:ex:p> <http://a/bb/ccc/g?y/../x> .
+<urn:ex:s040> <urn:ex:p> <http://a/bb/ccc/g#s/./x> .
+<urn:ex:s041> <urn:ex:p> <http://a/bb/ccc/g#s/../x> .

--- a/rdf/rdf11/rdf-trig/IRI-resolution-01.nq
+++ b/rdf/rdf11/rdf-trig/IRI-resolution-01.nq
@@ -21,7 +21,6 @@
 <urn:ex:s021> <urn:ex:p> <http://a/> .
 <urn:ex:s022> <urn:ex:p> <http://a/> .
 <urn:ex:s023> <urn:ex:p> <http://a/g> .
-
 <urn:ex:s024> <urn:ex:p> <http://a/g> .
 <urn:ex:s025> <urn:ex:p> <http://a/g> .
 <urn:ex:s026> <urn:ex:p> <http://a/g> .

--- a/rdf/rdf11/rdf-trig/IRI-resolution-02.nq
+++ b/rdf/rdf11/rdf-trig/IRI-resolution-02.nq
@@ -21,7 +21,6 @@
 <urn:ex:s063> <urn:ex:p> <http://a/bb/> .
 <urn:ex:s064> <urn:ex:p> <http://a/bb/> .
 <urn:ex:s065> <urn:ex:p> <http://a/bb/g> .
-
 <urn:ex:s066> <urn:ex:p> <http://a/g> .
 <urn:ex:s067> <urn:ex:p> <http://a/g> .
 <urn:ex:s068> <urn:ex:p> <http://a/g> .

--- a/rdf/rdf11/rdf-trig/IRI-resolution-02.nq
+++ b/rdf/rdf11/rdf-trig/IRI-resolution-02.nq
@@ -1,42 +1,42 @@
-<urn:ex:s043> <urn:ex:p> <g:h>.
-<urn:ex:s044> <urn:ex:p> <http://a/bb/ccc/d/g>.
-<urn:ex:s045> <urn:ex:p> <http://a/bb/ccc/d/g>.
-<urn:ex:s046> <urn:ex:p> <http://a/bb/ccc/d/g/>.
-<urn:ex:s047> <urn:ex:p> <http://a/g>.
-<urn:ex:s048> <urn:ex:p> <http://g>.
-<urn:ex:s049> <urn:ex:p> <http://a/bb/ccc/d/?y>.
-<urn:ex:s050> <urn:ex:p> <http://a/bb/ccc/d/g?y>.
-<urn:ex:s051> <urn:ex:p> <http://a/bb/ccc/d/#s>.
-<urn:ex:s052> <urn:ex:p> <http://a/bb/ccc/d/g#s>.
-<urn:ex:s053> <urn:ex:p> <http://a/bb/ccc/d/g?y#s>.
-<urn:ex:s054> <urn:ex:p> <http://a/bb/ccc/d/;x>.
-<urn:ex:s055> <urn:ex:p> <http://a/bb/ccc/d/g;x>.
-<urn:ex:s056> <urn:ex:p> <http://a/bb/ccc/d/g;x?y#s>.
-<urn:ex:s057> <urn:ex:p> <http://a/bb/ccc/d/>.
-<urn:ex:s058> <urn:ex:p> <http://a/bb/ccc/d/>.
-<urn:ex:s059> <urn:ex:p> <http://a/bb/ccc/d/>.
-<urn:ex:s060> <urn:ex:p> <http://a/bb/ccc/>.
-<urn:ex:s061> <urn:ex:p> <http://a/bb/ccc/>.
-<urn:ex:s062> <urn:ex:p> <http://a/bb/ccc/g>.
-<urn:ex:s063> <urn:ex:p> <http://a/bb/>.
-<urn:ex:s064> <urn:ex:p> <http://a/bb/>.
-<urn:ex:s065> <urn:ex:p> <http://a/bb/g>.
+<urn:ex:s043> <urn:ex:p> <g:h> .
+<urn:ex:s044> <urn:ex:p> <http://a/bb/ccc/d/g> .
+<urn:ex:s045> <urn:ex:p> <http://a/bb/ccc/d/g> .
+<urn:ex:s046> <urn:ex:p> <http://a/bb/ccc/d/g/> .
+<urn:ex:s047> <urn:ex:p> <http://a/g> .
+<urn:ex:s048> <urn:ex:p> <http://g> .
+<urn:ex:s049> <urn:ex:p> <http://a/bb/ccc/d/?y> .
+<urn:ex:s050> <urn:ex:p> <http://a/bb/ccc/d/g?y> .
+<urn:ex:s051> <urn:ex:p> <http://a/bb/ccc/d/#s> .
+<urn:ex:s052> <urn:ex:p> <http://a/bb/ccc/d/g#s> .
+<urn:ex:s053> <urn:ex:p> <http://a/bb/ccc/d/g?y#s> .
+<urn:ex:s054> <urn:ex:p> <http://a/bb/ccc/d/;x> .
+<urn:ex:s055> <urn:ex:p> <http://a/bb/ccc/d/g;x> .
+<urn:ex:s056> <urn:ex:p> <http://a/bb/ccc/d/g;x?y#s> .
+<urn:ex:s057> <urn:ex:p> <http://a/bb/ccc/d/> .
+<urn:ex:s058> <urn:ex:p> <http://a/bb/ccc/d/> .
+<urn:ex:s059> <urn:ex:p> <http://a/bb/ccc/d/> .
+<urn:ex:s060> <urn:ex:p> <http://a/bb/ccc/> .
+<urn:ex:s061> <urn:ex:p> <http://a/bb/ccc/> .
+<urn:ex:s062> <urn:ex:p> <http://a/bb/ccc/g> .
+<urn:ex:s063> <urn:ex:p> <http://a/bb/> .
+<urn:ex:s064> <urn:ex:p> <http://a/bb/> .
+<urn:ex:s065> <urn:ex:p> <http://a/bb/g> .
 
-<urn:ex:s066> <urn:ex:p> <http://a/g>.
-<urn:ex:s067> <urn:ex:p> <http://a/g>.
-<urn:ex:s068> <urn:ex:p> <http://a/g>.
-<urn:ex:s069> <urn:ex:p> <http://a/g>.
-<urn:ex:s070> <urn:ex:p> <http://a/bb/ccc/d/g.>.
-<urn:ex:s071> <urn:ex:p> <http://a/bb/ccc/d/.g>.
-<urn:ex:s072> <urn:ex:p> <http://a/bb/ccc/d/g..>.
-<urn:ex:s073> <urn:ex:p> <http://a/bb/ccc/d/..g>.
-<urn:ex:s074> <urn:ex:p> <http://a/bb/ccc/g>.
-<urn:ex:s075> <urn:ex:p> <http://a/bb/ccc/d/g/>.
-<urn:ex:s076> <urn:ex:p> <http://a/bb/ccc/d/g/h>.
-<urn:ex:s077> <urn:ex:p> <http://a/bb/ccc/d/h>.
-<urn:ex:s078> <urn:ex:p> <http://a/bb/ccc/d/g;x=1/y>.
-<urn:ex:s079> <urn:ex:p> <http://a/bb/ccc/d/y>.
-<urn:ex:s080> <urn:ex:p> <http://a/bb/ccc/d/g?y/./x>.
-<urn:ex:s081> <urn:ex:p> <http://a/bb/ccc/d/g?y/../x>.
-<urn:ex:s082> <urn:ex:p> <http://a/bb/ccc/d/g#s/./x>.
-<urn:ex:s083> <urn:ex:p> <http://a/bb/ccc/d/g#s/../x>.
+<urn:ex:s066> <urn:ex:p> <http://a/g> .
+<urn:ex:s067> <urn:ex:p> <http://a/g> .
+<urn:ex:s068> <urn:ex:p> <http://a/g> .
+<urn:ex:s069> <urn:ex:p> <http://a/g> .
+<urn:ex:s070> <urn:ex:p> <http://a/bb/ccc/d/g.> .
+<urn:ex:s071> <urn:ex:p> <http://a/bb/ccc/d/.g> .
+<urn:ex:s072> <urn:ex:p> <http://a/bb/ccc/d/g..> .
+<urn:ex:s073> <urn:ex:p> <http://a/bb/ccc/d/..g> .
+<urn:ex:s074> <urn:ex:p> <http://a/bb/ccc/g> .
+<urn:ex:s075> <urn:ex:p> <http://a/bb/ccc/d/g/> .
+<urn:ex:s076> <urn:ex:p> <http://a/bb/ccc/d/g/h> .
+<urn:ex:s077> <urn:ex:p> <http://a/bb/ccc/d/h> .
+<urn:ex:s078> <urn:ex:p> <http://a/bb/ccc/d/g;x=1/y> .
+<urn:ex:s079> <urn:ex:p> <http://a/bb/ccc/d/y> .
+<urn:ex:s080> <urn:ex:p> <http://a/bb/ccc/d/g?y/./x> .
+<urn:ex:s081> <urn:ex:p> <http://a/bb/ccc/d/g?y/../x> .
+<urn:ex:s082> <urn:ex:p> <http://a/bb/ccc/d/g#s/./x> .
+<urn:ex:s083> <urn:ex:p> <http://a/bb/ccc/d/g#s/../x> .

--- a/rdf/rdf11/rdf-trig/IRI-resolution-07.nq
+++ b/rdf/rdf11/rdf-trig/IRI-resolution-07.nq
@@ -21,7 +21,6 @@
 <urn:ex:s273> <urn:ex:p> <file:///a/> .
 <urn:ex:s274> <urn:ex:p> <file:///a/> .
 <urn:ex:s275> <urn:ex:p> <file:///a/g> .
-
 <urn:ex:s276> <urn:ex:p> <file:///g> .
 <urn:ex:s277> <urn:ex:p> <file:///g> .
 <urn:ex:s278> <urn:ex:p> <file:///g> .

--- a/rdf/rdf11/rdf-trig/IRI-resolution-07.nq
+++ b/rdf/rdf11/rdf-trig/IRI-resolution-07.nq
@@ -1,43 +1,43 @@
-<urn:ex:s253> <urn:ex:p> <g:h>.
-<urn:ex:s254> <urn:ex:p> <file:///a/bb/ccc/g>.
-<urn:ex:s255> <urn:ex:p> <file:///a/bb/ccc/g>.
-<urn:ex:s256> <urn:ex:p> <file:///a/bb/ccc/g/>.
-<urn:ex:s257> <urn:ex:p> <file:///g>.
-<urn:ex:s258> <urn:ex:p> <file://g>.
-<urn:ex:s259> <urn:ex:p> <file:///a/bb/ccc/d;p?y>.
-<urn:ex:s260> <urn:ex:p> <file:///a/bb/ccc/g?y>.
-<urn:ex:s261> <urn:ex:p> <file:///a/bb/ccc/d;p?q#s>.
-<urn:ex:s262> <urn:ex:p> <file:///a/bb/ccc/g#s>.
-<urn:ex:s263> <urn:ex:p> <file:///a/bb/ccc/g?y#s>.
-<urn:ex:s264> <urn:ex:p> <file:///a/bb/ccc/;x>.
-<urn:ex:s265> <urn:ex:p> <file:///a/bb/ccc/g;x>.
-<urn:ex:s266> <urn:ex:p> <file:///a/bb/ccc/g;x?y#s>.
-<urn:ex:s267> <urn:ex:p> <file:///a/bb/ccc/d;p?q>.
-<urn:ex:s268> <urn:ex:p> <file:///a/bb/ccc/>.
-<urn:ex:s269> <urn:ex:p> <file:///a/bb/ccc/>.
-<urn:ex:s270> <urn:ex:p> <file:///a/bb/>.
-<urn:ex:s271> <urn:ex:p> <file:///a/bb/>.
-<urn:ex:s272> <urn:ex:p> <file:///a/bb/g>.
-<urn:ex:s273> <urn:ex:p> <file:///a/>.
-<urn:ex:s274> <urn:ex:p> <file:///a/>.
-<urn:ex:s275> <urn:ex:p> <file:///a/g>.
+<urn:ex:s253> <urn:ex:p> <g:h> .
+<urn:ex:s254> <urn:ex:p> <file:///a/bb/ccc/g> .
+<urn:ex:s255> <urn:ex:p> <file:///a/bb/ccc/g> .
+<urn:ex:s256> <urn:ex:p> <file:///a/bb/ccc/g/> .
+<urn:ex:s257> <urn:ex:p> <file:///g> .
+<urn:ex:s258> <urn:ex:p> <file://g> .
+<urn:ex:s259> <urn:ex:p> <file:///a/bb/ccc/d;p?y> .
+<urn:ex:s260> <urn:ex:p> <file:///a/bb/ccc/g?y> .
+<urn:ex:s261> <urn:ex:p> <file:///a/bb/ccc/d;p?q#s> .
+<urn:ex:s262> <urn:ex:p> <file:///a/bb/ccc/g#s> .
+<urn:ex:s263> <urn:ex:p> <file:///a/bb/ccc/g?y#s> .
+<urn:ex:s264> <urn:ex:p> <file:///a/bb/ccc/;x> .
+<urn:ex:s265> <urn:ex:p> <file:///a/bb/ccc/g;x> .
+<urn:ex:s266> <urn:ex:p> <file:///a/bb/ccc/g;x?y#s> .
+<urn:ex:s267> <urn:ex:p> <file:///a/bb/ccc/d;p?q> .
+<urn:ex:s268> <urn:ex:p> <file:///a/bb/ccc/> .
+<urn:ex:s269> <urn:ex:p> <file:///a/bb/ccc/> .
+<urn:ex:s270> <urn:ex:p> <file:///a/bb/> .
+<urn:ex:s271> <urn:ex:p> <file:///a/bb/> .
+<urn:ex:s272> <urn:ex:p> <file:///a/bb/g> .
+<urn:ex:s273> <urn:ex:p> <file:///a/> .
+<urn:ex:s274> <urn:ex:p> <file:///a/> .
+<urn:ex:s275> <urn:ex:p> <file:///a/g> .
 
-<urn:ex:s276> <urn:ex:p> <file:///g>.
-<urn:ex:s277> <urn:ex:p> <file:///g>.
-<urn:ex:s278> <urn:ex:p> <file:///g>.
-<urn:ex:s279> <urn:ex:p> <file:///g>.
-<urn:ex:s280> <urn:ex:p> <file:///a/bb/ccc/g.>.
-<urn:ex:s281> <urn:ex:p> <file:///a/bb/ccc/.g>.
-<urn:ex:s282> <urn:ex:p> <file:///a/bb/ccc/g..>.
-<urn:ex:s283> <urn:ex:p> <file:///a/bb/ccc/..g>.
-<urn:ex:s284> <urn:ex:p> <file:///a/bb/g>.
-<urn:ex:s285> <urn:ex:p> <file:///a/bb/ccc/g/>.
-<urn:ex:s286> <urn:ex:p> <file:///a/bb/ccc/g/h>.
-<urn:ex:s287> <urn:ex:p> <file:///a/bb/ccc/h>.
-<urn:ex:s288> <urn:ex:p> <file:///a/bb/ccc/g;x=1/y>.
-<urn:ex:s289> <urn:ex:p> <file:///a/bb/ccc/y>.
-<urn:ex:s290> <urn:ex:p> <file:///a/bb/ccc/g?y/./x>.
-<urn:ex:s291> <urn:ex:p> <file:///a/bb/ccc/g?y/../x>.
-<urn:ex:s292> <urn:ex:p> <file:///a/bb/ccc/g#s/./x>.
-<urn:ex:s293> <urn:ex:p> <file:///a/bb/ccc/g#s/../x>.
-<urn:ex:s294> <urn:ex:p> <http:g>.
+<urn:ex:s276> <urn:ex:p> <file:///g> .
+<urn:ex:s277> <urn:ex:p> <file:///g> .
+<urn:ex:s278> <urn:ex:p> <file:///g> .
+<urn:ex:s279> <urn:ex:p> <file:///g> .
+<urn:ex:s280> <urn:ex:p> <file:///a/bb/ccc/g.> .
+<urn:ex:s281> <urn:ex:p> <file:///a/bb/ccc/.g> .
+<urn:ex:s282> <urn:ex:p> <file:///a/bb/ccc/g..> .
+<urn:ex:s283> <urn:ex:p> <file:///a/bb/ccc/..g> .
+<urn:ex:s284> <urn:ex:p> <file:///a/bb/g> .
+<urn:ex:s285> <urn:ex:p> <file:///a/bb/ccc/g/> .
+<urn:ex:s286> <urn:ex:p> <file:///a/bb/ccc/g/h> .
+<urn:ex:s287> <urn:ex:p> <file:///a/bb/ccc/h> .
+<urn:ex:s288> <urn:ex:p> <file:///a/bb/ccc/g;x=1/y> .
+<urn:ex:s289> <urn:ex:p> <file:///a/bb/ccc/y> .
+<urn:ex:s290> <urn:ex:p> <file:///a/bb/ccc/g?y/./x> .
+<urn:ex:s291> <urn:ex:p> <file:///a/bb/ccc/g?y/../x> .
+<urn:ex:s292> <urn:ex:p> <file:///a/bb/ccc/g#s/./x> .
+<urn:ex:s293> <urn:ex:p> <file:///a/bb/ccc/g#s/../x> .
+<urn:ex:s294> <urn:ex:p> <http:g> .

--- a/rdf/rdf11/rdf-trig/IRI-resolution-08.nq
+++ b/rdf/rdf11/rdf-trig/IRI-resolution-08.nq
@@ -4,11 +4,9 @@
 <urn:ex:s298> <urn:ex:p> <http://abc/> .
 <urn:ex:s299> <urn:ex:p> <http://abc/?a=b> .
 <urn:ex:s300> <urn:ex:p> <http://abc/#a=b> .
-
 <urn:ex:s301> <urn:ex:p> <http://ab//de//xyz> .
 <urn:ex:s302> <urn:ex:p> <http://ab//de//xyz> .
 <urn:ex:s303> <urn:ex:p> <http://ab//de/xyz> .
-
 <urn:ex:s304> <urn:ex:p> <http://abc/d:f/xyz> .
 <urn:ex:s305> <urn:ex:p> <http://abc/d:f/xyz> .
 <urn:ex:s306> <urn:ex:p> <http://abc/xyz> .

--- a/rdf/rdf11/rdf-trig/IRI-resolution-08.nq
+++ b/rdf/rdf11/rdf-trig/IRI-resolution-08.nq
@@ -1,14 +1,14 @@
-<urn:ex:s295> <urn:ex:p> <http://abc/def/>.
-<urn:ex:s296> <urn:ex:p> <http://abc/def/?a=b>.
-<urn:ex:s297> <urn:ex:p> <http://abc/def/#a=b>.
-<urn:ex:s298> <urn:ex:p> <http://abc/>.
-<urn:ex:s299> <urn:ex:p> <http://abc/?a=b>.
-<urn:ex:s300> <urn:ex:p> <http://abc/#a=b>.
+<urn:ex:s295> <urn:ex:p> <http://abc/def/> .
+<urn:ex:s296> <urn:ex:p> <http://abc/def/?a=b> .
+<urn:ex:s297> <urn:ex:p> <http://abc/def/#a=b> .
+<urn:ex:s298> <urn:ex:p> <http://abc/> .
+<urn:ex:s299> <urn:ex:p> <http://abc/?a=b> .
+<urn:ex:s300> <urn:ex:p> <http://abc/#a=b> .
 
-<urn:ex:s301> <urn:ex:p> <http://ab//de//xyz>.
-<urn:ex:s302> <urn:ex:p> <http://ab//de//xyz>.
-<urn:ex:s303> <urn:ex:p> <http://ab//de/xyz>.
+<urn:ex:s301> <urn:ex:p> <http://ab//de//xyz> .
+<urn:ex:s302> <urn:ex:p> <http://ab//de//xyz> .
+<urn:ex:s303> <urn:ex:p> <http://ab//de/xyz> .
 
-<urn:ex:s304> <urn:ex:p> <http://abc/d:f/xyz>.
-<urn:ex:s305> <urn:ex:p> <http://abc/d:f/xyz>.
-<urn:ex:s306> <urn:ex:p> <http://abc/xyz>.
+<urn:ex:s304> <urn:ex:p> <http://abc/d:f/xyz> .
+<urn:ex:s305> <urn:ex:p> <http://abc/d:f/xyz> .
+<urn:ex:s306> <urn:ex:p> <http://abc/xyz> .

--- a/rdf/rdf11/rdf-trig/blankNodePropertyList_as_object_containing_objectList.nq
+++ b/rdf/rdf11/rdf-trig/blankNodePropertyList_as_object_containing_objectList.nq
@@ -1,3 +1,3 @@
-<http://a.example/s> <http://a.example/p> _:b1 <http://a.example/g>.
-_:b1 <http://a.example/p2> <http://a.example/o> <http://a.example/g>.
-_:b1 <http://a.example/p2> <http://a.example/o2> <http://a.example/g>.
+<http://a.example/s> <http://a.example/p> _:b1 <http://a.example/g> .
+_:b1 <http://a.example/p2> <http://a.example/o> <http://a.example/g> .
+_:b1 <http://a.example/p2> <http://a.example/o2> <http://a.example/g> .

--- a/rdf/rdf11/rdf-trig/blankNodePropertyList_as_object_containing_objectList_of_two_objects.nq
+++ b/rdf/rdf11/rdf-trig/blankNodePropertyList_as_object_containing_objectList_of_two_objects.nq
@@ -1,3 +1,3 @@
-<http://a.example/s> <http://a.example/p> _:b1 <http://a.example/g>.
-_:b1 <http://a.example/p2> <http://a.example/o> <http://a.example/g>.
-<http://a.example/s> <http://a.example/p> <http://a.example/o2> <http://a.example/g>.
+<http://a.example/s> <http://a.example/p> _:b1 <http://a.example/g> .
+_:b1 <http://a.example/p2> <http://a.example/o> <http://a.example/g> .
+<http://a.example/s> <http://a.example/p> <http://a.example/o2> <http://a.example/g> .

--- a/rdf/rdf11/rdf-trig/localname_with_COLON.nq
+++ b/rdf/rdf11/rdf-trig/localname_with_COLON.nq
@@ -1,2 +1,2 @@
 <http://a.example/s:> <http://a.example/p> <http://a.example/o> .
-<http://a.example/s:> <http://a.example/p> <http://a.example/o> <http://example/graph>.
+<http://a.example/s:> <http://a.example/p> <http://a.example/o> <http://example/graph> .

--- a/rdf/rdf11/rdf-trig/manifest.ttl
+++ b/rdf/rdf11/rdf-trig/manifest.ttl
@@ -412,2668 +412,2668 @@
 
 # TriG tests
 <#anonymous_blank_node_graph> rdf:type rdft:TestTrigEval ;
-   mf:name      "anonymous_blank_node_graph" ;
-   rdfs:comment "anonymous blank node graph" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <anonymous_blank_node_graph.trig> ;
-   mf:result    <labeled_blank_node_graph.nq> ;
-   .
+    mf:name      "anonymous_blank_node_graph" ;
+    rdfs:comment "anonymous blank node graph" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <anonymous_blank_node_graph.trig> ;
+    mf:result    <labeled_blank_node_graph.nq> ;
+    .
 
 <#labeled_blank_node_graph> rdf:type rdft:TestTrigEval ;
-   mf:name      "labeled_blank_node_graph" ;
-   rdfs:comment "labeled blank node graph" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_graph.trig> ;
-   mf:result    <labeled_blank_node_graph.nq> ;
-   .
+    mf:name      "labeled_blank_node_graph" ;
+    rdfs:comment "labeled blank node graph" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_graph.trig> ;
+    mf:result    <labeled_blank_node_graph.nq> ;
+    .
 
 <#alternating_iri_graphs> rdf:type rdft:TestTrigEval ;
-   mf:name      "alternating_iri_graphs" ;
-   rdfs:comment "alternating graphs with IRI names" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <alternating_iri_graphs.trig> ;
-   mf:result    <alternating_iri_graphs.nq> ;
-   .
+    mf:name      "alternating_iri_graphs" ;
+    rdfs:comment "alternating graphs with IRI names" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <alternating_iri_graphs.trig> ;
+    mf:result    <alternating_iri_graphs.nq> ;
+    .
 
 <#alternating_bnode_graphs> rdf:type rdft:TestTrigEval ;
-   mf:name      "alternating_bnode_graphs" ;
-   rdfs:comment "alternating graphs with BNode names" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <alternating_bnode_graphs.trig> ;
-   mf:result    <alternating_bnode_graphs.nq> ;
-   .
+    mf:name      "alternating_bnode_graphs" ;
+    rdfs:comment "alternating graphs with BNode names" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <alternating_bnode_graphs.trig> ;
+    mf:result    <alternating_bnode_graphs.nq> ;
+    .
 
 <#trig-syntax-bad-base-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-base-04" ;
-   rdfs:comment "@base inside graph (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-base-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-base-04" ;
+    rdfs:comment "@base inside graph (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-base-04.trig> ;
+    .
 
 <#trig-syntax-bad-base-05> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-base-05" ;
-   rdfs:comment "BASE inside graph (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-base-05.trig> ;
-   .
+    mf:name    "trig-syntax-bad-base-05" ;
+    rdfs:comment "BASE inside graph (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-base-05.trig> ;
+    .
 
 <#trig-syntax-bad-prefix-06> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-prefix-06" ;
-   rdfs:comment "@prefix inside graph (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-prefix-06.trig> ;
-   .
+    mf:name    "trig-syntax-bad-prefix-06" ;
+    rdfs:comment "@prefix inside graph (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-prefix-06.trig> ;
+    .
 
 <#trig-syntax-bad-prefix-07> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-prefix-07" ;
-   rdfs:comment "PREFIX inside graph (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-prefix-07.trig> ;
-   .
+    mf:name    "trig-syntax-bad-prefix-07" ;
+    rdfs:comment "PREFIX inside graph (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-prefix-07.trig> ;
+    .
 
 <#trig-syntax-struct-06> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-struct-06" ;
-   rdfs:comment "missing '.'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-struct-06.trig> ;
-   .
+    mf:name    "trig-syntax-struct-06" ;
+    rdfs:comment "missing '.'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-struct-06.trig> ;
+    .
 
 <#trig-syntax-struct-07> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-struct-07" ;
-   rdfs:comment "trailing ';' no '.'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-struct-07.trig> ;
-   .
+    mf:name    "trig-syntax-struct-07" ;
+    rdfs:comment "trailing ';' no '.'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-struct-07.trig> ;
+    .
 
 <#trig-syntax-minimal-whitespace-01> a rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-syntax-minimal-whitespace-01" ;
-   rdfs:comment "tests absense of whitespace in various positions" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-minimal-whitespace-01.trig> ;
-   .
+    mf:name      "trig-syntax-minimal-whitespace-01" ;
+    rdfs:comment "tests absense of whitespace in various positions" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-minimal-whitespace-01.trig> ;
+    .
 
 # Original Turtle tests
 # atomic tests
 <#IRI_subject> rdf:type rdft:TestTrigEval ;
-   mf:name      "IRI_subject" ;
-   rdfs:comment "IRI subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <IRI_subject.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "IRI_subject" ;
+    rdfs:comment "IRI subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <IRI_subject.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#IRI_with_four_digit_numeric_escape> rdf:type rdft:TestTrigEval ;
-   mf:name      "IRI_with_four_digit_numeric_escape" ;
-   rdfs:comment "IRI with four digit numeric escape (\\u)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <IRI_with_four_digit_numeric_escape.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "IRI_with_four_digit_numeric_escape" ;
+    rdfs:comment "IRI with four digit numeric escape (\\u)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <IRI_with_four_digit_numeric_escape.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#IRI_with_eight_digit_numeric_escape> rdf:type rdft:TestTrigEval ;
-   mf:name      "IRI_with_eight_digit_numeric_escape" ;
-   rdfs:comment "IRI with eight digit numeric escape (\\U)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <IRI_with_eight_digit_numeric_escape.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "IRI_with_eight_digit_numeric_escape" ;
+    rdfs:comment "IRI with eight digit numeric escape (\\U)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <IRI_with_eight_digit_numeric_escape.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#IRI_with_all_punctuation> rdf:type rdft:TestTrigEval ;
-   mf:name      "IRI_with_all_punctuation" ;
-   rdfs:comment "IRI with all punctuation" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <IRI_with_all_punctuation.trig> ;
-   mf:result    <IRI_with_all_punctuation.nq> ;
-   .
+    mf:name      "IRI_with_all_punctuation" ;
+    rdfs:comment "IRI with all punctuation" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <IRI_with_all_punctuation.trig> ;
+    mf:result    <IRI_with_all_punctuation.nq> ;
+    .
 
 <#bareword_a_predicate> rdf:type rdft:TestTrigEval ;
-   mf:name      "bareword_a_predicate" ;
-   rdfs:comment "bareword a predicate" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <bareword_a_predicate.trig> ;
-   mf:result    <bareword_a_predicate.nq> ;
-   .
+    mf:name      "bareword_a_predicate" ;
+    rdfs:comment "bareword a predicate" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <bareword_a_predicate.trig> ;
+    mf:result    <bareword_a_predicate.nq> ;
+    .
 
 <#old_style_prefix> rdf:type rdft:TestTrigEval ;
-   mf:name      "old_style_prefix" ;
-   rdfs:comment "old-style prefix" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <old_style_prefix.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "old_style_prefix" ;
+    rdfs:comment "old-style prefix" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <old_style_prefix.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#SPARQL_style_prefix> rdf:type rdft:TestTrigEval ;
-   mf:name      "SPARQL_style_prefix" ;
-   rdfs:comment "SPARQL-style prefix" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <SPARQL_style_prefix.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "SPARQL_style_prefix" ;
+    rdfs:comment "SPARQL-style prefix" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <SPARQL_style_prefix.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#prefixed_IRI_predicate> rdf:type rdft:TestTrigEval ;
-   mf:name      "prefixed_IRI_predicate" ;
-   rdfs:comment "prefixed IRI predicate" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefixed_IRI_predicate.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "prefixed_IRI_predicate" ;
+    rdfs:comment "prefixed IRI predicate" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefixed_IRI_predicate.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#prefixed_IRI_object> rdf:type rdft:TestTrigEval ;
-   mf:name      "prefixed_IRI_object" ;
-   rdfs:comment "prefixed IRI object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefixed_IRI_object.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "prefixed_IRI_object" ;
+    rdfs:comment "prefixed IRI object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefixed_IRI_object.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#prefix_only_IRI> rdf:type rdft:TestTrigEval ;
-   mf:name      "prefix_only_IRI" ;
-   rdfs:comment "prefix-only IRI (p:)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefix_only_IRI.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "prefix_only_IRI" ;
+    rdfs:comment "prefix-only IRI (p:)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefix_only_IRI.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#prefix_with_PN_CHARS_BASE_character_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "prefix_with_PN_CHARS_BASE_character_boundaries" ;
-   rdfs:comment "prefix with PN CHARS BASE character boundaries (prefix: AZazÀÖØöø...:)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefix_with_PN_CHARS_BASE_character_boundaries.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "prefix_with_PN_CHARS_BASE_character_boundaries" ;
+    rdfs:comment "prefix with PN CHARS BASE character boundaries (prefix: AZazÀÖØöø...:)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefix_with_PN_CHARS_BASE_character_boundaries.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#prefix_with_non_leading_extras> rdf:type rdft:TestTrigEval ;
-   mf:name      "prefix_with_non_leading_extras" ;
-   rdfs:comment "prefix with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefix_with_non_leading_extras.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "prefix_with_non_leading_extras" ;
+    rdfs:comment "prefix with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefix_with_non_leading_extras.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries" ;
-   rdfs:comment "localName with assigned, NFC-normalized, basic-multilingual-plane PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries.trig> ;
-   mf:result    <localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries.nq> ;
-   .
+    mf:name      "localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries" ;
+    rdfs:comment "localName with assigned, NFC-normalized, basic-multilingual-plane PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries.trig> ;
+    mf:result    <localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries.nq> ;
+    .
 
 <#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries" ;
-   rdfs:comment "localName with assigned, NFC-normalized PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries.trig> ;
-   mf:result    <localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries.nq> ;
-   .
+    mf:name      "localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries" ;
+    rdfs:comment "localName with assigned, NFC-normalized PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries.trig> ;
+    mf:result    <localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries.nq> ;
+    .
 
 <#localName_with_nfc_PN_CHARS_BASE_character_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "localName_with_nfc_PN_CHARS_BASE_character_boundaries" ;
-   rdfs:comment "localName with nfc-normalize PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_nfc_PN_CHARS_BASE_character_boundaries.trig> ;
-   mf:result    <localName_with_nfc_PN_CHARS_BASE_character_boundaries.nq> ;
-   .
+    mf:name      "localName_with_nfc_PN_CHARS_BASE_character_boundaries" ;
+    rdfs:comment "localName with nfc-normalize PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_nfc_PN_CHARS_BASE_character_boundaries.trig> ;
+    mf:result    <localName_with_nfc_PN_CHARS_BASE_character_boundaries.nq> ;
+    .
 
 <#default_namespace_IRI> rdf:type rdft:TestTrigEval ;
-   mf:name      "default_namespace_IRI" ;
-   rdfs:comment "default namespace IRI (:ln)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <default_namespace_IRI.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "default_namespace_IRI" ;
+    rdfs:comment "default namespace IRI (:ln)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <default_namespace_IRI.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#prefix_reassigned_and_used> rdf:type rdft:TestTrigEval ;
-   mf:name      "prefix_reassigned_and_used" ;
-   rdfs:comment "prefix reassigned and used" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefix_reassigned_and_used.trig> ;
-   mf:result    <prefix_reassigned_and_used.nq> ;
-   .
+    mf:name      "prefix_reassigned_and_used" ;
+    rdfs:comment "prefix reassigned and used" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefix_reassigned_and_used.trig> ;
+    mf:result    <prefix_reassigned_and_used.nq> ;
+    .
 
 <#reserved_escaped_localName> rdf:type rdft:TestTrigEval ;
-   mf:name      "reserved_escaped_localName" ;
-   rdfs:comment "reserved-escaped local name" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <reserved_escaped_localName.trig> ;
-   mf:result    <reserved_escaped_localName.nq> ;
-   .
+    mf:name      "reserved_escaped_localName" ;
+    rdfs:comment "reserved-escaped local name" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <reserved_escaped_localName.trig> ;
+    mf:result    <reserved_escaped_localName.nq> ;
+    .
 
 <#percent_escaped_localName> rdf:type rdft:TestTrigEval ;
-   mf:name      "percent_escaped_localName" ;
-   rdfs:comment "percent-escaped local name" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <percent_escaped_localName.trig> ;
-   mf:result    <percent_escaped_localName.nq> ;
-   .
+    mf:name      "percent_escaped_localName" ;
+    rdfs:comment "percent-escaped local name" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <percent_escaped_localName.trig> ;
+    mf:result    <percent_escaped_localName.nq> ;
+    .
 
 <#HYPHEN_MINUS_in_localName> rdf:type rdft:TestTrigEval ;
-   mf:name      "HYPHEN_MINUS_in_localName" ;
-   rdfs:comment "HYPHEN-MINUS in local name" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <HYPHEN_MINUS_in_localName.trig> ;
-   mf:result    <HYPHEN_MINUS_in_localName.nq> ;
-   .
+    mf:name      "HYPHEN_MINUS_in_localName" ;
+    rdfs:comment "HYPHEN-MINUS in local name" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <HYPHEN_MINUS_in_localName.trig> ;
+    mf:result    <HYPHEN_MINUS_in_localName.nq> ;
+    .
 
 <#underscore_in_localName> rdf:type rdft:TestTrigEval ;
-   mf:name      "underscore_in_localName" ;
-   rdfs:comment "underscore in local name" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <underscore_in_localName.trig> ;
-   mf:result    <underscore_in_localName.nq> ;
-   .
+    mf:name      "underscore_in_localName" ;
+    rdfs:comment "underscore in local name" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <underscore_in_localName.trig> ;
+    mf:result    <underscore_in_localName.nq> ;
+    .
 
 <#localname_with_COLON> rdf:type rdft:TestTrigEval ;
-   mf:name      "localname_with_COLON" ;
-   rdfs:comment "localname with COLON" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localname_with_COLON.trig> ;
-   mf:result    <localname_with_COLON.nq> ;
-   .
+    mf:name      "localname_with_COLON" ;
+    rdfs:comment "localname with COLON" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localname_with_COLON.trig> ;
+    mf:result    <localname_with_COLON.nq> ;
+    .
 
 <#localName_with_leading_underscore> rdf:type rdft:TestTrigEval ;
-   mf:name      "localName_with_leading_underscore" ;
-   rdfs:comment "localName with leading underscore (p:_)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_leading_underscore.trig> ;
-   mf:result    <localName_with_leading_underscore.nq> ;
-   .
+    mf:name      "localName_with_leading_underscore" ;
+    rdfs:comment "localName with leading underscore (p:_)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_leading_underscore.trig> ;
+    mf:result    <localName_with_leading_underscore.nq> ;
+    .
 
 <#localName_with_leading_digit> rdf:type rdft:TestTrigEval ;
-   mf:name      "localName_with_leading_digit" ;
-   rdfs:comment "localName with leading digit (p:_)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_leading_digit.trig> ;
-   mf:result    <localName_with_leading_digit.nq> ;
-   .
+    mf:name      "localName_with_leading_digit" ;
+    rdfs:comment "localName with leading digit (p:_)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_leading_digit.trig> ;
+    mf:result    <localName_with_leading_digit.nq> ;
+    .
 
 <#localName_with_non_leading_extras> rdf:type rdft:TestTrigEval ;
-   mf:name      "localName_with_non_leading_extras" ;
-   rdfs:comment "localName with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_non_leading_extras.trig> ;
-   mf:result    <localName_with_non_leading_extras.nq> ;
-   .
+    mf:name      "localName_with_non_leading_extras" ;
+    rdfs:comment "localName with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_non_leading_extras.trig> ;
+    mf:result    <localName_with_non_leading_extras.nq> ;
+    .
 
 <#old_style_base> rdf:type rdft:TestTrigEval ;
-   mf:name      "old_style_base" ;
-   rdfs:comment "old-style base" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <old_style_base.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "old_style_base" ;
+    rdfs:comment "old-style base" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <old_style_base.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#SPARQL_style_base> rdf:type rdft:TestTrigEval ;
-   mf:name      "SPARQL_style_base" ;
-   rdfs:comment "SPARQL-style base" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <SPARQL_style_base.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "SPARQL_style_base" ;
+    rdfs:comment "SPARQL-style base" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <SPARQL_style_base.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#labeled_blank_node_subject> rdf:type rdft:TestTrigEval ;
-   mf:name      "labeled_blank_node_subject" ;
-   rdfs:comment "labeled blank node subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_subject.trig> ;
-   mf:result    <labeled_blank_node_subject.nq> ;
-   .
+    mf:name      "labeled_blank_node_subject" ;
+    rdfs:comment "labeled blank node subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_subject.trig> ;
+    mf:result    <labeled_blank_node_subject.nq> ;
+    .
 
 <#labeled_blank_node_object> rdf:type rdft:TestTrigEval ;
-   mf:name      "labeled_blank_node_object" ;
-   rdfs:comment "labeled blank node object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_object.trig> ;
-   mf:result    <labeled_blank_node_object.nq> ;
-   .
+    mf:name      "labeled_blank_node_object" ;
+    rdfs:comment "labeled blank node object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_object.trig> ;
+    mf:result    <labeled_blank_node_object.nq> ;
+    .
 
 <#labeled_blank_node_with_PN_CHARS_BASE_character_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "labeled_blank_node_with_PN_CHARS_BASE_character_boundaries" ;
-   rdfs:comment "labeled blank node with PN_CHARS_BASE character boundaries (_:AZazÀÖØöø...)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_with_PN_CHARS_BASE_character_boundaries.trig> ;
-   mf:result    <labeled_blank_node_object.nq> ;
-   .
+    mf:name      "labeled_blank_node_with_PN_CHARS_BASE_character_boundaries" ;
+    rdfs:comment "labeled blank node with PN_CHARS_BASE character boundaries (_:AZazÀÖØöø...)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_with_PN_CHARS_BASE_character_boundaries.trig> ;
+    mf:result    <labeled_blank_node_object.nq> ;
+    .
 
 <#labeled_blank_node_with_leading_underscore> rdf:type rdft:TestTrigEval ;
-   mf:name      "labeled_blank_node_with_leading_underscore" ;
-   rdfs:comment "labeled blank node with_leading_underscore (_:_)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_with_leading_underscore.trig> ;
-   mf:result    <labeled_blank_node_object.nq> ;
-   .
+    mf:name      "labeled_blank_node_with_leading_underscore" ;
+    rdfs:comment "labeled blank node with_leading_underscore (_:_)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_with_leading_underscore.trig> ;
+    mf:result    <labeled_blank_node_object.nq> ;
+    .
 
 <#labeled_blank_node_with_leading_digit> rdf:type rdft:TestTrigEval ;
-   mf:name      "labeled_blank_node_with_leading_digit" ;
-   rdfs:comment "labeled blank node with_leading_digit (_:0)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_with_leading_digit.trig> ;
-   mf:result    <labeled_blank_node_object.nq> ;
-   .
+    mf:name      "labeled_blank_node_with_leading_digit" ;
+    rdfs:comment "labeled blank node with_leading_digit (_:0)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_with_leading_digit.trig> ;
+    mf:result    <labeled_blank_node_object.nq> ;
+    .
 
 <#labeled_blank_node_with_non_leading_extras> rdf:type rdft:TestTrigEval ;
-   mf:name      "labeled_blank_node_with_non_leading_extras" ;
-   rdfs:comment "labeled blank node with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_with_non_leading_extras.trig> ;
-   mf:result    <labeled_blank_node_object.nq> ;
-   .
+    mf:name      "labeled_blank_node_with_non_leading_extras" ;
+    rdfs:comment "labeled blank node with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_with_non_leading_extras.trig> ;
+    mf:result    <labeled_blank_node_object.nq> ;
+    .
 
 <#anonymous_blank_node_subject> rdf:type rdft:TestTrigEval ;
-   mf:name      "anonymous_blank_node_subject" ;
-   rdfs:comment "anonymous blank node subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <anonymous_blank_node_subject.trig> ;
-   mf:result    <anonymous_blank_node_subject.nq> ;
-   .
+    mf:name      "anonymous_blank_node_subject" ;
+    rdfs:comment "anonymous blank node subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <anonymous_blank_node_subject.trig> ;
+    mf:result    <anonymous_blank_node_subject.nq> ;
+    .
 
 <#anonymous_blank_node_object> rdf:type rdft:TestTrigEval ;
-   mf:name      "anonymous_blank_node_object" ;
-   rdfs:comment "anonymous blank node object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <anonymous_blank_node_object.trig> ;
-   mf:result    <anonymous_blank_node_object.nq> ;
-   .
+    mf:name      "anonymous_blank_node_object" ;
+    rdfs:comment "anonymous blank node object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <anonymous_blank_node_object.trig> ;
+    mf:result    <anonymous_blank_node_object.nq> ;
+    .
 
 <#sole_blankNodePropertyList> rdf:type rdft:TestTrigEval ;
-   mf:name      "sole_blankNodePropertyList" ;
-   rdfs:comment "sole blankNodePropertyList [ <p> <o> ] ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <sole_blankNodePropertyList.trig> ;
-   mf:result    <sole_blankNodePropertyList.nq> ;
-   .
+    mf:name      "sole_blankNodePropertyList" ;
+    rdfs:comment "sole blankNodePropertyList [ <p> <o> ] ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <sole_blankNodePropertyList.trig> ;
+    mf:result    <sole_blankNodePropertyList.nq> ;
+    .
 
 <#blankNodePropertyList_as_subject> rdf:type rdft:TestTrigEval ;
-   mf:name      "blankNodePropertyList_as_subject" ;
-   rdfs:comment "blankNodePropertyList as subject [ … ] <p> <o> ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_as_subject.trig> ;
-   mf:result    <blankNodePropertyList_as_subject.nq> ;
-   .
+    mf:name      "blankNodePropertyList_as_subject" ;
+    rdfs:comment "blankNodePropertyList as subject [ … ] <p> <o> ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_as_subject.trig> ;
+    mf:result    <blankNodePropertyList_as_subject.nq> ;
+    .
 
 <#blankNodePropertyList_as_object> rdf:type rdft:TestTrigEval ;
-   mf:name      "blankNodePropertyList_as_object" ;
-   rdfs:comment "blankNodePropertyList as object <s> <p> [ … ] ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_as_object.trig> ;
-   mf:result    <blankNodePropertyList_as_object.nq> ;
-   .
+    mf:name      "blankNodePropertyList_as_object" ;
+    rdfs:comment "blankNodePropertyList as object <s> <p> [ … ] ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_as_object.trig> ;
+    mf:result    <blankNodePropertyList_as_object.nq> ;
+    .
 
 <#blankNodePropertyList_as_object_containing_objectList> rdf:type rdft:TestTrigEval ;
-   mf:name      "blankNodePropertyList_as_object_containing_objectList" ;
-   rdfs:comment "blankNodePropertyList as object containing objectList <s> <p> [ <p2> <o>,<o2> ] ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_as_object_containing_objectList.trig> ;
-   mf:result    <blankNodePropertyList_as_object_containing_objectList.nq> ;
-   .
+    mf:name      "blankNodePropertyList_as_object_containing_objectList" ;
+    rdfs:comment "blankNodePropertyList as object containing objectList <s> <p> [ <p2> <o>,<o2> ] ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_as_object_containing_objectList.trig> ;
+    mf:result    <blankNodePropertyList_as_object_containing_objectList.nq> ;
+    .
 
 <#blankNodePropertyList_as_object_containing_objectList_of_two_objects> rdf:type rdft:TestTrigEval ;
-   mf:name      "blankNodePropertyList_as_object_containing_objectList_of_two_objects" ;
-   rdfs:comment "blankNodePropertyList as object containing objectList of two objects <s> <p> [ <p2 <o> ] , <o2> ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_as_object_containing_objectList_of_two_objects.trig> ;
-   mf:result    <blankNodePropertyList_as_object_containing_objectList_of_two_objects.nq> ;
-   .
+    mf:name      "blankNodePropertyList_as_object_containing_objectList_of_two_objects" ;
+    rdfs:comment "blankNodePropertyList as object containing objectList of two objects <s> <p> [ <p2 <o> ] , <o2> ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_as_object_containing_objectList_of_two_objects.trig> ;
+    mf:result    <blankNodePropertyList_as_object_containing_objectList_of_two_objects.nq> ;
+    .
 
 <#blankNodePropertyList_with_multiple_triples> rdf:type rdft:TestTrigEval ;
-   mf:name      "blankNodePropertyList_with_multiple_triples" ;
-   rdfs:comment "blankNodePropertyList with multiple triples [ <s> <p> ; <s2> <p2> ]" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_with_multiple_triples.trig> ;
-   mf:result    <blankNodePropertyList_with_multiple_triples.nq> ;
-   .
+    mf:name      "blankNodePropertyList_with_multiple_triples" ;
+    rdfs:comment "blankNodePropertyList with multiple triples [ <s> <p> ; <s2> <p2> ]" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_with_multiple_triples.trig> ;
+    mf:result    <blankNodePropertyList_with_multiple_triples.nq> ;
+    .
 
 <#nested_blankNodePropertyLists> rdf:type rdft:TestTrigEval ;
-   mf:name      "nested_blankNodePropertyLists" ;
-   rdfs:comment "nested blankNodePropertyLists [ <p1> [ <p2> <o2> ] ; <p3> <o3> ]" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nested_blankNodePropertyLists.trig> ;
-   mf:result    <nested_blankNodePropertyLists.nq> ;
-   .
+    mf:name      "nested_blankNodePropertyLists" ;
+    rdfs:comment "nested blankNodePropertyLists [ <p1> [ <p2> <o2> ] ; <p3> <o3> ]" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nested_blankNodePropertyLists.trig> ;
+    mf:result    <nested_blankNodePropertyLists.nq> ;
+    .
 
 <#blankNodePropertyList_containing_collection> rdf:type rdft:TestTrigEval ;
-   mf:name      "blankNodePropertyList_containing_collection" ;
-   rdfs:comment "blankNodePropertyList containing collection [ <p1> ( … ) ]" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_containing_collection.trig> ;
-   mf:result    <blankNodePropertyList_containing_collection.nq> ;
-   .
+    mf:name      "blankNodePropertyList_containing_collection" ;
+    rdfs:comment "blankNodePropertyList containing collection [ <p1> ( … ) ]" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_containing_collection.trig> ;
+    mf:result    <blankNodePropertyList_containing_collection.nq> ;
+    .
 
 <#collection_subject> rdf:type rdft:TestTrigEval ;
-   mf:name      "collection_subject" ;
-   rdfs:comment "collection subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <collection_subject.trig> ;
-   mf:result    <collection_subject.nq> ;
-   .
+    mf:name      "collection_subject" ;
+    rdfs:comment "collection subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <collection_subject.trig> ;
+    mf:result    <collection_subject.nq> ;
+    .
 
 <#collection_object> rdf:type rdft:TestTrigEval ;
-   mf:name      "collection_object" ;
-   rdfs:comment "collection object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <collection_object.trig> ;
-   mf:result    <collection_object.nq> ;
-   .
+    mf:name      "collection_object" ;
+    rdfs:comment "collection object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <collection_object.trig> ;
+    mf:result    <collection_object.nq> ;
+    .
 
 <#empty_collection> rdf:type rdft:TestTrigEval ;
-   mf:name      "empty_collection" ;
-   rdfs:comment "empty collection ()" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <empty_collection.trig> ;
-   mf:result    <empty_collection.nq> ;
-   .
+    mf:name      "empty_collection" ;
+    rdfs:comment "empty collection ()" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <empty_collection.trig> ;
+    mf:result    <empty_collection.nq> ;
+    .
 
 <#nested_collection> rdf:type rdft:TestTrigEval ;
-   mf:name      "nested_collection" ;
-   rdfs:comment "nested collection (())" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nested_collection.trig> ;
-   mf:result    <nested_collection.nq> ;
-   .
+    mf:name      "nested_collection" ;
+    rdfs:comment "nested collection (())" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nested_collection.trig> ;
+    mf:result    <nested_collection.nq> ;
+    .
 
 <#first> rdf:type rdft:TestTrigEval ;
-   mf:name      "first" ;
-   rdfs:comment "first, not last, non-empty nested collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <first.trig> ;
-   mf:result    <first.nq> ;
-   .
+    mf:name      "first" ;
+    rdfs:comment "first, not last, non-empty nested collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <first.trig> ;
+    mf:result    <first.nq> ;
+    .
 
 <#last> rdf:type rdft:TestTrigEval ;
-   mf:name      "last" ;
-   rdfs:comment "last, not first, non-empty nested collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <last.trig> ;
-   mf:result    <last.nq> ;
-   .
+    mf:name      "last" ;
+    rdfs:comment "last, not first, non-empty nested collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <last.trig> ;
+    mf:result    <last.nq> ;
+    .
 
 <#LITERAL1> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL1" ;
-   rdfs:comment "LITERAL1 'x'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL1.trig> ;
-   mf:result    <LITERAL1.nq> ;
-   .
+    mf:name      "LITERAL1" ;
+    rdfs:comment "LITERAL1 'x'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL1.trig> ;
+    mf:result    <LITERAL1.nq> ;
+    .
 
 <#LITERAL1_ascii_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL1_ascii_boundaries" ;
-   rdfs:comment "LITERAL1_ascii_boundaries '\\x00\\x09\\x0b\\x0c\\x0e\\x26\\x28...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL1_ascii_boundaries.trig> ;
-   mf:result    <LITERAL1_ascii_boundaries.nq> ;
-   .
+    mf:name      "LITERAL1_ascii_boundaries" ;
+    rdfs:comment "LITERAL1_ascii_boundaries '\\x00\\x09\\x0b\\x0c\\x0e\\x26\\x28...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL1_ascii_boundaries.trig> ;
+    mf:result    <LITERAL1_ascii_boundaries.nq> ;
+    .
 
 <#LITERAL1_with_UTF8_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL1_with_UTF8_boundaries" ;
-   rdfs:comment "LITERAL1_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL1_with_UTF8_boundaries.trig> ;
-   mf:result    <LITERAL_with_UTF8_boundaries.nq> ;
-   .
+    mf:name      "LITERAL1_with_UTF8_boundaries" ;
+    rdfs:comment "LITERAL1_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL1_with_UTF8_boundaries.trig> ;
+    mf:result    <LITERAL_with_UTF8_boundaries.nq> ;
+    .
 
 <#LITERAL1_all_controls> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL1_all_controls" ;
-   rdfs:comment "LITERAL1_all_controls '\\x00\\x01\\x02\\x03\\x04...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL1_all_controls.trig> ;
-   mf:result    <LITERAL1_all_controls.nq> ;
-   .
+    mf:name      "LITERAL1_all_controls" ;
+    rdfs:comment "LITERAL1_all_controls '\\x00\\x01\\x02\\x03\\x04...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL1_all_controls.trig> ;
+    mf:result    <LITERAL1_all_controls.nq> ;
+    .
 
 <#LITERAL1_all_punctuation> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL1_all_punctuation" ;
-   rdfs:comment "LITERAL1_all_punctuation '!\"#$%&()...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL1_all_punctuation.trig> ;
-   mf:result    <LITERAL1_all_punctuation.nq> ;
-   .
+    mf:name      "LITERAL1_all_punctuation" ;
+    rdfs:comment "LITERAL1_all_punctuation '!\"#$%&()...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL1_all_punctuation.trig> ;
+    mf:result    <LITERAL1_all_punctuation.nq> ;
+    .
 
 <#LITERAL_LONG1> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL_LONG1" ;
-   rdfs:comment "LITERAL_LONG1 '''x'''" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG1.trig> ;
-   mf:result    <LITERAL1.nq> ;
-   .
+    mf:name      "LITERAL_LONG1" ;
+    rdfs:comment "LITERAL_LONG1 '''x'''" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG1.trig> ;
+    mf:result    <LITERAL1.nq> ;
+    .
 
 <#LITERAL_LONG1_ascii_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL_LONG1_ascii_boundaries" ;
-   rdfs:comment "LITERAL_LONG1_ascii_boundaries '\\x00\\x26\\x28...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG1_ascii_boundaries.trig> ;
-   mf:result    <LITERAL_LONG1_ascii_boundaries.nq> ;
-   .
+    mf:name      "LITERAL_LONG1_ascii_boundaries" ;
+    rdfs:comment "LITERAL_LONG1_ascii_boundaries '\\x00\\x26\\x28...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG1_ascii_boundaries.trig> ;
+    mf:result    <LITERAL_LONG1_ascii_boundaries.nq> ;
+    .
 
 <#LITERAL_LONG1_with_UTF8_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL_LONG1_with_UTF8_boundaries" ;
-   rdfs:comment "LITERAL_LONG1_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG1_with_UTF8_boundaries.trig> ;
-   mf:result    <LITERAL_with_UTF8_boundaries.nq> ;
-   .
+    mf:name      "LITERAL_LONG1_with_UTF8_boundaries" ;
+    rdfs:comment "LITERAL_LONG1_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG1_with_UTF8_boundaries.trig> ;
+    mf:result    <LITERAL_with_UTF8_boundaries.nq> ;
+    .
 
 <#LITERAL_LONG1_with_1_squote> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL_LONG1_with_1_squote" ;
-   rdfs:comment "LITERAL_LONG1 with 1 squote '''a'b'''" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG1_with_1_squote.trig> ;
-   mf:result    <LITERAL_LONG1_with_1_squote.nq> ;
-   .
+    mf:name      "LITERAL_LONG1_with_1_squote" ;
+    rdfs:comment "LITERAL_LONG1 with 1 squote '''a'b'''" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG1_with_1_squote.trig> ;
+    mf:result    <LITERAL_LONG1_with_1_squote.nq> ;
+    .
 
 <#LITERAL_LONG1_with_2_squotes> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL_LONG1_with_2_squotes" ;
-   rdfs:comment "LITERAL_LONG1 with 2 squotes '''a''b'''" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG1_with_2_squotes.trig> ;
-   mf:result    <LITERAL_LONG1_with_2_squotes.nq> ;
-   .
+    mf:name      "LITERAL_LONG1_with_2_squotes" ;
+    rdfs:comment "LITERAL_LONG1 with 2 squotes '''a''b'''" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG1_with_2_squotes.trig> ;
+    mf:result    <LITERAL_LONG1_with_2_squotes.nq> ;
+    .
 
 <#LITERAL2> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL2" ;
-   rdfs:comment "LITERAL2 \"x\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL2.trig> ;
-   mf:result    <LITERAL1.nq> ;
-   .
+    mf:name      "LITERAL2" ;
+    rdfs:comment "LITERAL2 \"x\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL2.trig> ;
+    mf:result    <LITERAL1.nq> ;
+    .
 
 <#LITERAL2_ascii_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL2_ascii_boundaries" ;
-   rdfs:comment "LITERAL2_ascii_boundaries '\\x00\\x09\\x0b\\x0c\\x0e\\x21\\x23...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL2_ascii_boundaries.trig> ;
-   mf:result    <LITERAL2_ascii_boundaries.nq> ;
-   .
+    mf:name      "LITERAL2_ascii_boundaries" ;
+    rdfs:comment "LITERAL2_ascii_boundaries '\\x00\\x09\\x0b\\x0c\\x0e\\x21\\x23...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL2_ascii_boundaries.trig> ;
+    mf:result    <LITERAL2_ascii_boundaries.nq> ;
+    .
 
 <#LITERAL2_with_UTF8_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL2_with_UTF8_boundaries" ;
-   rdfs:comment "LITERAL2_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL2_with_UTF8_boundaries.trig> ;
-   mf:result    <LITERAL_with_UTF8_boundaries.nq> ;
-   .
+    mf:name      "LITERAL2_with_UTF8_boundaries" ;
+    rdfs:comment "LITERAL2_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL2_with_UTF8_boundaries.trig> ;
+    mf:result    <LITERAL_with_UTF8_boundaries.nq> ;
+    .
 
 <#LITERAL_LONG2> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL_LONG2" ;
-   rdfs:comment "LITERAL_LONG2 \"\"\"x\"\"\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2.trig> ;
-   mf:result    <LITERAL1.nq> ;
-   .
+    mf:name      "LITERAL_LONG2" ;
+    rdfs:comment "LITERAL_LONG2 \"\"\"x\"\"\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2.trig> ;
+    mf:result    <LITERAL1.nq> ;
+    .
 
 <#LITERAL_LONG2_ascii_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL_LONG2_ascii_boundaries" ;
-   rdfs:comment "LITERAL_LONG2_ascii_boundaries '\\x00\\x21\\x23...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2_ascii_boundaries.trig> ;
-   mf:result    <LITERAL_LONG2_ascii_boundaries.nq> ;
-   .
+    mf:name      "LITERAL_LONG2_ascii_boundaries" ;
+    rdfs:comment "LITERAL_LONG2_ascii_boundaries '\\x00\\x21\\x23...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2_ascii_boundaries.trig> ;
+    mf:result    <LITERAL_LONG2_ascii_boundaries.nq> ;
+    .
 
 <#LITERAL_LONG2_with_UTF8_boundaries> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL_LONG2_with_UTF8_boundaries" ;
-   rdfs:comment "LITERAL_LONG2_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2_with_UTF8_boundaries.trig> ;
-   mf:result    <LITERAL_with_UTF8_boundaries.nq> ;
-   .
+    mf:name      "LITERAL_LONG2_with_UTF8_boundaries" ;
+    rdfs:comment "LITERAL_LONG2_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2_with_UTF8_boundaries.trig> ;
+    mf:result    <LITERAL_with_UTF8_boundaries.nq> ;
+    .
 
 <#LITERAL_LONG2_with_1_squote> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL_LONG2_with_1_squote" ;
-   rdfs:comment "LITERAL_LONG2 with 1 squote \"\"\"a\"b\"\"\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2_with_1_squote.trig> ;
-   mf:result    <LITERAL_LONG2_with_1_squote.nq> ;
-   .
+    mf:name      "LITERAL_LONG2_with_1_squote" ;
+    rdfs:comment "LITERAL_LONG2 with 1 squote \"\"\"a\"b\"\"\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2_with_1_squote.trig> ;
+    mf:result    <LITERAL_LONG2_with_1_squote.nq> ;
+    .
 
 <#LITERAL_LONG2_with_2_squotes> rdf:type rdft:TestTrigEval ;
-   mf:name      "LITERAL_LONG2_with_2_squotes" ;
-   rdfs:comment "LITERAL_LONG2 with 2 squotes \"\"\"a\"\"b\"\"\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2_with_2_squotes.trig> ;
-   mf:result    <LITERAL_LONG2_with_2_squotes.nq> ;
-   .
+    mf:name      "LITERAL_LONG2_with_2_squotes" ;
+    rdfs:comment "LITERAL_LONG2 with 2 squotes \"\"\"a\"\"b\"\"\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2_with_2_squotes.trig> ;
+    mf:result    <LITERAL_LONG2_with_2_squotes.nq> ;
+    .
 
 <#literal_with_CHARACTER_TABULATION> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_CHARACTER_TABULATION" ;
-   rdfs:comment "literal with CHARACTER TABULATION" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_CHARACTER_TABULATION.trig> ;
-   mf:result    <literal_with_CHARACTER_TABULATION.nq> ;
-   .
+    mf:name      "literal_with_CHARACTER_TABULATION" ;
+    rdfs:comment "literal with CHARACTER TABULATION" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_CHARACTER_TABULATION.trig> ;
+    mf:result    <literal_with_CHARACTER_TABULATION.nq> ;
+    .
 
 <#literal_with_BACKSPACE> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_BACKSPACE" ;
-   rdfs:comment "literal with BACKSPACE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_BACKSPACE.trig> ;
-   mf:result    <literal_with_BACKSPACE.nq> ;
-   .
+    mf:name      "literal_with_BACKSPACE" ;
+    rdfs:comment "literal with BACKSPACE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_BACKSPACE.trig> ;
+    mf:result    <literal_with_BACKSPACE.nq> ;
+    .
 
 <#literal_with_LINE_FEED> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_LINE_FEED" ;
-   rdfs:comment "literal with LINE FEED" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_LINE_FEED.trig> ;
-   mf:result    <literal_with_LINE_FEED.nq> ;
-   .
+    mf:name      "literal_with_LINE_FEED" ;
+    rdfs:comment "literal with LINE FEED" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_LINE_FEED.trig> ;
+    mf:result    <literal_with_LINE_FEED.nq> ;
+    .
 
 <#literal_with_CARRIAGE_RETURN> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_CARRIAGE_RETURN" ;
-   rdfs:comment "literal with CARRIAGE RETURN" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_CARRIAGE_RETURN.trig> ;
-   mf:result    <literal_with_CARRIAGE_RETURN.nq> ;
-   .
+    mf:name      "literal_with_CARRIAGE_RETURN" ;
+    rdfs:comment "literal with CARRIAGE RETURN" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_CARRIAGE_RETURN.trig> ;
+    mf:result    <literal_with_CARRIAGE_RETURN.nq> ;
+    .
 
 <#literal_with_FORM_FEED> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_FORM_FEED" ;
-   rdfs:comment "literal with FORM FEED" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_FORM_FEED.trig> ;
-   mf:result    <literal_with_FORM_FEED.nq> ;
-   .
+    mf:name      "literal_with_FORM_FEED" ;
+    rdfs:comment "literal with FORM FEED" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_FORM_FEED.trig> ;
+    mf:result    <literal_with_FORM_FEED.nq> ;
+    .
 
 <#literal_with_REVERSE_SOLIDUS> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_REVERSE_SOLIDUS" ;
-   rdfs:comment "literal with REVERSE SOLIDUS" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_REVERSE_SOLIDUS.trig> ;
-   mf:result    <literal_with_REVERSE_SOLIDUS.nq> ;
-   .
+    mf:name      "literal_with_REVERSE_SOLIDUS" ;
+    rdfs:comment "literal with REVERSE SOLIDUS" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_REVERSE_SOLIDUS.trig> ;
+    mf:result    <literal_with_REVERSE_SOLIDUS.nq> ;
+    .
 
 <#literal_with_escaped_CHARACTER_TABULATION> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_escaped_CHARACTER_TABULATION" ;
-   rdfs:comment "literal with escaped CHARACTER TABULATION" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_escaped_CHARACTER_TABULATION.trig> ;
-   mf:result    <literal_with_CHARACTER_TABULATION.nq> ;
-   .
+    mf:name      "literal_with_escaped_CHARACTER_TABULATION" ;
+    rdfs:comment "literal with escaped CHARACTER TABULATION" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_escaped_CHARACTER_TABULATION.trig> ;
+    mf:result    <literal_with_CHARACTER_TABULATION.nq> ;
+    .
 
 <#literal_with_escaped_BACKSPACE> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_escaped_BACKSPACE" ;
-   rdfs:comment "literal with escaped BACKSPACE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_escaped_BACKSPACE.trig> ;
-   mf:result    <literal_with_BACKSPACE.nq> ;
-   .
+    mf:name      "literal_with_escaped_BACKSPACE" ;
+    rdfs:comment "literal with escaped BACKSPACE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_escaped_BACKSPACE.trig> ;
+    mf:result    <literal_with_BACKSPACE.nq> ;
+    .
 
 <#literal_with_escaped_LINE_FEED> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_escaped_LINE_FEED" ;
-   rdfs:comment "literal with escaped LINE FEED" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_escaped_LINE_FEED.trig> ;
-   mf:result    <literal_with_LINE_FEED.nq> ;
-   .
+    mf:name      "literal_with_escaped_LINE_FEED" ;
+    rdfs:comment "literal with escaped LINE FEED" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_escaped_LINE_FEED.trig> ;
+    mf:result    <literal_with_LINE_FEED.nq> ;
+    .
 
 <#literal_with_escaped_CARRIAGE_RETURN> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_escaped_CARRIAGE_RETURN" ;
-   rdfs:comment "literal with escaped CARRIAGE RETURN" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_escaped_CARRIAGE_RETURN.trig> ;
-   mf:result    <literal_with_CARRIAGE_RETURN.nq> ;
-   .
+    mf:name      "literal_with_escaped_CARRIAGE_RETURN" ;
+    rdfs:comment "literal with escaped CARRIAGE RETURN" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_escaped_CARRIAGE_RETURN.trig> ;
+    mf:result    <literal_with_CARRIAGE_RETURN.nq> ;
+    .
 
 <#literal_with_escaped_FORM_FEED> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_escaped_FORM_FEED" ;
-   rdfs:comment "literal with escaped FORM FEED" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_escaped_FORM_FEED.trig> ;
-   mf:result    <literal_with_FORM_FEED.nq> ;
-   .
+    mf:name      "literal_with_escaped_FORM_FEED" ;
+    rdfs:comment "literal with escaped FORM FEED" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_escaped_FORM_FEED.trig> ;
+    mf:result    <literal_with_FORM_FEED.nq> ;
+    .
 
 <#literal_with_numeric_escape4> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_numeric_escape4" ;
-   rdfs:comment "literal with numeric escape4 \\u" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_numeric_escape4.trig> ;
-   mf:result    <literal_with_numeric_escape4.nq> ;
-   .
+    mf:name      "literal_with_numeric_escape4" ;
+    rdfs:comment "literal with numeric escape4 \\u" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_numeric_escape4.trig> ;
+    mf:result    <literal_with_numeric_escape4.nq> ;
+    .
 
 <#literal_with_numeric_escape8> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_with_numeric_escape8" ;
-   rdfs:comment "literal with numeric escape8 \\U" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_numeric_escape8.trig> ;
-   mf:result    <literal_with_numeric_escape4.nq> ;
-   .
+    mf:name      "literal_with_numeric_escape8" ;
+    rdfs:comment "literal with numeric escape8 \\U" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_numeric_escape8.trig> ;
+    mf:result    <literal_with_numeric_escape4.nq> ;
+    .
 
 <#IRIREF_datatype> rdf:type rdft:TestTrigEval ;
-   mf:name      "IRIREF_datatype" ;
-   rdfs:comment "IRIREF datatype \"\"^^<t>" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <IRIREF_datatype.trig> ;
-   mf:result    <IRIREF_datatype.nq> ;
-   .
+    mf:name      "IRIREF_datatype" ;
+    rdfs:comment "IRIREF datatype \"\"^^<t>" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <IRIREF_datatype.trig> ;
+    mf:result    <IRIREF_datatype.nq> ;
+    .
 
 <#prefixed_name_datatype> rdf:type rdft:TestTrigEval ;
-   mf:name      "prefixed_name_datatype" ;
-   rdfs:comment "prefixed name datatype \"\"^^p:t" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefixed_name_datatype.trig> ;
-   mf:result    <IRIREF_datatype.nq> ;
-   .
+    mf:name      "prefixed_name_datatype" ;
+    rdfs:comment "prefixed name datatype \"\"^^p:t" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefixed_name_datatype.trig> ;
+    mf:result    <IRIREF_datatype.nq> ;
+    .
 
 <#bareword_integer> rdf:type rdft:TestTrigEval ;
-   mf:name      "bareword_integer" ;
-   rdfs:comment "bareword integer" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <bareword_integer.trig> ;
-   mf:result    <IRIREF_datatype.nq> ;
-   .
+    mf:name      "bareword_integer" ;
+    rdfs:comment "bareword integer" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <bareword_integer.trig> ;
+    mf:result    <IRIREF_datatype.nq> ;
+    .
 
 <#bareword_decimal> rdf:type rdft:TestTrigEval ;
-   mf:name      "bareword_decimal" ;
-   rdfs:comment "bareword decimal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <bareword_decimal.trig> ;
-   mf:result    <bareword_decimal.nq> ;
-   .
+    mf:name      "bareword_decimal" ;
+    rdfs:comment "bareword decimal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <bareword_decimal.trig> ;
+    mf:result    <bareword_decimal.nq> ;
+    .
 
 <#bareword_double> rdf:type rdft:TestTrigEval ;
-   mf:name      "bareword_double" ;
-   rdfs:comment "bareword double" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <bareword_double.trig> ;
-   mf:result    <bareword_double.nq> ;
-   .
+    mf:name      "bareword_double" ;
+    rdfs:comment "bareword double" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <bareword_double.trig> ;
+    mf:result    <bareword_double.nq> ;
+    .
 
 <#double_lower_case_e> rdf:type rdft:TestTrigEval ;
-   mf:name      "double_lower_case_e" ;
-   rdfs:comment "double lower case e" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <double_lower_case_e.trig> ;
-   mf:result    <double_lower_case_e.nq> ;
-   .
+    mf:name      "double_lower_case_e" ;
+    rdfs:comment "double lower case e" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <double_lower_case_e.trig> ;
+    mf:result    <double_lower_case_e.nq> ;
+    .
 
 <#negative_numeric> rdf:type rdft:TestTrigEval ;
-   mf:name      "negative_numeric" ;
-   rdfs:comment "negative numeric" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <negative_numeric.trig> ;
-   mf:result    <negative_numeric.nq> ;
-   .
+    mf:name      "negative_numeric" ;
+    rdfs:comment "negative numeric" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <negative_numeric.trig> ;
+    mf:result    <negative_numeric.nq> ;
+    .
 
 <#positive_numeric> rdf:type rdft:TestTrigEval ;
-   mf:name      "positive_numeric" ;
-   rdfs:comment "positive numeric" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <positive_numeric.trig> ;
-   mf:result    <positive_numeric.nq> ;
-   .
+    mf:name      "positive_numeric" ;
+    rdfs:comment "positive numeric" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <positive_numeric.trig> ;
+    mf:result    <positive_numeric.nq> ;
+    .
 
 <#numeric_with_leading_0> rdf:type rdft:TestTrigEval ;
-   mf:name      "numeric_with_leading_0" ;
-   rdfs:comment "numeric with leading 0" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <numeric_with_leading_0.trig> ;
-   mf:result    <numeric_with_leading_0.nq> ;
-   .
+    mf:name      "numeric_with_leading_0" ;
+    rdfs:comment "numeric with leading 0" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <numeric_with_leading_0.trig> ;
+    mf:result    <numeric_with_leading_0.nq> ;
+    .
 
 <#literal_true> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_true" ;
-   rdfs:comment "literal true" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_true.trig> ;
-   mf:result    <literal_true.nq> ;
-   .
+    mf:name      "literal_true" ;
+    rdfs:comment "literal true" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_true.trig> ;
+    mf:result    <literal_true.nq> ;
+    .
 
 <#literal_false> rdf:type rdft:TestTrigEval ;
-   mf:name      "literal_false" ;
-   rdfs:comment "literal false" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_false.trig> ;
-   mf:result    <literal_false.nq> ;
-   .
+    mf:name      "literal_false" ;
+    rdfs:comment "literal false" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_false.trig> ;
+    mf:result    <literal_false.nq> ;
+    .
 
 <#langtagged_non_LONG> rdf:type rdft:TestTrigEval ;
-   mf:name      "langtagged_non_LONG" ;
-   rdfs:comment "langtagged non-LONG \"x\"@en" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <langtagged_non_LONG.trig> ;
-   mf:result    <langtagged_non_LONG.nq> ;
-   .
+    mf:name      "langtagged_non_LONG" ;
+    rdfs:comment "langtagged non-LONG \"x\"@en" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <langtagged_non_LONG.trig> ;
+    mf:result    <langtagged_non_LONG.nq> ;
+    .
 
 <#langtagged_LONG> rdf:type rdft:TestTrigEval ;
-   mf:name      "langtagged_LONG" ;
-   rdfs:comment "langtagged LONG \"\"\"x\"\"\"@en" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <langtagged_LONG.trig> ;
-   mf:result    <langtagged_non_LONG.nq> ;
-   .
+    mf:name      "langtagged_LONG" ;
+    rdfs:comment "langtagged LONG \"\"\"x\"\"\"@en" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <langtagged_LONG.trig> ;
+    mf:result    <langtagged_non_LONG.nq> ;
+    .
 
 <#lantag_with_subtag> rdf:type rdft:TestTrigEval ;
-   mf:name      "lantag_with_subtag" ;
-   rdfs:comment "lantag with subtag \"x\"@en-us" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <lantag_with_subtag.trig> ;
-   mf:result    <lantag_with_subtag.nq> ;
-   .
+    mf:name      "lantag_with_subtag" ;
+    rdfs:comment "lantag with subtag \"x\"@en-us" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <lantag_with_subtag.trig> ;
+    mf:result    <lantag_with_subtag.nq> ;
+    .
 
 <#objectList_with_two_objects> rdf:type rdft:TestTrigEval ;
-   mf:name      "objectList_with_two_objects" ;
-   rdfs:comment "objectList with two objects … <o1>,<o2>" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <objectList_with_two_objects.trig> ;
-   mf:result    <objectList_with_two_objects.nq> ;
-   .
+    mf:name      "objectList_with_two_objects" ;
+    rdfs:comment "objectList with two objects … <o1>,<o2>" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <objectList_with_two_objects.trig> ;
+    mf:result    <objectList_with_two_objects.nq> ;
+    .
 
 <#predicateObjectList_with_two_objectLists> rdf:type rdft:TestTrigEval ;
-   mf:name      "predicateObjectList_with_two_objectLists" ;
-   rdfs:comment "predicateObjectList with two objectLists … <o1>,<o2>" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <predicateObjectList_with_two_objectLists.trig> ;
-   mf:result    <predicateObjectList_with_two_objectLists.nq> ;
-   .
+    mf:name      "predicateObjectList_with_two_objectLists" ;
+    rdfs:comment "predicateObjectList with two objectLists … <o1>,<o2>" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <predicateObjectList_with_two_objectLists.trig> ;
+    mf:result    <predicateObjectList_with_two_objectLists.nq> ;
+    .
 
 <#predicateObjectList_with_blankNodePropertyList_as_object> rdf:type rdft:TestTrigEval ;
-   mf:name      "predicateObjectList_with_blankNodePropertyList_as_object" ;
-   rdfs:comment "predicateObjectList_with_blankNodePropertyList_as_object <s> <p> [ <p2> <o> ] ; <p3> [ <p4> <o2> , <o3> ] " ;
-   rdft:approval rdft:Approved ;
-   mf:action    <predicateObjectList_with_blankNodePropertyList_as_object.trig> ;
-   mf:result    <predicateObjectList_with_blankNodePropertyList_as_object.nq> ;
-   .
+    mf:name      "predicateObjectList_with_blankNodePropertyList_as_object" ;
+    rdfs:comment "predicateObjectList_with_blankNodePropertyList_as_object <s> <p> [ <p2> <o> ] ; <p3> [ <p4> <o2> , <o3> ] " ;
+    rdft:approval rdft:Approved ;
+    mf:action    <predicateObjectList_with_blankNodePropertyList_as_object.trig> ;
+    mf:result    <predicateObjectList_with_blankNodePropertyList_as_object.nq> ;
+    .
 
 <#repeated_semis_at_end> rdf:type rdft:TestTrigEval ;
-   mf:name      "repeated_semis_at_end" ;
-   rdfs:comment "repeated semis at end <s> <p> <o> ;; <p2> <o2> ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <repeated_semis_at_end.trig> ;
-   mf:result    <predicateObjectList_with_two_objectLists.nq> ;
-   .
+    mf:name      "repeated_semis_at_end" ;
+    rdfs:comment "repeated semis at end <s> <p> <o> ;; <p2> <o2> ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <repeated_semis_at_end.trig> ;
+    mf:result    <predicateObjectList_with_two_objectLists.nq> ;
+    .
 
 <#repeated_semis_not_at_end> rdf:type rdft:TestTrigEval ;
-   mf:name      "repeated_semis_not_at_end" ;
-   rdfs:comment "repeated semis not at end <s> <p> <o> ;;." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <repeated_semis_not_at_end.trig> ;
-   mf:result    <repeated_semis_not_at_end.nq> ;
-   .
+    mf:name      "repeated_semis_not_at_end" ;
+    rdfs:comment "repeated semis not at end <s> <p> <o> ;;." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <repeated_semis_not_at_end.trig> ;
+    mf:result    <repeated_semis_not_at_end.nq> ;
+    .
 
 # original tests-ttl
 <#trig-syntax-file-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-file-01" ;
-   rdfs:comment "Empty file" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-file-01.trig> ;
-   .
+    mf:name    "trig-syntax-file-01" ;
+    rdfs:comment "Empty file" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-file-01.trig> ;
+    .
 
 <#trig-syntax-file-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-file-02" ;
-   rdfs:comment "Only comment" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-file-02.trig> ;
-   .
+    mf:name    "trig-syntax-file-02" ;
+    rdfs:comment "Only comment" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-file-02.trig> ;
+    .
 
 <#trig-syntax-file-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-file-03" ;
-   rdfs:comment "One comment, one empty line" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-file-03.trig> ;
-   .
+    mf:name    "trig-syntax-file-03" ;
+    rdfs:comment "One comment, one empty line" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-file-03.trig> ;
+    .
 
 <#trig-syntax-uri-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-uri-01" ;
-   rdfs:comment "Only IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-uri-01.trig> ;
-   .
+    mf:name    "trig-syntax-uri-01" ;
+    rdfs:comment "Only IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-uri-01.trig> ;
+    .
 
 <#trig-syntax-uri-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-uri-02" ;
-   rdfs:comment "IRIs with Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-uri-02.trig> ;
-   .
+    mf:name    "trig-syntax-uri-02" ;
+    rdfs:comment "IRIs with Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-uri-02.trig> ;
+    .
 
 <#trig-syntax-uri-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-uri-03" ;
-   rdfs:comment "IRIs with long Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-uri-03.trig> ;
-   .
+    mf:name    "trig-syntax-uri-03" ;
+    rdfs:comment "IRIs with long Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-uri-03.trig> ;
+    .
 
 <#trig-syntax-uri-04> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-uri-04" ;
-   rdfs:comment "Legal IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-uri-04.trig> ;
-   .
+    mf:name    "trig-syntax-uri-04" ;
+    rdfs:comment "Legal IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-uri-04.trig> ;
+    .
 
 <#trig-syntax-bad-uri-escape-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-uri-escape-01" ;
-   rdfs:comment "Bad IRI : good escape, bad character (negative evaluation test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-uri-escape-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-uri-escape-01" ;
+    rdfs:comment "Bad IRI : good escape, bad character (negative evaluation test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-uri-escape-01.trig> ;
+    .
 
 <#trig-syntax-bad-uri-escape-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-uri-escape-02" ;
-   rdfs:comment "Bad IRI : hex 3C is < (negative evaluation test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-uri-escape-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-uri-escape-02" ;
+    rdfs:comment "Bad IRI : hex 3C is < (negative evaluation test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-uri-escape-02.trig> ;
+    .
 
 <#trig-syntax-bad-uri-escape-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-uri-escape-03" ;
-   rdfs:comment "Bad IRI : hex 3E is  (negative evaluation test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-uri-escape-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-uri-escape-03" ;
+    rdfs:comment "Bad IRI : hex 3E is  (negative evaluation test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-uri-escape-03.trig> ;
+    .
 
 <#trig-syntax-bad-uri-escape-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-uri-escape-04" ;
-   rdfs:comment "Bad IRI : {abc} (negative evaluation test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-uri-escape-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-uri-escape-04" ;
+    rdfs:comment "Bad IRI : {abc} (negative evaluation test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-uri-escape-04.trig> ;
+    .
 
 <#trig-syntax-base-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-base-01" ;
-   rdfs:comment "@base" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-base-01.trig> ;
-   .
+    mf:name    "trig-syntax-base-01" ;
+    rdfs:comment "@base" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-base-01.trig> ;
+    .
 
 <#trig-syntax-base-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-base-02" ;
-   rdfs:comment "BASE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-base-02.trig> ;
-   .
+    mf:name    "trig-syntax-base-02" ;
+    rdfs:comment "BASE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-base-02.trig> ;
+    .
 
 <#trig-syntax-base-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-base-03" ;
-   rdfs:comment "@base with relative IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-base-03.trig> ;
-   .
+    mf:name    "trig-syntax-base-03" ;
+    rdfs:comment "@base with relative IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-base-03.trig> ;
+    .
 
 <#trig-syntax-base-04> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-base-04" ;
-   rdfs:comment "base with relative IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-base-04.trig> ;
-   .
+    mf:name    "trig-syntax-base-04" ;
+    rdfs:comment "base with relative IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-base-04.trig> ;
+    .
 
 <#trig-syntax-prefix-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-prefix-01" ;
-   rdfs:comment "@prefix" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-prefix-01.trig> ;
-   .
+    mf:name    "trig-syntax-prefix-01" ;
+    rdfs:comment "@prefix" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-prefix-01.trig> ;
+    .
 
 <#trig-syntax-prefix-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-prefix-02" ;
-   rdfs:comment "PreFIX" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-prefix-02.trig> ;
-   .
+    mf:name    "trig-syntax-prefix-02" ;
+    rdfs:comment "PreFIX" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-prefix-02.trig> ;
+    .
 
 <#trig-syntax-prefix-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-prefix-03" ;
-   rdfs:comment "Empty PREFIX" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-prefix-03.trig> ;
-   .
+    mf:name    "trig-syntax-prefix-03" ;
+    rdfs:comment "Empty PREFIX" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-prefix-03.trig> ;
+    .
 
 <#trig-syntax-prefix-04> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-prefix-04" ;
-   rdfs:comment "Empty @prefix with % escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-prefix-04.trig> ;
-   .
+    mf:name    "trig-syntax-prefix-04" ;
+    rdfs:comment "Empty @prefix with % escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-prefix-04.trig> ;
+    .
 
 <#trig-syntax-prefix-05> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-prefix-05" ;
-   rdfs:comment "@prefix with no suffix" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-prefix-05.trig> ;
-   .
+    mf:name    "trig-syntax-prefix-05" ;
+    rdfs:comment "@prefix with no suffix" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-prefix-05.trig> ;
+    .
 
 <#trig-syntax-prefix-06> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-prefix-06" ;
-   rdfs:comment "colon is a legal pname character" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-prefix-06.trig> ;
-   .
+    mf:name    "trig-syntax-prefix-06" ;
+    rdfs:comment "colon is a legal pname character" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-prefix-06.trig> ;
+    .
 
 <#trig-syntax-prefix-07> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-prefix-07" ;
-   rdfs:comment "dash is a legal pname character" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-prefix-07.trig> ;
-   .
+    mf:name    "trig-syntax-prefix-07" ;
+    rdfs:comment "dash is a legal pname character" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-prefix-07.trig> ;
+    .
 
 <#trig-syntax-prefix-08> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-prefix-08" ;
-   rdfs:comment "underscore is a legal pname character" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-prefix-08.trig> ;
-   .
+    mf:name    "trig-syntax-prefix-08" ;
+    rdfs:comment "underscore is a legal pname character" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-prefix-08.trig> ;
+    .
 
 <#trig-syntax-prefix-09> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-prefix-09" ;
-   rdfs:comment "percents in pnames" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-prefix-09.trig> ;
-   .
+    mf:name    "trig-syntax-prefix-09" ;
+    rdfs:comment "percents in pnames" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-prefix-09.trig> ;
+    .
 
 <#trig-syntax-string-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-01" ;
-   rdfs:comment "string literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-01.trig> ;
-   .
+    mf:name    "trig-syntax-string-01" ;
+    rdfs:comment "string literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-01.trig> ;
+    .
 
 <#trig-syntax-string-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-02" ;
-   rdfs:comment "langString literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-02.trig> ;
-   .
+    mf:name    "trig-syntax-string-02" ;
+    rdfs:comment "langString literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-02.trig> ;
+    .
 
 <#trig-syntax-string-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-03" ;
-   rdfs:comment "langString literal with region" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-03.trig> ;
-   .
+    mf:name    "trig-syntax-string-03" ;
+    rdfs:comment "langString literal with region" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-03.trig> ;
+    .
 
 <#trig-syntax-string-04> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-04" ;
-   rdfs:comment "squote string literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-04.trig> ;
-   .
+    mf:name    "trig-syntax-string-04" ;
+    rdfs:comment "squote string literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-04.trig> ;
+    .
 
 <#trig-syntax-string-05> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-05" ;
-   rdfs:comment "squote langString literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-05.trig> ;
-   .
+    mf:name    "trig-syntax-string-05" ;
+    rdfs:comment "squote langString literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-05.trig> ;
+    .
 
 <#trig-syntax-string-06> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-06" ;
-   rdfs:comment "squote langString literal with region" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-06.trig> ;
-   .
+    mf:name    "trig-syntax-string-06" ;
+    rdfs:comment "squote langString literal with region" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-06.trig> ;
+    .
 
 <#trig-syntax-string-07> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-07" ;
-   rdfs:comment "long string literal with embedded single- and double-quotes" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-07.trig> ;
-   .
+    mf:name    "trig-syntax-string-07" ;
+    rdfs:comment "long string literal with embedded single- and double-quotes" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-07.trig> ;
+    .
 
 <#trig-syntax-string-08> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-08" ;
-   rdfs:comment "long string literal with embedded newline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-08.trig> ;
-   .
+    mf:name    "trig-syntax-string-08" ;
+    rdfs:comment "long string literal with embedded newline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-08.trig> ;
+    .
 
 <#trig-syntax-string-09> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-09" ;
-   rdfs:comment "squote long string literal with embedded single- and double-quotes" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-09.trig> ;
-   .
+    mf:name    "trig-syntax-string-09" ;
+    rdfs:comment "squote long string literal with embedded single- and double-quotes" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-09.trig> ;
+    .
 
 <#trig-syntax-string-10> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-10" ;
-   rdfs:comment "long langString literal with embedded newline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-10.trig> ;
-   .
+    mf:name    "trig-syntax-string-10" ;
+    rdfs:comment "long langString literal with embedded newline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-10.trig> ;
+    .
 
 <#trig-syntax-string-11> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-string-11" ;
-   rdfs:comment "squote long langString literal with embedded newline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-string-11.trig> ;
-   .
+    mf:name    "trig-syntax-string-11" ;
+    rdfs:comment "squote long langString literal with embedded newline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-string-11.trig> ;
+    .
 
 <#trig-syntax-str-esc-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-str-esc-01" ;
-   rdfs:comment "string literal with escaped newline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-str-esc-01.trig> ;
-   .
+    mf:name    "trig-syntax-str-esc-01" ;
+    rdfs:comment "string literal with escaped newline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-str-esc-01.trig> ;
+    .
 
 <#trig-syntax-str-esc-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-str-esc-02" ;
-   rdfs:comment "string literal with Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-str-esc-02.trig> ;
-   .
+    mf:name    "trig-syntax-str-esc-02" ;
+    rdfs:comment "string literal with Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-str-esc-02.trig> ;
+    .
 
 <#trig-syntax-str-esc-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-str-esc-03" ;
-   rdfs:comment "string literal with long Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-str-esc-03.trig> ;
-   .
+    mf:name    "trig-syntax-str-esc-03" ;
+    rdfs:comment "string literal with long Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-str-esc-03.trig> ;
+    .
 
 <#trig-syntax-pname-esc-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-pname-esc-01" ;
-   rdfs:comment "pname with back-slash escapes" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-pname-esc-01.trig> ;
-   .
+    mf:name    "trig-syntax-pname-esc-01" ;
+    rdfs:comment "pname with back-slash escapes" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-pname-esc-01.trig> ;
+    .
 
 <#trig-syntax-pname-esc-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-pname-esc-02" ;
-   rdfs:comment "pname with back-slash escapes (2)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-pname-esc-02.trig> ;
-   .
+    mf:name    "trig-syntax-pname-esc-02" ;
+    rdfs:comment "pname with back-slash escapes (2)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-pname-esc-02.trig> ;
+    .
 
 <#trig-syntax-pname-esc-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-pname-esc-03" ;
-   rdfs:comment "pname with back-slash escapes (3)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-pname-esc-03.trig> ;
-   .
+    mf:name    "trig-syntax-pname-esc-03" ;
+    rdfs:comment "pname with back-slash escapes (3)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-pname-esc-03.trig> ;
+    .
 
 <#trig-syntax-bnode-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-bnode-01" ;
-   rdfs:comment "bnode subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bnode-01.trig> ;
-   .
+    mf:name    "trig-syntax-bnode-01" ;
+    rdfs:comment "bnode subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bnode-01.trig> ;
+    .
 
 <#trig-syntax-bnode-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-bnode-02" ;
-   rdfs:comment "bnode object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bnode-02.trig> ;
-   .
+    mf:name    "trig-syntax-bnode-02" ;
+    rdfs:comment "bnode object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bnode-02.trig> ;
+    .
 
 <#trig-syntax-bnode-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-bnode-03" ;
-   rdfs:comment "bnode property list object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bnode-03.trig> ;
-   .
+    mf:name    "trig-syntax-bnode-03" ;
+    rdfs:comment "bnode property list object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bnode-03.trig> ;
+    .
 
 <#trig-syntax-bnode-04> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-bnode-04" ;
-   rdfs:comment "bnode property list object (2)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bnode-04.trig> ;
-   .
+    mf:name    "trig-syntax-bnode-04" ;
+    rdfs:comment "bnode property list object (2)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bnode-04.trig> ;
+    .
 
 <#trig-syntax-bnode-05> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-bnode-05" ;
-   rdfs:comment "bnode property list subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bnode-05.trig> ;
-   .
+    mf:name    "trig-syntax-bnode-05" ;
+    rdfs:comment "bnode property list subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bnode-05.trig> ;
+    .
 
 <#trig-syntax-bnode-06> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-bnode-06" ;
-   rdfs:comment "labeled bnode subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bnode-06.trig> ;
-   .
+    mf:name    "trig-syntax-bnode-06" ;
+    rdfs:comment "labeled bnode subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bnode-06.trig> ;
+    .
 
 <#trig-syntax-bnode-07> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-bnode-07" ;
-   rdfs:comment "labeled bnode subject and object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bnode-07.trig> ;
-   .
+    mf:name    "trig-syntax-bnode-07" ;
+    rdfs:comment "labeled bnode subject and object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bnode-07.trig> ;
+    .
 
 <#trig-syntax-bnode-08> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-bnode-08" ;
-   rdfs:comment "bare bnode property list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bnode-08.trig> ;
-   .
+    mf:name    "trig-syntax-bnode-08" ;
+    rdfs:comment "bare bnode property list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bnode-08.trig> ;
+    .
 
 <#trig-syntax-bnode-09> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-bnode-09" ;
-   rdfs:comment "bnode property list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bnode-09.trig> ;
-   .
+    mf:name    "trig-syntax-bnode-09" ;
+    rdfs:comment "bnode property list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bnode-09.trig> ;
+    .
 
 <#trig-syntax-bnode-10> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-bnode-10" ;
-   rdfs:comment "mixed bnode property list and triple" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bnode-10.trig> ;
-   .
+    mf:name    "trig-syntax-bnode-10" ;
+    rdfs:comment "mixed bnode property list and triple" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bnode-10.trig> ;
+    .
 
 <#trig-syntax-number-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-01" ;
-   rdfs:comment "integer literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-01.trig> ;
-   .
+    mf:name    "trig-syntax-number-01" ;
+    rdfs:comment "integer literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-01.trig> ;
+    .
 
 <#trig-syntax-number-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-02" ;
-   rdfs:comment "negative integer literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-02.trig> ;
-   .
+    mf:name    "trig-syntax-number-02" ;
+    rdfs:comment "negative integer literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-02.trig> ;
+    .
 
 <#trig-syntax-number-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-03" ;
-   rdfs:comment "positive integer literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-03.trig> ;
-   .
+    mf:name    "trig-syntax-number-03" ;
+    rdfs:comment "positive integer literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-03.trig> ;
+    .
 
 <#trig-syntax-number-04> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-04" ;
-   rdfs:comment "decimal literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-04.trig> ;
-   .
+    mf:name    "trig-syntax-number-04" ;
+    rdfs:comment "decimal literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-04.trig> ;
+    .
 
 <#trig-syntax-number-05> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-05" ;
-   rdfs:comment "decimal literal (no leading digits)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-05.trig> ;
-   .
+    mf:name    "trig-syntax-number-05" ;
+    rdfs:comment "decimal literal (no leading digits)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-05.trig> ;
+    .
 
 <#trig-syntax-number-06> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-06" ;
-   rdfs:comment "negative decimal literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-06.trig> ;
-   .
+    mf:name    "trig-syntax-number-06" ;
+    rdfs:comment "negative decimal literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-06.trig> ;
+    .
 
 <#trig-syntax-number-07> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-07" ;
-   rdfs:comment "positive decimal literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-07.trig> ;
-   .
+    mf:name    "trig-syntax-number-07" ;
+    rdfs:comment "positive decimal literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-07.trig> ;
+    .
 
 <#trig-syntax-number-08> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-08" ;
-   rdfs:comment "integer literal with decimal lexical confusion" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-08.trig> ;
-   .
+    mf:name    "trig-syntax-number-08" ;
+    rdfs:comment "integer literal with decimal lexical confusion" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-08.trig> ;
+    .
 
 <#trig-syntax-number-09> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-09" ;
-   rdfs:comment "double literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-09.trig> ;
-   .
+    mf:name    "trig-syntax-number-09" ;
+    rdfs:comment "double literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-09.trig> ;
+    .
 
 <#trig-syntax-number-10> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-10" ;
-   rdfs:comment "negative double literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-10.trig> ;
-   .
+    mf:name    "trig-syntax-number-10" ;
+    rdfs:comment "negative double literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-10.trig> ;
+    .
 
 <#trig-syntax-number-11> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-11" ;
-   rdfs:comment "double literal no fraction" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-11.trig> ;
-   .
+    mf:name    "trig-syntax-number-11" ;
+    rdfs:comment "double literal no fraction" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-11.trig> ;
+    .
 
 <#trig-syntax-number-12> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-12" ;
-   rdfs:comment "double literal no leading zero" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-12.trig> ;
-   .
+    mf:name    "trig-syntax-number-12" ;
+    rdfs:comment "double literal no leading zero" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-12.trig> ;
+    .
 
 <#trig-syntax-number-13> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-number-13" ;
-   rdfs:comment "decimal literal no leading zero" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-number-13.trig> ;
-   .
+    mf:name    "trig-syntax-number-13" ;
+    rdfs:comment "decimal literal no leading zero" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-number-13.trig> ;
+    .
 
 <#trig-syntax-datatypes-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-datatypes-01" ;
-   rdfs:comment "xsd:byte literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-datatypes-01.trig> ;
-   .
+    mf:name    "trig-syntax-datatypes-01" ;
+    rdfs:comment "xsd:byte literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-datatypes-01.trig> ;
+    .
 
 <#trig-syntax-datatypes-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-datatypes-02" ;
-   rdfs:comment "integer as xsd:string" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-datatypes-02.trig> ;
-   .
+    mf:name    "trig-syntax-datatypes-02" ;
+    rdfs:comment "integer as xsd:string" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-datatypes-02.trig> ;
+    .
 
 <#trig-syntax-kw-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-kw-01" ;
-   rdfs:comment "boolean literal (true)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-kw-01.trig> ;
-   .
+    mf:name    "trig-syntax-kw-01" ;
+    rdfs:comment "boolean literal (true)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-kw-01.trig> ;
+    .
 
 <#trig-syntax-kw-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-kw-02" ;
-   rdfs:comment "boolean literal (false)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-kw-02.trig> ;
-   .
+    mf:name    "trig-syntax-kw-02" ;
+    rdfs:comment "boolean literal (false)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-kw-02.trig> ;
+    .
 
 <#trig-syntax-kw-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-kw-03" ;
-   rdfs:comment "'a' as keyword" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-kw-03.trig> ;
-   .
+    mf:name    "trig-syntax-kw-03" ;
+    rdfs:comment "'a' as keyword" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-kw-03.trig> ;
+    .
 
 <#trig-syntax-struct-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-struct-01" ;
-   rdfs:comment "object list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-struct-01.trig> ;
-   .
+    mf:name    "trig-syntax-struct-01" ;
+    rdfs:comment "object list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-struct-01.trig> ;
+    .
 
 <#trig-syntax-struct-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-struct-02" ;
-   rdfs:comment "predicate list with object list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-struct-02.trig> ;
-   .
+    mf:name    "trig-syntax-struct-02" ;
+    rdfs:comment "predicate list with object list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-struct-02.trig> ;
+    .
 
 <#trig-syntax-struct-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-struct-03" ;
-   rdfs:comment "predicate list with object list and dangling ';'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-struct-03.trig> ;
-   .
+    mf:name    "trig-syntax-struct-03" ;
+    rdfs:comment "predicate list with object list and dangling ';'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-struct-03.trig> ;
+    .
 
 <#trig-syntax-struct-04> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-struct-04" ;
-   rdfs:comment "predicate list with multiple ;;" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-struct-04.trig> ;
-   .
+    mf:name    "trig-syntax-struct-04" ;
+    rdfs:comment "predicate list with multiple ;;" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-struct-04.trig> ;
+    .
 
 <#trig-syntax-struct-05> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-struct-05" ;
-   rdfs:comment "predicate list with multiple ;;" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-struct-05.trig> ;
-   .
+    mf:name    "trig-syntax-struct-05" ;
+    rdfs:comment "predicate list with multiple ;;" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-struct-05.trig> ;
+    .
 
 <#trig-syntax-lists-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-lists-01" ;
-   rdfs:comment "empty list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-lists-01.trig> ;
-   .
+    mf:name    "trig-syntax-lists-01" ;
+    rdfs:comment "empty list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-lists-01.trig> ;
+    .
 
 <#trig-syntax-lists-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-lists-02" ;
-   rdfs:comment "mixed list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-lists-02.trig> ;
-   .
+    mf:name    "trig-syntax-lists-02" ;
+    rdfs:comment "mixed list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-lists-02.trig> ;
+    .
 
 <#trig-syntax-lists-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-lists-03" ;
-   rdfs:comment "isomorphic list as subject and object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-lists-03.trig> ;
-   .
+    mf:name    "trig-syntax-lists-03" ;
+    rdfs:comment "isomorphic list as subject and object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-lists-03.trig> ;
+    .
 
 <#trig-syntax-lists-04> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-lists-04" ;
-   rdfs:comment "lists of lists" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-lists-04.trig> ;
-   .
+    mf:name    "trig-syntax-lists-04" ;
+    rdfs:comment "lists of lists" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-lists-04.trig> ;
+    .
 
 <#trig-syntax-lists-05> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name    "trig-syntax-lists-05" ;
-   rdfs:comment "mixed lists with embedded lists" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-lists-05.trig> ;
-   .
+    mf:name    "trig-syntax-lists-05" ;
+    rdfs:comment "mixed lists with embedded lists" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-lists-05.trig> ;
+    .
 
 <#trig-syntax-bad-uri-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-uri-01" ;
-   rdfs:comment "Bad IRI : space (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-uri-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-uri-01" ;
+    rdfs:comment "Bad IRI : space (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-uri-01.trig> ;
+    .
 
 <#trig-syntax-bad-uri-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-uri-02" ;
-   rdfs:comment "Bad IRI : bad escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-uri-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-uri-02" ;
+    rdfs:comment "Bad IRI : bad escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-uri-02.trig> ;
+    .
 
 <#trig-syntax-bad-uri-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-uri-03" ;
-   rdfs:comment "Bad IRI : bad long escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-uri-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-uri-03" ;
+    rdfs:comment "Bad IRI : bad long escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-uri-03.trig> ;
+    .
 
 <#trig-syntax-bad-uri-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-uri-04" ;
-   rdfs:comment "Bad IRI : character escapes not allowed (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-uri-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-uri-04" ;
+    rdfs:comment "Bad IRI : character escapes not allowed (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-uri-04.trig> ;
+    .
 
 <#trig-syntax-bad-uri-05> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-uri-05" ;
-   rdfs:comment "Bad IRI : character escapes not allowed (2) (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-uri-05.trig> ;
-   .
+    mf:name    "trig-syntax-bad-uri-05" ;
+    rdfs:comment "Bad IRI : character escapes not allowed (2) (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-uri-05.trig> ;
+    .
 
 <#trig-syntax-bad-prefix-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-prefix-01" ;
-   rdfs:comment "No prefix (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-prefix-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-prefix-01" ;
+    rdfs:comment "No prefix (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-prefix-01.trig> ;
+    .
 
 <#trig-syntax-bad-prefix-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-prefix-02" ;
-   rdfs:comment "No prefix (2) (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-prefix-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-prefix-02" ;
+    rdfs:comment "No prefix (2) (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-prefix-02.trig> ;
+    .
 
 <#trig-syntax-bad-prefix-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-prefix-03" ;
-   rdfs:comment "@prefix without URI (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-prefix-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-prefix-03" ;
+    rdfs:comment "@prefix without URI (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-prefix-03.trig> ;
+    .
 
 <#trig-syntax-bad-prefix-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-prefix-04" ;
-   rdfs:comment "@prefix without prefix name (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-prefix-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-prefix-04" ;
+    rdfs:comment "@prefix without prefix name (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-prefix-04.trig> ;
+    .
 
 <#trig-syntax-bad-prefix-05> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-prefix-05" ;
-   rdfs:comment "@prefix without ':' (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-prefix-05.trig> ;
-   .
+    mf:name    "trig-syntax-bad-prefix-05" ;
+    rdfs:comment "@prefix without ':' (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-prefix-05.trig> ;
+    .
 
 <#trig-syntax-bad-base-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-base-01" ;
-   rdfs:comment "@base without URI (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-base-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-base-01" ;
+    rdfs:comment "@base without URI (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-base-01.trig> ;
+    .
 
 <#trig-syntax-bad-base-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-base-02" ;
-   rdfs:comment "@base in wrong case (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-base-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-base-02" ;
+    rdfs:comment "@base in wrong case (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-base-02.trig> ;
+    .
 
 <#trig-syntax-bad-base-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-base-03" ;
-   rdfs:comment "BASE without URI (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-base-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-base-03" ;
+    rdfs:comment "BASE without URI (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-base-03.trig> ;
+    .
 
 <#trig-syntax-bad-bnode-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-syntax-bad-bnode-01" ;
-   rdfs:comment "Colon in bnode label not allowed (negative test)" ;
-   mf:action    <trig-syntax-bad-bnode-01.trig> ;
-   .
+    mf:name      "trig-syntax-bad-bnode-01" ;
+    rdfs:comment "Colon in bnode label not allowed (negative test)" ;
+    mf:action    <trig-syntax-bad-bnode-01.trig> ;
+    .
 
 <#trig-syntax-bad-bnode-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-syntax-bad-bnode-02" ;
-   rdfs:comment "Colon in bnode label not allowed (negative test)" ;
-   mf:action    <trig-syntax-bad-bnode-02.trig> ;
-   .
+    mf:name      "trig-syntax-bad-bnode-02" ;
+    rdfs:comment "Colon in bnode label not allowed (negative test)" ;
+    mf:action    <trig-syntax-bad-bnode-02.trig> ;
+    .
 
 <#trig-syntax-bad-struct-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-02" ;
-   rdfs:comment "Turtle is not N3 (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-02" ;
+    rdfs:comment "Turtle is not N3 (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-02.trig> ;
+    .
 
 <#trig-syntax-bad-struct-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-03" ;
-   rdfs:comment "Turtle is not NQuads (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-03" ;
+    rdfs:comment "Turtle is not NQuads (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-03.trig> ;
+    .
 
 <#trig-syntax-bad-struct-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-04" ;
-   rdfs:comment "Turtle does not allow literals-as-subjects (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-04" ;
+    rdfs:comment "Turtle does not allow literals-as-subjects (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-04.trig> ;
+    .
 
 <#trig-syntax-bad-struct-05> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-05" ;
-   rdfs:comment "Turtle does not allow literals-as-predicates (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-05.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-05" ;
+    rdfs:comment "Turtle does not allow literals-as-predicates (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-05.trig> ;
+    .
 
 <#trig-syntax-bad-struct-06> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-06" ;
-   rdfs:comment "Turtle does not allow bnodes-as-predicates (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-06.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-06" ;
+    rdfs:comment "Turtle does not allow bnodes-as-predicates (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-06.trig> ;
+    .
 
 <#trig-syntax-bad-struct-07> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-07" ;
-   rdfs:comment "Turtle does not allow labeled bnodes-as-predicates (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-07.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-07" ;
+    rdfs:comment "Turtle does not allow labeled bnodes-as-predicates (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-07.trig> ;
+    .
 
 <#trig-syntax-bad-kw-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-kw-01" ;
-   rdfs:comment "'A' is not a keyword (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-kw-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-kw-01" ;
+    rdfs:comment "'A' is not a keyword (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-kw-01.trig> ;
+    .
 
 <#trig-syntax-bad-kw-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-kw-02" ;
-   rdfs:comment "'a' cannot be used as subject (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-kw-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-kw-02" ;
+    rdfs:comment "'a' cannot be used as subject (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-kw-02.trig> ;
+    .
 
 <#trig-syntax-bad-kw-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-kw-03" ;
-   rdfs:comment "'a' cannot be used as object (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-kw-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-kw-03" ;
+    rdfs:comment "'a' cannot be used as object (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-kw-03.trig> ;
+    .
 
 <#trig-syntax-bad-kw-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-kw-04" ;
-   rdfs:comment "'true' cannot be used as subject (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-kw-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-kw-04" ;
+    rdfs:comment "'true' cannot be used as subject (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-kw-04.trig> ;
+    .
 
 <#trig-syntax-bad-kw-05> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-kw-05" ;
-   rdfs:comment "'true' cannot be used as object (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-kw-05.trig> ;
-   .
+    mf:name    "trig-syntax-bad-kw-05" ;
+    rdfs:comment "'true' cannot be used as object (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-kw-05.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-01" ;
-   rdfs:comment "{} fomulae not in TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-01" ;
+    rdfs:comment "{} fomulae not in TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-01.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-02" ;
-   rdfs:comment "= is not TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-02" ;
+    rdfs:comment "= is not TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-02.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-03" ;
-   rdfs:comment "N3 paths not in TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-03" ;
+    rdfs:comment "N3 paths not in TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-03.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-04" ;
-   rdfs:comment "N3 paths not in TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-04" ;
+    rdfs:comment "N3 paths not in TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-04.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-05> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-05" ;
-   rdfs:comment "N3 is...of not in TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-05.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-05" ;
+    rdfs:comment "N3 is...of not in TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-05.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-06> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-06" ;
-   rdfs:comment "N3 paths not in TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-06.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-06" ;
+    rdfs:comment "N3 paths not in TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-06.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-07> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-07" ;
-   rdfs:comment "@keywords is not TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-07.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-07" ;
+    rdfs:comment "@keywords is not TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-07.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-08> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-08" ;
-   rdfs:comment "@keywords is not TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-08.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-08" ;
+    rdfs:comment "@keywords is not TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-08.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-09> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-09" ;
-   rdfs:comment "=> is not TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-09.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-09" ;
+    rdfs:comment "=> is not TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-09.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-10> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-10" ;
-   rdfs:comment "<= is not TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-10.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-10" ;
+    rdfs:comment "<= is not TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-10.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-11> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-11" ;
-   rdfs:comment "@forSome is not TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-11.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-11" ;
+    rdfs:comment "@forSome is not TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-11.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-12> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-12" ;
-   rdfs:comment "@forAll is not TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-12.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-12" ;
+    rdfs:comment "@forAll is not TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-12.trig> ;
+    .
 
 <#trig-syntax-bad-n3-extras-13> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-n3-extras-13" ;
-   rdfs:comment "@keywords is not TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-n3-extras-13.trig> ;
-   .
+    mf:name    "trig-syntax-bad-n3-extras-13" ;
+    rdfs:comment "@keywords is not TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-n3-extras-13.trig> ;
+    .
 
 <#trig-syntax-bad-numeric-escape-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-numeric-escape-01" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-numeric-escape-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-numeric-escape-01" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-numeric-escape-01.trig> ;
+    .
 
 <#trig-syntax-bad-numeric-escape-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-numeric-escape-02" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-numeric-escape-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-numeric-escape-02" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-numeric-escape-02.trig> ;
+    .
 
 <#trig-syntax-bad-numeric-escape-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-numeric-escape-03" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_SINGLE_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-numeric-escape-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-numeric-escape-03" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_SINGLE_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-numeric-escape-03.trig> ;
+    .
 
 <#trig-syntax-bad-numeric-escape-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-numeric-escape-04" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_SINGLE_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-numeric-escape-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-numeric-escape-04" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_SINGLE_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-numeric-escape-04.trig> ;
+    .
 
 <#trig-syntax-bad-numeric-escape-05> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-numeric-escape-05" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_SINGLE_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-numeric-escape-05.trig> ;
-   .
+    mf:name    "trig-syntax-bad-numeric-escape-05" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_SINGLE_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-numeric-escape-05.trig> ;
+    .
 
 <#trig-syntax-bad-numeric-escape-06> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-numeric-escape-06" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_SINGLE_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-numeric-escape-06.trig> ;
-   .
+    mf:name    "trig-syntax-bad-numeric-escape-06" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_SINGLE_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-numeric-escape-06.trig> ;
+    .
 
 <#trig-syntax-bad-numeric-escape-07> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-numeric-escape-07" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-numeric-escape-07.trig> ;
-   .
+    mf:name    "trig-syntax-bad-numeric-escape-07" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-numeric-escape-07.trig> ;
+    .
 
 <#trig-syntax-bad-numeric-escape-08> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-numeric-escape-08" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-numeric-escape-08.trig> ;
-   .
+    mf:name    "trig-syntax-bad-numeric-escape-08" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-numeric-escape-08.trig> ;
+    .
 
 <#trig-syntax-bad-numeric-escape-09> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-numeric-escape-09" ;
-   rdfs:comment "Surrogates not allowed in IRIREF" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-numeric-escape-09.trig> ;
-   .
+    mf:name    "trig-syntax-bad-numeric-escape-09" ;
+    rdfs:comment "Surrogates not allowed in IRIREF" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-numeric-escape-09.trig> ;
+    .
 
 <#trig-syntax-bad-numeric-escape-10> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-numeric-escape-10" ;
-   rdfs:comment "Surrogates not allowed in IRIREF" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-numeric-escape-10.trig> ;
-   .
+    mf:name    "trig-syntax-bad-numeric-escape-10" ;
+    rdfs:comment "Surrogates not allowed in IRIREF" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-numeric-escape-10.trig> ;
+    .
 
 <#trig-syntax-bad-struct-09> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-09" ;
-   rdfs:comment "extra '.' (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-09.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-09" ;
+    rdfs:comment "extra '.' (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-09.trig> ;
+    .
 
 <#trig-syntax-bad-struct-10> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-10" ;
-   rdfs:comment "extra '.' (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-10.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-10" ;
+    rdfs:comment "extra '.' (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-10.trig> ;
+    .
 
 <#trig-syntax-bad-struct-12> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-12" ;
-   rdfs:comment "subject, predicate, no object (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-12.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-12" ;
+    rdfs:comment "subject, predicate, no object (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-12.trig> ;
+    .
 
 <#trig-syntax-bad-struct-13> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-13" ;
-   rdfs:comment "subject, predicate, no object (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-13.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-13" ;
+    rdfs:comment "subject, predicate, no object (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-13.trig> ;
+    .
 
 <#trig-syntax-bad-struct-14> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-14" ;
-   rdfs:comment "literal as subject (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-14.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-14" ;
+    rdfs:comment "literal as subject (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-14.trig> ;
+    .
 
 <#trig-syntax-bad-struct-15> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-15" ;
-   rdfs:comment "literal as predicate (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-15.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-15" ;
+    rdfs:comment "literal as predicate (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-15.trig> ;
+    .
 
 <#trig-syntax-bad-struct-16> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-16" ;
-   rdfs:comment "bnode as predicate (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-16.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-16" ;
+    rdfs:comment "bnode as predicate (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-16.trig> ;
+    .
 
 <#trig-syntax-bad-struct-17> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-struct-17" ;
-   rdfs:comment "labeled bnode as predicate (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-struct-17.trig> ;
-   .
+    mf:name    "trig-syntax-bad-struct-17" ;
+    rdfs:comment "labeled bnode as predicate (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-struct-17.trig> ;
+    .
 
 <#trig-syntax-bad-lang-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-lang-01" ;
-   rdfs:comment "langString with bad lang (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-lang-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-lang-01" ;
+    rdfs:comment "langString with bad lang (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-lang-01.trig> ;
+    .
 
 <#trig-syntax-bad-esc-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-esc-01" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-esc-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-esc-01" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-esc-01.trig> ;
+    .
 
 <#trig-syntax-bad-esc-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-esc-02" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-esc-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-esc-02" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-esc-02.trig> ;
+    .
 
 <#trig-syntax-bad-esc-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-esc-03" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-esc-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-esc-03" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-esc-03.trig> ;
+    .
 
 <#trig-syntax-bad-esc-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-esc-04" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-esc-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-esc-04" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-esc-04.trig> ;
+    .
 
 <#trig-syntax-bad-pname-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-pname-01" ;
-   rdfs:comment "'~' must be escaped in pname (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-pname-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-pname-01" ;
+    rdfs:comment "'~' must be escaped in pname (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-pname-01.trig> ;
+    .
 
 <#trig-syntax-bad-pname-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-pname-02" ;
-   rdfs:comment "Bad %-sequence in pname (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-pname-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-pname-02" ;
+    rdfs:comment "Bad %-sequence in pname (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-pname-02.trig> ;
+    .
 
 <#trig-syntax-bad-pname-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-pname-03" ;
-   rdfs:comment "Bad unicode escape in pname (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-pname-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-pname-03" ;
+    rdfs:comment "Bad unicode escape in pname (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-pname-03.trig> ;
+    .
 
 <#trig-syntax-bad-string-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-string-01" ;
-   rdfs:comment "mismatching string literal open/close (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-string-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-string-01" ;
+    rdfs:comment "mismatching string literal open/close (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-string-01.trig> ;
+    .
 
 <#trig-syntax-bad-string-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-string-02" ;
-   rdfs:comment "mismatching string literal open/close (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-string-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-string-02" ;
+    rdfs:comment "mismatching string literal open/close (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-string-02.trig> ;
+    .
 
 <#trig-syntax-bad-string-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-string-03" ;
-   rdfs:comment "mismatching string literal long/short (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-string-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-string-03" ;
+    rdfs:comment "mismatching string literal long/short (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-string-03.trig> ;
+    .
 
 <#trig-syntax-bad-string-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-string-04" ;
-   rdfs:comment "mismatching long string literal open/close (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-string-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-string-04" ;
+    rdfs:comment "mismatching long string literal open/close (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-string-04.trig> ;
+    .
 
 <#trig-syntax-bad-string-05> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-string-05" ;
-   rdfs:comment "Long literal with missing end (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-string-05.trig> ;
-   .
+    mf:name    "trig-syntax-bad-string-05" ;
+    rdfs:comment "Long literal with missing end (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-string-05.trig> ;
+    .
 
 <#trig-syntax-bad-string-06> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-string-06" ;
-   rdfs:comment "Long literal with extra quote (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-string-06.trig> ;
-   .
+    mf:name    "trig-syntax-bad-string-06" ;
+    rdfs:comment "Long literal with extra quote (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-string-06.trig> ;
+    .
 
 <#trig-syntax-bad-string-07> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-string-07" ;
-   rdfs:comment "Long literal with extra squote (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-string-07.trig> ;
-   .
+    mf:name    "trig-syntax-bad-string-07" ;
+    rdfs:comment "Long literal with extra squote (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-string-07.trig> ;
+    .
 
 <#trig-syntax-bad-num-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-num-01" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-num-01.trig> ;
-   .
+    mf:name    "trig-syntax-bad-num-01" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-num-01.trig> ;
+    .
 
 <#trig-syntax-bad-num-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-num-02" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-num-02.trig> ;
-   .
+    mf:name    "trig-syntax-bad-num-02" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-num-02.trig> ;
+    .
 
 <#trig-syntax-bad-num-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-num-03" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-num-03.trig> ;
-   .
+    mf:name    "trig-syntax-bad-num-03" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-num-03.trig> ;
+    .
 
 <#trig-syntax-bad-num-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-num-04" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-num-04.trig> ;
-   .
+    mf:name    "trig-syntax-bad-num-04" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-num-04.trig> ;
+    .
 
 <#trig-syntax-bad-num-05> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-num-05" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-num-05.trig> ;
-   .
+    mf:name    "trig-syntax-bad-num-05" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-num-05.trig> ;
+    .
 
 <#trig-eval-struct-01> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-eval-struct-01" ;
-   rdfs:comment "triple with IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-eval-struct-01.trig> ;
-   mf:result    <trig-eval-struct-01.nq> ;
-   .
+    mf:name    "trig-eval-struct-01" ;
+    rdfs:comment "triple with IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-eval-struct-01.trig> ;
+    mf:result    <trig-eval-struct-01.nq> ;
+    .
 
 <#trig-eval-struct-02> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-eval-struct-02" ;
-   rdfs:comment "triple with IRIs and embedded whitespace" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-eval-struct-02.trig> ;
-   mf:result    <trig-eval-struct-02.nq> ;
-   .
+    mf:name    "trig-eval-struct-02" ;
+    rdfs:comment "triple with IRIs and embedded whitespace" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-eval-struct-02.trig> ;
+    mf:result    <trig-eval-struct-02.nq> ;
+    .
 
 <#trig-subm-01> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-01" ;
-   rdfs:comment "Blank subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-01.trig> ;
-   mf:result    <trig-subm-01.nq> ;
-   .
+    mf:name    "trig-subm-01" ;
+    rdfs:comment "Blank subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-01.trig> ;
+    mf:result    <trig-subm-01.nq> ;
+    .
 
 <#trig-subm-02> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-02" ;
-   rdfs:comment "@prefix and qnames" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-02.trig> ;
-   mf:result    <trig-subm-02.nq> ;
-   .
+    mf:name    "trig-subm-02" ;
+    rdfs:comment "@prefix and qnames" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-02.trig> ;
+    mf:result    <trig-subm-02.nq> ;
+    .
 
 <#trig-subm-03> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-03" ;
-   rdfs:comment ", operator" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-03.trig> ;
-   mf:result    <trig-subm-03.nq> ;
-   .
+    mf:name    "trig-subm-03" ;
+    rdfs:comment ", operator" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-03.trig> ;
+    mf:result    <trig-subm-03.nq> ;
+    .
 
 <#trig-subm-04> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-04" ;
-   rdfs:comment "; operator" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-04.trig> ;
-   mf:result    <trig-subm-04.nq> ;
-   .
+    mf:name    "trig-subm-04" ;
+    rdfs:comment "; operator" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-04.trig> ;
+    mf:result    <trig-subm-04.nq> ;
+    .
 
 <#trig-subm-05> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-05" ;
-   rdfs:comment "empty [] as subject and object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-05.trig> ;
-   mf:result    <trig-subm-05.nq> ;
-   .
+    mf:name    "trig-subm-05" ;
+    rdfs:comment "empty [] as subject and object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-05.trig> ;
+    mf:result    <trig-subm-05.nq> ;
+    .
 
 <#trig-subm-06> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-06" ;
-   rdfs:comment "non-empty [] as subject and object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-06.trig> ;
-   mf:result    <trig-subm-06.nq> ;
-   .
+    mf:name    "trig-subm-06" ;
+    rdfs:comment "non-empty [] as subject and object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-06.trig> ;
+    mf:result    <trig-subm-06.nq> ;
+    .
 
 <#trig-subm-07> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-07" ;
-   rdfs:comment "'a' as predicate" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-07.trig> ;
-   mf:result    <trig-subm-07.nq> ;
-   .
+    mf:name    "trig-subm-07" ;
+    rdfs:comment "'a' as predicate" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-07.trig> ;
+    mf:result    <trig-subm-07.nq> ;
+    .
 
 <#trig-subm-08> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-08" ;
-   rdfs:comment "simple collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-08.trig> ;
-   mf:result    <trig-subm-08.nq> ;
-   .
+    mf:name    "trig-subm-08" ;
+    rdfs:comment "simple collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-08.trig> ;
+    mf:result    <trig-subm-08.nq> ;
+    .
 
 <#trig-subm-09> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-09" ;
-   rdfs:comment "empty collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-09.trig> ;
-   mf:result    <trig-subm-09.nq> ;
-   .
+    mf:name    "trig-subm-09" ;
+    rdfs:comment "empty collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-09.trig> ;
+    mf:result    <trig-subm-09.nq> ;
+    .
 
 <#trig-subm-10> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-10" ;
-   rdfs:comment "integer datatyped literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-10.trig> ;
-   mf:result    <trig-subm-10.nq> ;
-   .
+    mf:name    "trig-subm-10" ;
+    rdfs:comment "integer datatyped literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-10.trig> ;
+    mf:result    <trig-subm-10.nq> ;
+    .
 
 <#trig-subm-11> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-11" ;
-   rdfs:comment "decimal integer canonicalization" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-11.trig> ;
-   mf:result    <trig-subm-11.nq> ;
-   .
+    mf:name    "trig-subm-11" ;
+    rdfs:comment "decimal integer canonicalization" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-11.trig> ;
+    mf:result    <trig-subm-11.nq> ;
+    .
 
 <#trig-subm-12> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-12" ;
-   rdfs:comment "- and _ in names and qnames" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-12.trig> ;
-   mf:result    <trig-subm-12.nq> ;
-   .
+    mf:name    "trig-subm-12" ;
+    rdfs:comment "- and _ in names and qnames" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-12.trig> ;
+    mf:result    <trig-subm-12.nq> ;
+    .
 
 <#trig-subm-13> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-13" ;
-   rdfs:comment "tests for rdf:_<numbers> and other qnames starting with _" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-13.trig> ;
-   mf:result    <trig-subm-13.nq> ;
-   .
+    mf:name    "trig-subm-13" ;
+    rdfs:comment "tests for rdf:_<numbers> and other qnames starting with _" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-13.trig> ;
+    mf:result    <trig-subm-13.nq> ;
+    .
 
 <#trig-subm-14> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-14" ;
-   rdfs:comment "bare : allowed" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-14.trig> ;
-   mf:result    <trig-subm-14.nq> ;
-   .
+    mf:name    "trig-subm-14" ;
+    rdfs:comment "bare : allowed" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-14.trig> ;
+    mf:result    <trig-subm-14.nq> ;
+    .
 
 <#trig-subm-15> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-15" ;
-   rdfs:comment "simple long literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-15.trig> ;
-   mf:result    <trig-subm-15.nq> ;
-   .
+    mf:name    "trig-subm-15" ;
+    rdfs:comment "simple long literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-15.trig> ;
+    mf:result    <trig-subm-15.nq> ;
+    .
 
 <#trig-subm-16> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-16" ;
-   rdfs:comment "long literals with escapes" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-16.trig> ;
-   mf:result    <trig-subm-16.nq> ;
-   .
+    mf:name    "trig-subm-16" ;
+    rdfs:comment "long literals with escapes" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-16.trig> ;
+    mf:result    <trig-subm-16.nq> ;
+    .
 
 <#trig-subm-17> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-17" ;
-   rdfs:comment "floating point number" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-17.trig> ;
-   mf:result    <trig-subm-17.nq> ;
-   .
+    mf:name    "trig-subm-17" ;
+    rdfs:comment "floating point number" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-17.trig> ;
+    mf:result    <trig-subm-17.nq> ;
+    .
 
 <#trig-subm-18> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-18" ;
-   rdfs:comment "empty literals, normal and long variant" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-18.trig> ;
-   mf:result    <trig-subm-18.nq> ;
-   .
+    mf:name    "trig-subm-18" ;
+    rdfs:comment "empty literals, normal and long variant" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-18.trig> ;
+    mf:result    <trig-subm-18.nq> ;
+    .
 
 <#trig-subm-19> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-19" ;
-   rdfs:comment "positive integer, decimal and doubles" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-19.trig> ;
-   mf:result    <trig-subm-19.nq> ;
-   .
+    mf:name    "trig-subm-19" ;
+    rdfs:comment "positive integer, decimal and doubles" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-19.trig> ;
+    mf:result    <trig-subm-19.nq> ;
+    .
 
 <#trig-subm-20> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-20" ;
-   rdfs:comment "negative integer, decimal and doubles" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-20.trig> ;
-   mf:result    <trig-subm-20.nq> ;
-   .
+    mf:name    "trig-subm-20" ;
+    rdfs:comment "negative integer, decimal and doubles" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-20.trig> ;
+    mf:result    <trig-subm-20.nq> ;
+    .
 
 <#trig-subm-21> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-21" ;
-   rdfs:comment "long literal ending in double quote" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-21.trig> ;
-   mf:result    <trig-subm-21.nq> ;
-   .
+    mf:name    "trig-subm-21" ;
+    rdfs:comment "long literal ending in double quote" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-21.trig> ;
+    mf:result    <trig-subm-21.nq> ;
+    .
 
 <#trig-subm-22> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-22" ;
-   rdfs:comment "boolean literals" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-22.trig> ;
-   mf:result    <trig-subm-22.nq> ;
-   .
+    mf:name    "trig-subm-22" ;
+    rdfs:comment "boolean literals" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-22.trig> ;
+    mf:result    <trig-subm-22.nq> ;
+    .
 
 <#trig-subm-23> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-23" ;
-   rdfs:comment "comments" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-23.trig> ;
-   mf:result    <trig-subm-23.nq> ;
-   .
+    mf:name    "trig-subm-23" ;
+    rdfs:comment "comments" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-23.trig> ;
+    mf:result    <trig-subm-23.nq> ;
+    .
 
 <#trig-subm-24> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-24" ;
-   rdfs:comment "no final mewline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-24.trig> ;
-   mf:result    <trig-subm-24.nq> ;
-   .
+    mf:name    "trig-subm-24" ;
+    rdfs:comment "no final mewline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-24.trig> ;
+    mf:result    <trig-subm-24.nq> ;
+    .
 
 <#trig-subm-25> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-25" ;
-   rdfs:comment "repeating a @prefix changes pname definition" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-25.trig> ;
-   mf:result    <trig-subm-25.nq> ;
-   .
+    mf:name    "trig-subm-25" ;
+    rdfs:comment "repeating a @prefix changes pname definition" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-25.trig> ;
+    mf:result    <trig-subm-25.nq> ;
+    .
 
 <#trig-subm-26> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-26" ;
-   rdfs:comment "Variations on decimal canonicalization" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-26.trig> ;
-   mf:result    <trig-subm-26.nq> ;
-   .
+    mf:name    "trig-subm-26" ;
+    rdfs:comment "Variations on decimal canonicalization" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-26.trig> ;
+    mf:result    <trig-subm-26.nq> ;
+    .
 
 <#trig-subm-27> rdf:type rdft:TestTrigEval ;
-   mf:name    "trig-subm-27" ;
-   rdfs:comment "Repeating @base changes base for relative IRI lookup" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-subm-27.trig> ;
-   mf:result    <trig-subm-27.nq> ;
-   .
+    mf:name    "trig-subm-27" ;
+    rdfs:comment "Repeating @base changes base for relative IRI lookup" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-subm-27.trig> ;
+    mf:result    <trig-subm-27.nq> ;
+    .
 
 # tests requested by Jeremy Carroll
 # http://www.w3.org/2011/rdf-wg/wiki/Turtle_Candidate_Recommendation_Comments#c35
 <#comment_following_localName> rdf:type rdft:TestTrigEval ;
-   mf:name      "comment_following_localName" ;
-   rdfs:comment "comment following localName" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <comment_following_localName.trig> ;
-   mf:result    <IRI_spo.nq> ;
-   .
+    mf:name      "comment_following_localName" ;
+    rdfs:comment "comment following localName" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <comment_following_localName.trig> ;
+    mf:result    <IRI_spo.nq> ;
+    .
 
 <#number_sign_following_localName> rdf:type rdft:TestTrigEval ;
-   mf:name      "number_sign_following_localName" ;
-   rdfs:comment "number sign following localName" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <number_sign_following_localName.trig> ;
-   mf:result    <number_sign_following_localName.nq> ;
-   .
+    mf:name      "number_sign_following_localName" ;
+    rdfs:comment "number sign following localName" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <number_sign_following_localName.trig> ;
+    mf:result    <number_sign_following_localName.nq> ;
+    .
 
 <#comment_following_PNAME_NS> rdf:type rdft:TestTrigEval ;
-   mf:name      "comment_following_PNAME_NS" ;
-   rdfs:comment "comment following PNAME_NS" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <comment_following_PNAME_NS.trig> ;
-   mf:result    <comment_following_PNAME_NS.nq> ;
-   .
+    mf:name      "comment_following_PNAME_NS" ;
+    rdfs:comment "comment following PNAME_NS" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <comment_following_PNAME_NS.trig> ;
+    mf:result    <comment_following_PNAME_NS.nq> ;
+    .
 
 <#number_sign_following_PNAME_NS> rdf:type rdft:TestTrigEval ;
-   mf:name      "number_sign_following_PNAME_NS" ;
-   rdfs:comment "number sign following PNAME_NS" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <number_sign_following_PNAME_NS.trig> ;
-   mf:result    <number_sign_following_PNAME_NS.nq> ;
-   .
+    mf:name      "number_sign_following_PNAME_NS" ;
+    rdfs:comment "number sign following PNAME_NS" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <number_sign_following_PNAME_NS.trig> ;
+    mf:result    <number_sign_following_PNAME_NS.nq> ;
+    .
 
 # tests from Dave Beckett
 # http://www.w3.org/2011/rdf-wg/wiki/Turtle_Candidate_Recommendation_Comments#c28
 <#LITERAL_LONG2_with_REVERSE_SOLIDUS> rdf:type rdft:TestTrigEval ;
-   mf:name    "LITERAL_LONG2_with_REVERSE_SOLIDUS" ;
-   rdfs:comment "REVERSE SOLIDUS at end of LITERAL_LONG2" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2_with_REVERSE_SOLIDUS.trig> ;
-   mf:result    <LITERAL_LONG2_with_REVERSE_SOLIDUS.nq> ;
-   .
+    mf:name    "LITERAL_LONG2_with_REVERSE_SOLIDUS" ;
+    rdfs:comment "REVERSE SOLIDUS at end of LITERAL_LONG2" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2_with_REVERSE_SOLIDUS.trig> ;
+    mf:result    <LITERAL_LONG2_with_REVERSE_SOLIDUS.nq> ;
+    .
 
 <#trig-syntax-bad-LITERAL2_with_langtag_and_datatype> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name    "trig-syntax-bad-num-05" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-syntax-bad-LITERAL2_with_langtag_and_datatype.trig> ;
-   .
+    mf:name    "trig-syntax-bad-num-05" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-syntax-bad-LITERAL2_with_langtag_and_datatype.trig> ;
+    .
 
 <#two_LITERAL_LONG2s> rdf:type rdft:TestTrigEval ;
-   mf:name    "two_LITERAL_LONG2s" ;
-   rdfs:comment "two LITERAL_LONG2s testing quote delimiter overrun" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <two_LITERAL_LONG2s.trig> ;
-   mf:result    <two_LITERAL_LONG2s.nq> ;
-   .
+    mf:name    "two_LITERAL_LONG2s" ;
+    rdfs:comment "two LITERAL_LONG2s testing quote delimiter overrun" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <two_LITERAL_LONG2s.trig> ;
+    mf:result    <two_LITERAL_LONG2s.nq> ;
+    .
 
 <#langtagged_LONG_with_subtag> rdf:type rdft:TestTrigEval ;
-   mf:name      "langtagged_LONG_with_subtag" ;
-   rdfs:comment "langtagged LONG with subtag \"\"\"Cheers\"\"\"@en-UK" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <langtagged_LONG_with_subtag.trig> ;
-   mf:result    <langtagged_LONG_with_subtag.nq> ;
-   .
+    mf:name      "langtagged_LONG_with_subtag" ;
+    rdfs:comment "langtagged LONG with subtag \"\"\"Cheers\"\"\"@en-UK" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <langtagged_LONG_with_subtag.trig> ;
+    mf:result    <langtagged_LONG_with_subtag.nq> ;
+    .
 
 # tests from David Robillard
 # http://www.w3.org/2011/rdf-wg/wiki/Turtle_Candidate_Recommendation_Comments#c21
 <#trig-syntax-bad-blank-label-dot-end>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Blank node label must not end in dot" ;
-   mf:name "trig-syntax-bad-blank-label-dot-end" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-blank-label-dot-end.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Blank node label must not end in dot" ;
+    mf:name "trig-syntax-bad-blank-label-dot-end" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-blank-label-dot-end.trig> ;
+    .
 
 <#trig-syntax-bad-number-dot-in-anon>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Dot delimeter may not appear in anonymous nodes" ;
-   mf:name "trig-syntax-bad-number-dot-in-anon" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-number-dot-in-anon.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Dot delimeter may not appear in anonymous nodes" ;
+    mf:name "trig-syntax-bad-number-dot-in-anon" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-number-dot-in-anon.trig> ;
+    .
 
 <#trig-syntax-bad-ln-dash-start>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Local name must not begin with dash" ;
-   mf:name "trig-syntax-bad-ln-dash-start" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-ln-dash-start.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Local name must not begin with dash" ;
+    mf:name "trig-syntax-bad-ln-dash-start" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-ln-dash-start.trig> ;
+    .
 
 <#trig-syntax-bad-ln-escape>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Bad hex escape in local name" ;
-   mf:name "trig-syntax-bad-ln-escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-ln-escape.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Bad hex escape in local name" ;
+    mf:name "trig-syntax-bad-ln-escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-ln-escape.trig> ;
+    .
 
 <#trig-syntax-bad-ln-escape-start>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Bad hex escape at start of local name" ;
-   mf:name "trig-syntax-bad-ln-escape-start" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-ln-escape-start.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Bad hex escape at start of local name" ;
+    mf:name "trig-syntax-bad-ln-escape-start" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-ln-escape-start.trig> ;
+    .
 
 <#trig-syntax-bad-ns-dot-end>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Prefix must not end in dot" ;
-   mf:name "trig-syntax-bad-ns-dot-end" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-ns-dot-end.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Prefix must not end in dot" ;
+    mf:name "trig-syntax-bad-ns-dot-end" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-ns-dot-end.trig> ;
+    .
 
 <#trig-syntax-bad-ns-dot-start>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Prefix must not start with dot" ;
-   mf:name "trig-syntax-bad-ns-dot-start" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-ns-dot-start.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Prefix must not start with dot" ;
+    mf:name "trig-syntax-bad-ns-dot-start" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-ns-dot-start.trig> ;
+    .
 
 <#trig-syntax-bad-missing-ns-dot-end>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Prefix must not end in dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)" ;
-   mf:name "trig-syntax-bad-missing-ns-dot-end" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-missing-ns-dot-end.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Prefix must not end in dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)" ;
+    mf:name "trig-syntax-bad-missing-ns-dot-end" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-missing-ns-dot-end.trig> ;
+    .
 
 <#trig-syntax-bad-missing-ns-dot-start>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Prefix must not start with dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)" ;
-   mf:name "trig-syntax-bad-missing-ns-dot-start" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-missing-ns-dot-start.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Prefix must not start with dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)" ;
+    mf:name "trig-syntax-bad-missing-ns-dot-start" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-missing-ns-dot-start.trig> ;
+    .
 
 <#trig-syntax-bad-list-01>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Free-standing list outside {} : bad syntax" ;
-   mf:name "trig-syntax-bad-list-01" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-list-01.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Free-standing list outside {} : bad syntax" ;
+    mf:name "trig-syntax-bad-list-01" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-list-01.trig> ;
+    .
 
 <#trig-syntax-bad-list-02>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Free-standing list of zero-elements outside {} : bad syntax" ;
-   mf:name "trig-syntax-bad-list-02" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-list-02.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Free-standing list of zero-elements outside {} : bad syntax" ;
+    mf:name "trig-syntax-bad-list-02" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-list-02.trig> ;
+    .
 
 <#trig-syntax-bad-list-03>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Free-standing list inside {} : bad syntax" ;
-   mf:name "trig-syntax-bad-list-03" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-list-03.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Free-standing list inside {} : bad syntax" ;
+    mf:name "trig-syntax-bad-list-03" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-list-03.trig> ;
+    .
 
 <#trig-syntax-bad-list-04>
-   rdf:type rdft:TestTrigNegativeSyntax ;
-   rdfs:comment "Free-standing list of zero elements : bad syntax" ;
-   mf:name "trig-syntax-bad-list-04" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-list-04.trig> ;
-   .
+    rdf:type rdft:TestTrigNegativeSyntax ;
+    rdfs:comment "Free-standing list of zero elements : bad syntax" ;
+    mf:name "trig-syntax-bad-list-04" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-bad-list-04.trig> ;
+    .
 
 <#trig-syntax-ln-dots>
-   rdf:type rdft:TestTrigPositiveSyntax ;
-   rdfs:comment "Dots in pname local names" ;
-   mf:name "trig-syntax-ln-dots" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-ln-dots.trig> ;
-   .
+    rdf:type rdft:TestTrigPositiveSyntax ;
+    rdfs:comment "Dots in pname local names" ;
+    mf:name "trig-syntax-ln-dots" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-ln-dots.trig> ;
+    .
 
 <#trig-syntax-ln-colons>
-   rdf:type rdft:TestTrigPositiveSyntax ;
-   rdfs:comment "Colons in pname local names" ;
-   mf:name "trig-syntax-ln-colons" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-ln-colons.trig> ;
-   .
+    rdf:type rdft:TestTrigPositiveSyntax ;
+    rdfs:comment "Colons in pname local names" ;
+    mf:name "trig-syntax-ln-colons" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-ln-colons.trig> ;
+    .
 
 <#trig-syntax-ns-dots>
-   rdf:type rdft:TestTrigPositiveSyntax ;
-   rdfs:comment "Dots in namespace names" ;
-   mf:name "trig-syntax-ns-dots" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-ns-dots.trig> ;
-   .
+    rdf:type rdft:TestTrigPositiveSyntax ;
+    rdfs:comment "Dots in namespace names" ;
+    mf:name "trig-syntax-ns-dots" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-ns-dots.trig> ;
+    .
 
 <#trig-syntax-blank-label>
-   rdf:type rdft:TestTrigPositiveSyntax ;
-   rdfs:comment "Characters allowed in blank node labels" ;
-   mf:name "trig-syntax-blank-label" ;
-   rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-blank-label.trig> ;
-   .
+    rdf:type rdft:TestTrigPositiveSyntax ;
+    rdfs:comment "Characters allowed in blank node labels" ;
+    mf:name "trig-syntax-blank-label" ;
+    rdft:approval rdft:Approved ;
+    mf:action <trig-syntax-blank-label.trig> ;
+    .
 
 # tests for bnode graph names, optional GRAPH keyword and
 # triples outside {}
 
 <#trig-kw-graph-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-kw-graph-01" ;
-   rdfs:comment "Named graphs can be proceeded by GRAPH" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-kw-graph-01.trig> ;
-   .
+    mf:name      "trig-kw-graph-01" ;
+    rdfs:comment "Named graphs can be proceeded by GRAPH" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-kw-graph-01.trig> ;
+    .
 
 <#trig-kw-graph-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-kw-graph-02" ;
-   rdfs:comment "Trailing . not necessary inside {}" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-kw-graph-02.trig> ;
-   .
+    mf:name      "trig-kw-graph-02" ;
+    rdfs:comment "Trailing . not necessary inside {}" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-kw-graph-02.trig> ;
+    .
 
 <#trig-kw-graph-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-kw-graph-03" ;
-   rdfs:comment "Named graph may be empty" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-kw-graph-03.trig> ;
-   .
+    mf:name      "trig-kw-graph-03" ;
+    rdfs:comment "Named graph may be empty" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-kw-graph-03.trig> ;
+    .
 
 <#trig-kw-graph-04> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-kw-graph-04" ;
-   rdfs:comment "" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-kw-graph-04.trig> ;
-   .
+    mf:name      "trig-kw-graph-04" ;
+    rdfs:comment "" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-kw-graph-04.trig> ;
+    .
 
 <#trig-kw-graph-05> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-kw-graph-05" ;
-   rdfs:comment "Use of empty prefix inside named graph" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-kw-graph-05.trig> ;
-   .
+    mf:name      "trig-kw-graph-05" ;
+    rdfs:comment "Use of empty prefix inside named graph" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-kw-graph-05.trig> ;
+    .
 
 <#trig-kw-graph-06> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-kw-graph-06" ;
-   rdfs:comment "" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-kw-graph-06.trig> ;
-   .
+    mf:name      "trig-kw-graph-06" ;
+    rdfs:comment "" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-kw-graph-06.trig> ;
+    .
 
 <#trig-kw-graph-07> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-kw-graph-07" ;
-   rdfs:comment "Named graph may be named with BNode _:a" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-kw-graph-07.trig> ;
-   .
+    mf:name      "trig-kw-graph-07" ;
+    rdfs:comment "Named graph may be named with BNode _:a" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-kw-graph-07.trig> ;
+    .
 
 <#trig-kw-graph-08> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-kw-graph-08" ;
-   rdfs:comment "Named graph may be named with BNode []" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-kw-graph-08.trig> ;
-   .
+    mf:name      "trig-kw-graph-08" ;
+    rdfs:comment "Named graph may be named with BNode []" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-kw-graph-08.trig> ;
+    .
 
 <#trig-kw-graph-09> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-kw-graph-09" ;
-   rdfs:comment "Named graph may be named with PNAME" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-kw-graph-09.trig> ;
-   .
+    mf:name      "trig-kw-graph-09" ;
+    rdfs:comment "Named graph may be named with PNAME" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-kw-graph-09.trig> ;
+    .
 
 <#trig-kw-graph-10> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-kw-graph-10" ;
-   rdfs:comment "Named graph with PNAME and empty graph" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-kw-graph-10.trig> ;
-   .
+    mf:name      "trig-kw-graph-10" ;
+    rdfs:comment "Named graph with PNAME and empty graph" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-kw-graph-10.trig> ;
+    .
 
 <#trig-graph-bad-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-01" ;
-   rdfs:comment "GRAPH but no name - GRAPH is not used with the default graph" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-01.trig> ;
-   .
+    mf:name      "trig-graph-bad-01" ;
+    rdfs:comment "GRAPH but no name - GRAPH is not used with the default graph" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-01.trig> ;
+    .
 
 <#trig-graph-bad-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-02" ;
-   rdfs:comment "GRAPH not followed by DOT" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-02.trig> ;
-   .
+    mf:name      "trig-graph-bad-02" ;
+    rdfs:comment "GRAPH not followed by DOT" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-02.trig> ;
+    .
 
 <#trig-graph-bad-03> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-03" ;
-   rdfs:comment "GRAPH needs {}" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-03.trig> ;
-   .
+    mf:name      "trig-graph-bad-03" ;
+    rdfs:comment "GRAPH needs {}" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-03.trig> ;
+    .
 
 <#trig-graph-bad-04> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-04" ;
-   rdfs:comment "GRAPH needs {}" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-04.trig> ;
-   .
+    mf:name      "trig-graph-bad-04" ;
+    rdfs:comment "GRAPH needs {}" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-04.trig> ;
+    .
 
 <#trig-graph-bad-05> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-05" ;
-   rdfs:comment "GRAPH and a name, not several" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-05.trig> ;
-   .
+    mf:name      "trig-graph-bad-05" ;
+    rdfs:comment "GRAPH and a name, not several" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-05.trig> ;
+    .
 
 <#trig-graph-bad-06> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-06" ;
-   rdfs:comment "GRAPH - Must close {}" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-06.trig> ;
-   .
+    mf:name      "trig-graph-bad-06" ;
+    rdfs:comment "GRAPH - Must close {}" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-06.trig> ;
+    .
 
 <#trig-graph-bad-07> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-07" ;
-   rdfs:comment "GRAPH may not include a GRAPH" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-07.trig> ;
-   .
+    mf:name      "trig-graph-bad-07" ;
+    rdfs:comment "GRAPH may not include a GRAPH" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-07.trig> ;
+    .
 
 <#trig-graph-bad-08> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-08" ;
-   rdfs:comment "@graph is not a keyword" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-08.trig> ;
-   .
+    mf:name      "trig-graph-bad-08" ;
+    rdfs:comment "@graph is not a keyword" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-08.trig> ;
+    .
 
 <#trig-graph-bad-09> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-09" ;
-   rdfs:comment "Directives not allowed inside GRAPH" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-09.trig> ;
-   .
+    mf:name      "trig-graph-bad-09" ;
+    rdfs:comment "Directives not allowed inside GRAPH" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-09.trig> ;
+    .
 
 <#trig-graph-bad-10> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-10" ;
-   rdfs:comment "A graph may not be named with an empty collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-10.trig> ;
-   .
+    mf:name      "trig-graph-bad-10" ;
+    rdfs:comment "A graph may not be named with an empty collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-10.trig> ;
+    .
 
 <#trig-graph-bad-11> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-graph-bad-11" ;
-   rdfs:comment "A graph may not be named with a collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-graph-bad-11.trig> ;
-   .
+    mf:name      "trig-graph-bad-11" ;
+    rdfs:comment "A graph may not be named with a collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-graph-bad-11.trig> ;
+    .
 
 <#trig-bnodeplist-graph-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-bnodeplist-graph-bad-01" ;
-   rdfs:comment "A graph may not be named with a blankNodePropertyList" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-bnodeplist-graph-bad-01.trig> ;
-   .
+    mf:name      "trig-bnodeplist-graph-bad-01" ;
+    rdfs:comment "A graph may not be named with a blankNodePropertyList" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-bnodeplist-graph-bad-01.trig> ;
+    .
 
 <#trig-collection-graph-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-collection-graph-bad-01" ;
-   rdfs:comment "A graph may not be named with an empty collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-collection-graph-bad-01.trig> ;
-   .
+    mf:name      "trig-collection-graph-bad-01" ;
+    rdfs:comment "A graph may not be named with an empty collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-collection-graph-bad-01.trig> ;
+    .
 
 <#trig-collection-graph-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-collection-graph-bad-02" ;
-   rdfs:comment "A graph may not be named with a collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-collection-graph-bad-02.trig> ;
-   .
+    mf:name      "trig-collection-graph-bad-02" ;
+    rdfs:comment "A graph may not be named with a collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-collection-graph-bad-02.trig> ;
+    .
 
 <#trig-turtle-01> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-turtle-01" ;
-   rdfs:comment "TriG can parse Turtle" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-turtle-01.trig> ;
-   .
+    mf:name      "trig-turtle-01" ;
+    rdfs:comment "TriG can parse Turtle" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-turtle-01.trig> ;
+    .
 
 <#trig-turtle-02> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-turtle-02" ;
-   rdfs:comment "TriG can parse Turtle (repeated PREFIX)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-turtle-02.trig> ;
-   .
+    mf:name      "trig-turtle-02" ;
+    rdfs:comment "TriG can parse Turtle (repeated PREFIX)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-turtle-02.trig> ;
+    .
 
 <#trig-turtle-03> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-turtle-03" ;
-   rdfs:comment "TriG can parse Turtle (blankNodePropertyList subject)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-turtle-03.trig> ;
-   .
+    mf:name      "trig-turtle-03" ;
+    rdfs:comment "TriG can parse Turtle (blankNodePropertyList subject)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-turtle-03.trig> ;
+    .
 
 <#trig-turtle-04> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-turtle-04" ;
-   rdfs:comment "TriG can parse Turtle (blankNodePropertyList subject)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-turtle-04.trig> ;
-   .
+    mf:name      "trig-turtle-04" ;
+    rdfs:comment "TriG can parse Turtle (blankNodePropertyList subject)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-turtle-04.trig> ;
+    .
 
 <#trig-turtle-05> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-turtle-05" ;
-   rdfs:comment "TriG can parse Turtle (bare blankNodePropertyList)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-turtle-05.trig> ;
-   .
+    mf:name      "trig-turtle-05" ;
+    rdfs:comment "TriG can parse Turtle (bare blankNodePropertyList)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-turtle-05.trig> ;
+    .
 
 <#trig-turtle-06> rdf:type rdft:TestTrigPositiveSyntax ;
-   mf:name      "trig-turtle-06" ;
-   rdfs:comment "TriG can parse Turtle (collection subject and object)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-turtle-06.trig> ;
-   .
+    mf:name      "trig-turtle-06" ;
+    rdfs:comment "TriG can parse Turtle (collection subject and object)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-turtle-06.trig> ;
+    .
 
 <#trig-turtle-bad-01> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-turtle-bad-01" ;
-   rdfs:comment "Trailing dot required in Turtle block" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-turtle-bad-01.trig> ;
-   .
+    mf:name      "trig-turtle-bad-01" ;
+    rdfs:comment "Trailing dot required in Turtle block" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-turtle-bad-01.trig> ;
+    .
 
 <#trig-turtle-bad-02> rdf:type rdft:TestTrigNegativeSyntax ;
-   mf:name      "trig-turtle-bad-02" ;
-   rdfs:comment "TriG is not N-Quads" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <trig-turtle-bad-02.trig> ;
-   .
+    mf:name      "trig-turtle-bad-02" ;
+    rdfs:comment "TriG is not N-Quads" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <trig-turtle-bad-02.trig> ;
+    .
 
 # IRI resolution tests
 <#IRI-resolution-01>
-   rdf:type rdft:TestTrigEval ;
-   rdfs:comment "IRI resolution (RFC3986 original cases)" ;
-   mf:name "IRI-resolution-01" ;
-   rdft:approval rdft:Proposed ;
-   mf:action <IRI-resolution-01.trig> ;
-   mf:result <IRI-resolution-01.nq> ;
-   .
+    rdf:type rdft:TestTrigEval ;
+    rdfs:comment "IRI resolution (RFC3986 original cases)" ;
+    mf:name "IRI-resolution-01" ;
+    rdft:approval rdft:Proposed ;
+    mf:action <IRI-resolution-01.trig> ;
+    mf:result <IRI-resolution-01.nq> ;
+    .
 
 <#IRI-resolution-02>
-   rdf:type rdft:TestTrigEval ;
-   rdfs:comment "IRI resolution (RFC3986 using base IRI with trailing slash)" ;
-   mf:name "IRI-resolution-02" ;
-   rdft:approval rdft:Proposed ;
-   mf:action <IRI-resolution-02.trig> ;
-   mf:result <IRI-resolution-02.nq> ;
-   .
+    rdf:type rdft:TestTrigEval ;
+    rdfs:comment "IRI resolution (RFC3986 using base IRI with trailing slash)" ;
+    mf:name "IRI-resolution-02" ;
+    rdft:approval rdft:Proposed ;
+    mf:action <IRI-resolution-02.trig> ;
+    mf:result <IRI-resolution-02.nq> ;
+    .
 
 <#IRI-resolution-07>
-   rdf:type rdft:TestTrigEval ;
-   rdfs:comment "IRI resolution (RFC3986 using base IRI with file path)" ;
-   mf:name "IRI-resolution-07" ;
-   rdft:approval rdft:Proposed ;
-   mf:action <IRI-resolution-07.trig> ;
-   mf:result <IRI-resolution-07.nq> ;
-   .
+    rdf:type rdft:TestTrigEval ;
+    rdfs:comment "IRI resolution (RFC3986 using base IRI with file path)" ;
+    mf:name "IRI-resolution-07" ;
+    rdft:approval rdft:Proposed ;
+    mf:action <IRI-resolution-07.trig> ;
+    mf:result <IRI-resolution-07.nq> ;
+    .
 
 <#IRI-resolution-08>
-   rdf:type rdft:TestTrigEval ;
-   rdfs:comment "IRI resolution (miscellaneous cases)" ;
-   mf:name "IRI-resolution-08" ;
-   rdft:approval rdft:Proposed ;
-   mf:action <IRI-resolution-08.trig> ;
-   mf:result <IRI-resolution-08.nq> ;
-   .
+    rdf:type rdft:TestTrigEval ;
+    rdfs:comment "IRI resolution (miscellaneous cases)" ;
+    mf:name "IRI-resolution-08" ;
+    rdft:approval rdft:Proposed ;
+    mf:action <IRI-resolution-08.trig> ;
+    mf:result <IRI-resolution-08.nq> ;
+    .

--- a/rdf/rdf11/rdf-trig/manifest.ttl
+++ b/rdf/rdf11/rdf-trig/manifest.ttl
@@ -426,6 +426,7 @@
    mf:action    <labeled_blank_node_graph.trig> ;
    mf:result    <labeled_blank_node_graph.nq> ;
    .
+
 <#alternating_iri_graphs> rdf:type rdft:TestTrigEval ;
    mf:name      "alternating_iri_graphs" ;
    rdfs:comment "alternating graphs with IRI names" ;
@@ -490,6 +491,7 @@
    rdft:approval rdft:Approved ;
    mf:action    <trig-syntax-minimal-whitespace-01.trig> ;
    .
+
 # Original Turtle tests
 # atomic tests
 <#IRI_subject> rdf:type rdft:TestTrigEval ;
@@ -2681,70 +2683,79 @@
    rdfs:comment "Blank node label must not end in dot" ;
    mf:name "trig-syntax-bad-blank-label-dot-end" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-blank-label-dot-end.trig> .
+   mf:action <trig-syntax-bad-blank-label-dot-end.trig> ;
+   .
 
 <#trig-syntax-bad-number-dot-in-anon>
    rdf:type rdft:TestTrigNegativeSyntax ;
    rdfs:comment "Dot delimeter may not appear in anonymous nodes" ;
    mf:name "trig-syntax-bad-number-dot-in-anon" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-number-dot-in-anon.trig> .
+   mf:action <trig-syntax-bad-number-dot-in-anon.trig> ;
+   .
 
 <#trig-syntax-bad-ln-dash-start>
    rdf:type rdft:TestTrigNegativeSyntax ;
    rdfs:comment "Local name must not begin with dash" ;
    mf:name "trig-syntax-bad-ln-dash-start" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-ln-dash-start.trig> .
+   mf:action <trig-syntax-bad-ln-dash-start.trig> ;
+   .
 
 <#trig-syntax-bad-ln-escape>
    rdf:type rdft:TestTrigNegativeSyntax ;
    rdfs:comment "Bad hex escape in local name" ;
    mf:name "trig-syntax-bad-ln-escape" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-ln-escape.trig> .
+   mf:action <trig-syntax-bad-ln-escape.trig> ;
+   .
 
 <#trig-syntax-bad-ln-escape-start>
    rdf:type rdft:TestTrigNegativeSyntax ;
    rdfs:comment "Bad hex escape at start of local name" ;
    mf:name "trig-syntax-bad-ln-escape-start" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-ln-escape-start.trig> .
+   mf:action <trig-syntax-bad-ln-escape-start.trig> ;
+   .
 
 <#trig-syntax-bad-ns-dot-end>
    rdf:type rdft:TestTrigNegativeSyntax ;
    rdfs:comment "Prefix must not end in dot" ;
    mf:name "trig-syntax-bad-ns-dot-end" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-ns-dot-end.trig> .
+   mf:action <trig-syntax-bad-ns-dot-end.trig> ;
+   .
 
 <#trig-syntax-bad-ns-dot-start>
    rdf:type rdft:TestTrigNegativeSyntax ;
    rdfs:comment "Prefix must not start with dot" ;
    mf:name "trig-syntax-bad-ns-dot-start" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-ns-dot-start.trig> .
+   mf:action <trig-syntax-bad-ns-dot-start.trig> ;
+   .
 
 <#trig-syntax-bad-missing-ns-dot-end>
    rdf:type rdft:TestTrigNegativeSyntax ;
    rdfs:comment "Prefix must not end in dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)" ;
    mf:name "trig-syntax-bad-missing-ns-dot-end" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-missing-ns-dot-end.trig> .
+   mf:action <trig-syntax-bad-missing-ns-dot-end.trig> ;
+   .
 
 <#trig-syntax-bad-missing-ns-dot-start>
    rdf:type rdft:TestTrigNegativeSyntax ;
    rdfs:comment "Prefix must not start with dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)" ;
    mf:name "trig-syntax-bad-missing-ns-dot-start" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-missing-ns-dot-start.trig> .
+   mf:action <trig-syntax-bad-missing-ns-dot-start.trig> ;
+   .
 
 <#trig-syntax-bad-list-01>
    rdf:type rdft:TestTrigNegativeSyntax ;
    rdfs:comment "Free-standing list outside {} : bad syntax" ;
    mf:name "trig-syntax-bad-list-01" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-list-01.trig>
+   mf:action <trig-syntax-bad-list-01.trig> ;
    .
 
 <#trig-syntax-bad-list-02>
@@ -2752,7 +2763,7 @@
    rdfs:comment "Free-standing list of zero-elements outside {} : bad syntax" ;
    mf:name "trig-syntax-bad-list-02" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-list-02.trig>
+   mf:action <trig-syntax-bad-list-02.trig> ;
    .
 
 <#trig-syntax-bad-list-03>
@@ -2760,7 +2771,7 @@
    rdfs:comment "Free-standing list inside {} : bad syntax" ;
    mf:name "trig-syntax-bad-list-03" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-list-03.trig>
+   mf:action <trig-syntax-bad-list-03.trig> ;
    .
 
 <#trig-syntax-bad-list-04>
@@ -2768,7 +2779,7 @@
    rdfs:comment "Free-standing list of zero elements : bad syntax" ;
    mf:name "trig-syntax-bad-list-04" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-bad-list-04.trig>
+   mf:action <trig-syntax-bad-list-04.trig> ;
    .
 
 <#trig-syntax-ln-dots>
@@ -2776,28 +2787,32 @@
    rdfs:comment "Dots in pname local names" ;
    mf:name "trig-syntax-ln-dots" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-ln-dots.trig> .
+   mf:action <trig-syntax-ln-dots.trig> ;
+   .
 
 <#trig-syntax-ln-colons>
    rdf:type rdft:TestTrigPositiveSyntax ;
    rdfs:comment "Colons in pname local names" ;
    mf:name "trig-syntax-ln-colons" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-ln-colons.trig> .
+   mf:action <trig-syntax-ln-colons.trig> ;
+   .
 
 <#trig-syntax-ns-dots>
    rdf:type rdft:TestTrigPositiveSyntax ;
    rdfs:comment "Dots in namespace names" ;
    mf:name "trig-syntax-ns-dots" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-ns-dots.trig> .
+   mf:action <trig-syntax-ns-dots.trig> ;
+   .
 
 <#trig-syntax-blank-label>
    rdf:type rdft:TestTrigPositiveSyntax ;
    rdfs:comment "Characters allowed in blank node labels" ;
    mf:name "trig-syntax-blank-label" ;
    rdft:approval rdft:Approved ;
-   mf:action <trig-syntax-blank-label.trig> .
+   mf:action <trig-syntax-blank-label.trig> ;
+   .
 
 # tests for bnode graph names, optional GRAPH keyword and
 # triples outside {}
@@ -3033,7 +3048,8 @@
    mf:name "IRI-resolution-01" ;
    rdft:approval rdft:Proposed ;
    mf:action <IRI-resolution-01.trig> ;
-   mf:result <IRI-resolution-01.nq> .
+   mf:result <IRI-resolution-01.nq> ;
+   .
 
 <#IRI-resolution-02>
    rdf:type rdft:TestTrigEval ;
@@ -3041,7 +3057,8 @@
    mf:name "IRI-resolution-02" ;
    rdft:approval rdft:Proposed ;
    mf:action <IRI-resolution-02.trig> ;
-   mf:result <IRI-resolution-02.nq> .
+   mf:result <IRI-resolution-02.nq> ;
+   .
 
 <#IRI-resolution-07>
    rdf:type rdft:TestTrigEval ;
@@ -3049,7 +3066,8 @@
    mf:name "IRI-resolution-07" ;
    rdft:approval rdft:Proposed ;
    mf:action <IRI-resolution-07.trig> ;
-   mf:result <IRI-resolution-07.nq> .
+   mf:result <IRI-resolution-07.nq> ;
+   .
 
 <#IRI-resolution-08>
    rdf:type rdft:TestTrigEval ;
@@ -3057,4 +3075,5 @@
    mf:name "IRI-resolution-08" ;
    rdft:approval rdft:Proposed ;
    mf:action <IRI-resolution-08.trig> ;
-   mf:result <IRI-resolution-08.nq> .
+   mf:result <IRI-resolution-08.nq> ;
+   .

--- a/rdf/rdf11/rdf-trig/manifest.ttl
+++ b/rdf/rdf11/rdf-trig/manifest.ttl
@@ -2744,7 +2744,7 @@
     rdfs:comment "Free-standing list outside {} : bad syntax" ;
    	mf:name "trig-syntax-bad-list-01" ;
     rdft:approval rdft:Approved ;
-    mf:action <trig-syntax-bad-list-01.trig> 
+    mf:action <trig-syntax-bad-list-01.trig>
     .
 
 <#trig-syntax-bad-list-02>
@@ -2752,7 +2752,7 @@
     rdfs:comment "Free-standing list of zero-elements outside {} : bad syntax" ;
    	mf:name "trig-syntax-bad-list-02" ;
     rdft:approval rdft:Approved ;
-    mf:action <trig-syntax-bad-list-02.trig> 
+    mf:action <trig-syntax-bad-list-02.trig>
     .
 
 <#trig-syntax-bad-list-03>
@@ -2760,7 +2760,7 @@
     rdfs:comment "Free-standing list inside {} : bad syntax" ;
    	mf:name "trig-syntax-bad-list-03" ;
     rdft:approval rdft:Approved ;
-    mf:action <trig-syntax-bad-list-03.trig> 
+    mf:action <trig-syntax-bad-list-03.trig>
     .
 
 <#trig-syntax-bad-list-04>
@@ -2768,7 +2768,7 @@
     rdfs:comment "Free-standing list of zero elements : bad syntax" ;
    	mf:name "trig-syntax-bad-list-04" ;
     rdft:approval rdft:Approved ;
-    mf:action <trig-syntax-bad-list-04.trig> 
+    mf:action <trig-syntax-bad-list-04.trig>
     .
 
 <#trig-syntax-ln-dots>

--- a/rdf/rdf11/rdf-trig/manifest.ttl
+++ b/rdf/rdf11/rdf-trig/manifest.ttl
@@ -2677,127 +2677,127 @@
 # tests from David Robillard
 # http://www.w3.org/2011/rdf-wg/wiki/Turtle_Candidate_Recommendation_Comments#c21
 <#trig-syntax-bad-blank-label-dot-end>
-	rdf:type rdft:TestTrigNegativeSyntax ;
-	rdfs:comment "Blank node label must not end in dot" ;
-	mf:name "trig-syntax-bad-blank-label-dot-end" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-bad-blank-label-dot-end.trig> .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Blank node label must not end in dot" ;
+   mf:name "trig-syntax-bad-blank-label-dot-end" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-blank-label-dot-end.trig> .
 
 <#trig-syntax-bad-number-dot-in-anon>
-	rdf:type rdft:TestTrigNegativeSyntax ;
-	rdfs:comment "Dot delimeter may not appear in anonymous nodes" ;
-	mf:name "trig-syntax-bad-number-dot-in-anon" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-bad-number-dot-in-anon.trig> .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Dot delimeter may not appear in anonymous nodes" ;
+   mf:name "trig-syntax-bad-number-dot-in-anon" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-number-dot-in-anon.trig> .
 
 <#trig-syntax-bad-ln-dash-start>
-	rdf:type rdft:TestTrigNegativeSyntax ;
-	rdfs:comment "Local name must not begin with dash" ;
-	mf:name "trig-syntax-bad-ln-dash-start" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-bad-ln-dash-start.trig> .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Local name must not begin with dash" ;
+   mf:name "trig-syntax-bad-ln-dash-start" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-ln-dash-start.trig> .
 
 <#trig-syntax-bad-ln-escape>
-	rdf:type rdft:TestTrigNegativeSyntax ;
-	rdfs:comment "Bad hex escape in local name" ;
-	mf:name "trig-syntax-bad-ln-escape" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-bad-ln-escape.trig> .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Bad hex escape in local name" ;
+   mf:name "trig-syntax-bad-ln-escape" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-ln-escape.trig> .
 
 <#trig-syntax-bad-ln-escape-start>
-	rdf:type rdft:TestTrigNegativeSyntax ;
-	rdfs:comment "Bad hex escape at start of local name" ;
-	mf:name "trig-syntax-bad-ln-escape-start" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-bad-ln-escape-start.trig> .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Bad hex escape at start of local name" ;
+   mf:name "trig-syntax-bad-ln-escape-start" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-ln-escape-start.trig> .
 
 <#trig-syntax-bad-ns-dot-end>
-	rdf:type rdft:TestTrigNegativeSyntax ;
-	rdfs:comment "Prefix must not end in dot" ;
-	mf:name "trig-syntax-bad-ns-dot-end" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-bad-ns-dot-end.trig> .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Prefix must not end in dot" ;
+   mf:name "trig-syntax-bad-ns-dot-end" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-ns-dot-end.trig> .
 
 <#trig-syntax-bad-ns-dot-start>
-	rdf:type rdft:TestTrigNegativeSyntax ;
-	rdfs:comment "Prefix must not start with dot" ;
-	mf:name "trig-syntax-bad-ns-dot-start" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-bad-ns-dot-start.trig> .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Prefix must not start with dot" ;
+   mf:name "trig-syntax-bad-ns-dot-start" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-ns-dot-start.trig> .
 
 <#trig-syntax-bad-missing-ns-dot-end>
-	rdf:type rdft:TestTrigNegativeSyntax ;
-	rdfs:comment "Prefix must not end in dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)" ;
-	mf:name "trig-syntax-bad-missing-ns-dot-end" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-bad-missing-ns-dot-end.trig> .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Prefix must not end in dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)" ;
+   mf:name "trig-syntax-bad-missing-ns-dot-end" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-missing-ns-dot-end.trig> .
 
 <#trig-syntax-bad-missing-ns-dot-start>
-	rdf:type rdft:TestTrigNegativeSyntax ;
-	rdfs:comment "Prefix must not start with dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)" ;
-	mf:name "trig-syntax-bad-missing-ns-dot-start" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-bad-missing-ns-dot-start.trig> .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Prefix must not start with dot (error in triple, not prefix directive like trig-syntax-bad-ns-dot-end)" ;
+   mf:name "trig-syntax-bad-missing-ns-dot-start" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-missing-ns-dot-start.trig> .
 
 <#trig-syntax-bad-list-01>
-    rdf:type rdft:TestTrigNegativeSyntax ;
-    rdfs:comment "Free-standing list outside {} : bad syntax" ;
-   	mf:name "trig-syntax-bad-list-01" ;
-    rdft:approval rdft:Approved ;
-    mf:action <trig-syntax-bad-list-01.trig>
-    .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Free-standing list outside {} : bad syntax" ;
+   mf:name "trig-syntax-bad-list-01" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-list-01.trig>
+   .
 
 <#trig-syntax-bad-list-02>
-    rdf:type rdft:TestTrigNegativeSyntax ;
-    rdfs:comment "Free-standing list of zero-elements outside {} : bad syntax" ;
-   	mf:name "trig-syntax-bad-list-02" ;
-    rdft:approval rdft:Approved ;
-    mf:action <trig-syntax-bad-list-02.trig>
-    .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Free-standing list of zero-elements outside {} : bad syntax" ;
+   mf:name "trig-syntax-bad-list-02" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-list-02.trig>
+   .
 
 <#trig-syntax-bad-list-03>
-    rdf:type rdft:TestTrigNegativeSyntax ;
-    rdfs:comment "Free-standing list inside {} : bad syntax" ;
-   	mf:name "trig-syntax-bad-list-03" ;
-    rdft:approval rdft:Approved ;
-    mf:action <trig-syntax-bad-list-03.trig>
-    .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Free-standing list inside {} : bad syntax" ;
+   mf:name "trig-syntax-bad-list-03" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-list-03.trig>
+   .
 
 <#trig-syntax-bad-list-04>
-    rdf:type rdft:TestTrigNegativeSyntax ;
-    rdfs:comment "Free-standing list of zero elements : bad syntax" ;
-   	mf:name "trig-syntax-bad-list-04" ;
-    rdft:approval rdft:Approved ;
-    mf:action <trig-syntax-bad-list-04.trig>
-    .
+   rdf:type rdft:TestTrigNegativeSyntax ;
+   rdfs:comment "Free-standing list of zero elements : bad syntax" ;
+   mf:name "trig-syntax-bad-list-04" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-bad-list-04.trig>
+   .
 
 <#trig-syntax-ln-dots>
-	rdf:type rdft:TestTrigPositiveSyntax ;
-	rdfs:comment "Dots in pname local names" ;
-	mf:name "trig-syntax-ln-dots" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-ln-dots.trig> .
+   rdf:type rdft:TestTrigPositiveSyntax ;
+   rdfs:comment "Dots in pname local names" ;
+   mf:name "trig-syntax-ln-dots" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-ln-dots.trig> .
 
 <#trig-syntax-ln-colons>
-	rdf:type rdft:TestTrigPositiveSyntax ;
-	rdfs:comment "Colons in pname local names" ;
-	mf:name "trig-syntax-ln-colons" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-ln-colons.trig> .
+   rdf:type rdft:TestTrigPositiveSyntax ;
+   rdfs:comment "Colons in pname local names" ;
+   mf:name "trig-syntax-ln-colons" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-ln-colons.trig> .
 
 <#trig-syntax-ns-dots>
-	rdf:type rdft:TestTrigPositiveSyntax ;
-	rdfs:comment "Dots in namespace names" ;
-	mf:name "trig-syntax-ns-dots" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-ns-dots.trig> .
+   rdf:type rdft:TestTrigPositiveSyntax ;
+   rdfs:comment "Dots in namespace names" ;
+   mf:name "trig-syntax-ns-dots" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-ns-dots.trig> .
 
 <#trig-syntax-blank-label>
-	rdf:type rdft:TestTrigPositiveSyntax ;
-	rdfs:comment "Characters allowed in blank node labels" ;
-	mf:name "trig-syntax-blank-label" ;
-        rdft:approval rdft:Approved ;
-	mf:action <trig-syntax-blank-label.trig> .
+   rdf:type rdft:TestTrigPositiveSyntax ;
+   rdfs:comment "Characters allowed in blank node labels" ;
+   mf:name "trig-syntax-blank-label" ;
+   rdft:approval rdft:Approved ;
+   mf:action <trig-syntax-blank-label.trig> .
 
 # tests for bnode graph names, optional GRAPH keyword and
 # triples outside {}
@@ -3028,33 +3028,33 @@
 
 # IRI resolution tests
 <#IRI-resolution-01>
-	rdf:type rdft:TestTrigEval ;
-	rdfs:comment "IRI resolution (RFC3986 original cases)" ;
-	mf:name "IRI-resolution-01" ;
-	rdft:approval rdft:Proposed ;
-	mf:action <IRI-resolution-01.trig> ;
-	mf:result <IRI-resolution-01.nq> .
+   rdf:type rdft:TestTrigEval ;
+   rdfs:comment "IRI resolution (RFC3986 original cases)" ;
+   mf:name "IRI-resolution-01" ;
+   rdft:approval rdft:Proposed ;
+   mf:action <IRI-resolution-01.trig> ;
+   mf:result <IRI-resolution-01.nq> .
 
 <#IRI-resolution-02>
-	rdf:type rdft:TestTrigEval ;
-	rdfs:comment "IRI resolution (RFC3986 using base IRI with trailing slash)" ;
-	mf:name "IRI-resolution-02" ;
-	rdft:approval rdft:Proposed ;
-	mf:action <IRI-resolution-02.trig> ;
-	mf:result <IRI-resolution-02.nq> .
+   rdf:type rdft:TestTrigEval ;
+   rdfs:comment "IRI resolution (RFC3986 using base IRI with trailing slash)" ;
+   mf:name "IRI-resolution-02" ;
+   rdft:approval rdft:Proposed ;
+   mf:action <IRI-resolution-02.trig> ;
+   mf:result <IRI-resolution-02.nq> .
 
 <#IRI-resolution-07>
-	rdf:type rdft:TestTrigEval ;
-	rdfs:comment "IRI resolution (RFC3986 using base IRI with file path)" ;
-	mf:name "IRI-resolution-07" ;
-	rdft:approval rdft:Proposed ;
-	mf:action <IRI-resolution-07.trig> ;
-	mf:result <IRI-resolution-07.nq> .
+   rdf:type rdft:TestTrigEval ;
+   rdfs:comment "IRI resolution (RFC3986 using base IRI with file path)" ;
+   mf:name "IRI-resolution-07" ;
+   rdft:approval rdft:Proposed ;
+   mf:action <IRI-resolution-07.trig> ;
+   mf:result <IRI-resolution-07.nq> .
 
 <#IRI-resolution-08>
-	rdf:type rdft:TestTrigEval ;
-	rdfs:comment "IRI resolution (miscellaneous cases)" ;
-	mf:name "IRI-resolution-08" ;
-	rdft:approval rdft:Proposed ;
-	mf:action <IRI-resolution-08.trig> ;
-	mf:result <IRI-resolution-08.nq> .
+   rdf:type rdft:TestTrigEval ;
+   rdfs:comment "IRI resolution (miscellaneous cases)" ;
+   mf:name "IRI-resolution-08" ;
+   rdft:approval rdft:Proposed ;
+   mf:action <IRI-resolution-08.trig> ;
+   mf:result <IRI-resolution-08.nq> .

--- a/rdf/rdf11/rdf-turtle/IRI-resolution-01.nt
+++ b/rdf/rdf11/rdf-turtle/IRI-resolution-01.nt
@@ -1,42 +1,42 @@
-<urn:ex:s001> <urn:ex:p> <g:h>.
-<urn:ex:s002> <urn:ex:p> <http://a/bb/ccc/g>.
-<urn:ex:s003> <urn:ex:p> <http://a/bb/ccc/g>.
-<urn:ex:s004> <urn:ex:p> <http://a/bb/ccc/g/>.
-<urn:ex:s005> <urn:ex:p> <http://a/g>.
-<urn:ex:s006> <urn:ex:p> <http://g>.
-<urn:ex:s007> <urn:ex:p> <http://a/bb/ccc/d;p?y>.
-<urn:ex:s008> <urn:ex:p> <http://a/bb/ccc/g?y>.
-<urn:ex:s009> <urn:ex:p> <http://a/bb/ccc/d;p?q#s>.
-<urn:ex:s010> <urn:ex:p> <http://a/bb/ccc/g#s>.
-<urn:ex:s011> <urn:ex:p> <http://a/bb/ccc/g?y#s>.
-<urn:ex:s012> <urn:ex:p> <http://a/bb/ccc/;x>.
-<urn:ex:s013> <urn:ex:p> <http://a/bb/ccc/g;x>.
-<urn:ex:s014> <urn:ex:p> <http://a/bb/ccc/g;x?y#s>.
-<urn:ex:s015> <urn:ex:p> <http://a/bb/ccc/d;p?q>.
-<urn:ex:s016> <urn:ex:p> <http://a/bb/ccc/>.
-<urn:ex:s017> <urn:ex:p> <http://a/bb/ccc/>.
-<urn:ex:s018> <urn:ex:p> <http://a/bb/>.
-<urn:ex:s019> <urn:ex:p> <http://a/bb/>.
-<urn:ex:s020> <urn:ex:p> <http://a/bb/g>.
-<urn:ex:s021> <urn:ex:p> <http://a/>.
-<urn:ex:s022> <urn:ex:p> <http://a/>.
-<urn:ex:s023> <urn:ex:p> <http://a/g>.
+<urn:ex:s001> <urn:ex:p> <g:h> .
+<urn:ex:s002> <urn:ex:p> <http://a/bb/ccc/g> .
+<urn:ex:s003> <urn:ex:p> <http://a/bb/ccc/g> .
+<urn:ex:s004> <urn:ex:p> <http://a/bb/ccc/g/> .
+<urn:ex:s005> <urn:ex:p> <http://a/g> .
+<urn:ex:s006> <urn:ex:p> <http://g> .
+<urn:ex:s007> <urn:ex:p> <http://a/bb/ccc/d;p?y> .
+<urn:ex:s008> <urn:ex:p> <http://a/bb/ccc/g?y> .
+<urn:ex:s009> <urn:ex:p> <http://a/bb/ccc/d;p?q#s> .
+<urn:ex:s010> <urn:ex:p> <http://a/bb/ccc/g#s> .
+<urn:ex:s011> <urn:ex:p> <http://a/bb/ccc/g?y#s> .
+<urn:ex:s012> <urn:ex:p> <http://a/bb/ccc/;x> .
+<urn:ex:s013> <urn:ex:p> <http://a/bb/ccc/g;x> .
+<urn:ex:s014> <urn:ex:p> <http://a/bb/ccc/g;x?y#s> .
+<urn:ex:s015> <urn:ex:p> <http://a/bb/ccc/d;p?q> .
+<urn:ex:s016> <urn:ex:p> <http://a/bb/ccc/> .
+<urn:ex:s017> <urn:ex:p> <http://a/bb/ccc/> .
+<urn:ex:s018> <urn:ex:p> <http://a/bb/> .
+<urn:ex:s019> <urn:ex:p> <http://a/bb/> .
+<urn:ex:s020> <urn:ex:p> <http://a/bb/g> .
+<urn:ex:s021> <urn:ex:p> <http://a/> .
+<urn:ex:s022> <urn:ex:p> <http://a/> .
+<urn:ex:s023> <urn:ex:p> <http://a/g> .
 
-<urn:ex:s024> <urn:ex:p> <http://a/g>.
-<urn:ex:s025> <urn:ex:p> <http://a/g>.
-<urn:ex:s026> <urn:ex:p> <http://a/g>.
-<urn:ex:s027> <urn:ex:p> <http://a/g>.
-<urn:ex:s028> <urn:ex:p> <http://a/bb/ccc/g.>.
-<urn:ex:s029> <urn:ex:p> <http://a/bb/ccc/.g>.
-<urn:ex:s030> <urn:ex:p> <http://a/bb/ccc/g..>.
-<urn:ex:s031> <urn:ex:p> <http://a/bb/ccc/..g>.
-<urn:ex:s032> <urn:ex:p> <http://a/bb/g>.
-<urn:ex:s033> <urn:ex:p> <http://a/bb/ccc/g/>.
-<urn:ex:s034> <urn:ex:p> <http://a/bb/ccc/g/h>.
-<urn:ex:s035> <urn:ex:p> <http://a/bb/ccc/h>.
-<urn:ex:s036> <urn:ex:p> <http://a/bb/ccc/g;x=1/y>.
-<urn:ex:s037> <urn:ex:p> <http://a/bb/ccc/y>.
-<urn:ex:s038> <urn:ex:p> <http://a/bb/ccc/g?y/./x>.
-<urn:ex:s039> <urn:ex:p> <http://a/bb/ccc/g?y/../x>.
-<urn:ex:s040> <urn:ex:p> <http://a/bb/ccc/g#s/./x>.
-<urn:ex:s041> <urn:ex:p> <http://a/bb/ccc/g#s/../x>.
+<urn:ex:s024> <urn:ex:p> <http://a/g> .
+<urn:ex:s025> <urn:ex:p> <http://a/g> .
+<urn:ex:s026> <urn:ex:p> <http://a/g> .
+<urn:ex:s027> <urn:ex:p> <http://a/g> .
+<urn:ex:s028> <urn:ex:p> <http://a/bb/ccc/g.> .
+<urn:ex:s029> <urn:ex:p> <http://a/bb/ccc/.g> .
+<urn:ex:s030> <urn:ex:p> <http://a/bb/ccc/g..> .
+<urn:ex:s031> <urn:ex:p> <http://a/bb/ccc/..g> .
+<urn:ex:s032> <urn:ex:p> <http://a/bb/g> .
+<urn:ex:s033> <urn:ex:p> <http://a/bb/ccc/g/> .
+<urn:ex:s034> <urn:ex:p> <http://a/bb/ccc/g/h> .
+<urn:ex:s035> <urn:ex:p> <http://a/bb/ccc/h> .
+<urn:ex:s036> <urn:ex:p> <http://a/bb/ccc/g;x=1/y> .
+<urn:ex:s037> <urn:ex:p> <http://a/bb/ccc/y> .
+<urn:ex:s038> <urn:ex:p> <http://a/bb/ccc/g?y/./x> .
+<urn:ex:s039> <urn:ex:p> <http://a/bb/ccc/g?y/../x> .
+<urn:ex:s040> <urn:ex:p> <http://a/bb/ccc/g#s/./x> .
+<urn:ex:s041> <urn:ex:p> <http://a/bb/ccc/g#s/../x> .

--- a/rdf/rdf11/rdf-turtle/IRI-resolution-01.nt
+++ b/rdf/rdf11/rdf-turtle/IRI-resolution-01.nt
@@ -21,7 +21,6 @@
 <urn:ex:s021> <urn:ex:p> <http://a/> .
 <urn:ex:s022> <urn:ex:p> <http://a/> .
 <urn:ex:s023> <urn:ex:p> <http://a/g> .
-
 <urn:ex:s024> <urn:ex:p> <http://a/g> .
 <urn:ex:s025> <urn:ex:p> <http://a/g> .
 <urn:ex:s026> <urn:ex:p> <http://a/g> .

--- a/rdf/rdf11/rdf-turtle/IRI-resolution-02.nt
+++ b/rdf/rdf11/rdf-turtle/IRI-resolution-02.nt
@@ -21,7 +21,6 @@
 <urn:ex:s063> <urn:ex:p> <http://a/bb/> .
 <urn:ex:s064> <urn:ex:p> <http://a/bb/> .
 <urn:ex:s065> <urn:ex:p> <http://a/bb/g> .
-
 <urn:ex:s066> <urn:ex:p> <http://a/g> .
 <urn:ex:s067> <urn:ex:p> <http://a/g> .
 <urn:ex:s068> <urn:ex:p> <http://a/g> .

--- a/rdf/rdf11/rdf-turtle/IRI-resolution-02.nt
+++ b/rdf/rdf11/rdf-turtle/IRI-resolution-02.nt
@@ -1,42 +1,42 @@
-<urn:ex:s043> <urn:ex:p> <g:h>.
-<urn:ex:s044> <urn:ex:p> <http://a/bb/ccc/d/g>.
-<urn:ex:s045> <urn:ex:p> <http://a/bb/ccc/d/g>.
-<urn:ex:s046> <urn:ex:p> <http://a/bb/ccc/d/g/>.
-<urn:ex:s047> <urn:ex:p> <http://a/g>.
-<urn:ex:s048> <urn:ex:p> <http://g>.
-<urn:ex:s049> <urn:ex:p> <http://a/bb/ccc/d/?y>.
-<urn:ex:s050> <urn:ex:p> <http://a/bb/ccc/d/g?y>.
-<urn:ex:s051> <urn:ex:p> <http://a/bb/ccc/d/#s>.
-<urn:ex:s052> <urn:ex:p> <http://a/bb/ccc/d/g#s>.
-<urn:ex:s053> <urn:ex:p> <http://a/bb/ccc/d/g?y#s>.
-<urn:ex:s054> <urn:ex:p> <http://a/bb/ccc/d/;x>.
-<urn:ex:s055> <urn:ex:p> <http://a/bb/ccc/d/g;x>.
-<urn:ex:s056> <urn:ex:p> <http://a/bb/ccc/d/g;x?y#s>.
-<urn:ex:s057> <urn:ex:p> <http://a/bb/ccc/d/>.
-<urn:ex:s058> <urn:ex:p> <http://a/bb/ccc/d/>.
-<urn:ex:s059> <urn:ex:p> <http://a/bb/ccc/d/>.
-<urn:ex:s060> <urn:ex:p> <http://a/bb/ccc/>.
-<urn:ex:s061> <urn:ex:p> <http://a/bb/ccc/>.
-<urn:ex:s062> <urn:ex:p> <http://a/bb/ccc/g>.
-<urn:ex:s063> <urn:ex:p> <http://a/bb/>.
-<urn:ex:s064> <urn:ex:p> <http://a/bb/>.
-<urn:ex:s065> <urn:ex:p> <http://a/bb/g>.
+<urn:ex:s043> <urn:ex:p> <g:h> .
+<urn:ex:s044> <urn:ex:p> <http://a/bb/ccc/d/g> .
+<urn:ex:s045> <urn:ex:p> <http://a/bb/ccc/d/g> .
+<urn:ex:s046> <urn:ex:p> <http://a/bb/ccc/d/g/> .
+<urn:ex:s047> <urn:ex:p> <http://a/g> .
+<urn:ex:s048> <urn:ex:p> <http://g> .
+<urn:ex:s049> <urn:ex:p> <http://a/bb/ccc/d/?y> .
+<urn:ex:s050> <urn:ex:p> <http://a/bb/ccc/d/g?y> .
+<urn:ex:s051> <urn:ex:p> <http://a/bb/ccc/d/#s> .
+<urn:ex:s052> <urn:ex:p> <http://a/bb/ccc/d/g#s> .
+<urn:ex:s053> <urn:ex:p> <http://a/bb/ccc/d/g?y#s> .
+<urn:ex:s054> <urn:ex:p> <http://a/bb/ccc/d/;x> .
+<urn:ex:s055> <urn:ex:p> <http://a/bb/ccc/d/g;x> .
+<urn:ex:s056> <urn:ex:p> <http://a/bb/ccc/d/g;x?y#s> .
+<urn:ex:s057> <urn:ex:p> <http://a/bb/ccc/d/> .
+<urn:ex:s058> <urn:ex:p> <http://a/bb/ccc/d/> .
+<urn:ex:s059> <urn:ex:p> <http://a/bb/ccc/d/> .
+<urn:ex:s060> <urn:ex:p> <http://a/bb/ccc/> .
+<urn:ex:s061> <urn:ex:p> <http://a/bb/ccc/> .
+<urn:ex:s062> <urn:ex:p> <http://a/bb/ccc/g> .
+<urn:ex:s063> <urn:ex:p> <http://a/bb/> .
+<urn:ex:s064> <urn:ex:p> <http://a/bb/> .
+<urn:ex:s065> <urn:ex:p> <http://a/bb/g> .
 
-<urn:ex:s066> <urn:ex:p> <http://a/g>.
-<urn:ex:s067> <urn:ex:p> <http://a/g>.
-<urn:ex:s068> <urn:ex:p> <http://a/g>.
-<urn:ex:s069> <urn:ex:p> <http://a/g>.
-<urn:ex:s070> <urn:ex:p> <http://a/bb/ccc/d/g.>.
-<urn:ex:s071> <urn:ex:p> <http://a/bb/ccc/d/.g>.
-<urn:ex:s072> <urn:ex:p> <http://a/bb/ccc/d/g..>.
-<urn:ex:s073> <urn:ex:p> <http://a/bb/ccc/d/..g>.
-<urn:ex:s074> <urn:ex:p> <http://a/bb/ccc/g>.
-<urn:ex:s075> <urn:ex:p> <http://a/bb/ccc/d/g/>.
-<urn:ex:s076> <urn:ex:p> <http://a/bb/ccc/d/g/h>.
-<urn:ex:s077> <urn:ex:p> <http://a/bb/ccc/d/h>.
-<urn:ex:s078> <urn:ex:p> <http://a/bb/ccc/d/g;x=1/y>.
-<urn:ex:s079> <urn:ex:p> <http://a/bb/ccc/d/y>.
-<urn:ex:s080> <urn:ex:p> <http://a/bb/ccc/d/g?y/./x>.
-<urn:ex:s081> <urn:ex:p> <http://a/bb/ccc/d/g?y/../x>.
-<urn:ex:s082> <urn:ex:p> <http://a/bb/ccc/d/g#s/./x>.
-<urn:ex:s083> <urn:ex:p> <http://a/bb/ccc/d/g#s/../x>.
+<urn:ex:s066> <urn:ex:p> <http://a/g> .
+<urn:ex:s067> <urn:ex:p> <http://a/g> .
+<urn:ex:s068> <urn:ex:p> <http://a/g> .
+<urn:ex:s069> <urn:ex:p> <http://a/g> .
+<urn:ex:s070> <urn:ex:p> <http://a/bb/ccc/d/g.> .
+<urn:ex:s071> <urn:ex:p> <http://a/bb/ccc/d/.g> .
+<urn:ex:s072> <urn:ex:p> <http://a/bb/ccc/d/g..> .
+<urn:ex:s073> <urn:ex:p> <http://a/bb/ccc/d/..g> .
+<urn:ex:s074> <urn:ex:p> <http://a/bb/ccc/g> .
+<urn:ex:s075> <urn:ex:p> <http://a/bb/ccc/d/g/> .
+<urn:ex:s076> <urn:ex:p> <http://a/bb/ccc/d/g/h> .
+<urn:ex:s077> <urn:ex:p> <http://a/bb/ccc/d/h> .
+<urn:ex:s078> <urn:ex:p> <http://a/bb/ccc/d/g;x=1/y> .
+<urn:ex:s079> <urn:ex:p> <http://a/bb/ccc/d/y> .
+<urn:ex:s080> <urn:ex:p> <http://a/bb/ccc/d/g?y/./x> .
+<urn:ex:s081> <urn:ex:p> <http://a/bb/ccc/d/g?y/../x> .
+<urn:ex:s082> <urn:ex:p> <http://a/bb/ccc/d/g#s/./x> .
+<urn:ex:s083> <urn:ex:p> <http://a/bb/ccc/d/g#s/../x> .

--- a/rdf/rdf11/rdf-turtle/IRI-resolution-07.nt
+++ b/rdf/rdf11/rdf-turtle/IRI-resolution-07.nt
@@ -21,7 +21,6 @@
 <urn:ex:s273> <urn:ex:p> <file:///a/> .
 <urn:ex:s274> <urn:ex:p> <file:///a/> .
 <urn:ex:s275> <urn:ex:p> <file:///a/g> .
-
 <urn:ex:s276> <urn:ex:p> <file:///g> .
 <urn:ex:s277> <urn:ex:p> <file:///g> .
 <urn:ex:s278> <urn:ex:p> <file:///g> .

--- a/rdf/rdf11/rdf-turtle/IRI-resolution-07.nt
+++ b/rdf/rdf11/rdf-turtle/IRI-resolution-07.nt
@@ -1,43 +1,43 @@
-<urn:ex:s253> <urn:ex:p> <g:h>.
-<urn:ex:s254> <urn:ex:p> <file:///a/bb/ccc/g>.
-<urn:ex:s255> <urn:ex:p> <file:///a/bb/ccc/g>.
-<urn:ex:s256> <urn:ex:p> <file:///a/bb/ccc/g/>.
-<urn:ex:s257> <urn:ex:p> <file:///g>.
-<urn:ex:s258> <urn:ex:p> <file://g>.
-<urn:ex:s259> <urn:ex:p> <file:///a/bb/ccc/d;p?y>.
-<urn:ex:s260> <urn:ex:p> <file:///a/bb/ccc/g?y>.
-<urn:ex:s261> <urn:ex:p> <file:///a/bb/ccc/d;p?q#s>.
-<urn:ex:s262> <urn:ex:p> <file:///a/bb/ccc/g#s>.
-<urn:ex:s263> <urn:ex:p> <file:///a/bb/ccc/g?y#s>.
-<urn:ex:s264> <urn:ex:p> <file:///a/bb/ccc/;x>.
-<urn:ex:s265> <urn:ex:p> <file:///a/bb/ccc/g;x>.
-<urn:ex:s266> <urn:ex:p> <file:///a/bb/ccc/g;x?y#s>.
-<urn:ex:s267> <urn:ex:p> <file:///a/bb/ccc/d;p?q>.
-<urn:ex:s268> <urn:ex:p> <file:///a/bb/ccc/>.
-<urn:ex:s269> <urn:ex:p> <file:///a/bb/ccc/>.
-<urn:ex:s270> <urn:ex:p> <file:///a/bb/>.
-<urn:ex:s271> <urn:ex:p> <file:///a/bb/>.
-<urn:ex:s272> <urn:ex:p> <file:///a/bb/g>.
-<urn:ex:s273> <urn:ex:p> <file:///a/>.
-<urn:ex:s274> <urn:ex:p> <file:///a/>.
-<urn:ex:s275> <urn:ex:p> <file:///a/g>.
+<urn:ex:s253> <urn:ex:p> <g:h> .
+<urn:ex:s254> <urn:ex:p> <file:///a/bb/ccc/g> .
+<urn:ex:s255> <urn:ex:p> <file:///a/bb/ccc/g> .
+<urn:ex:s256> <urn:ex:p> <file:///a/bb/ccc/g/> .
+<urn:ex:s257> <urn:ex:p> <file:///g> .
+<urn:ex:s258> <urn:ex:p> <file://g> .
+<urn:ex:s259> <urn:ex:p> <file:///a/bb/ccc/d;p?y> .
+<urn:ex:s260> <urn:ex:p> <file:///a/bb/ccc/g?y> .
+<urn:ex:s261> <urn:ex:p> <file:///a/bb/ccc/d;p?q#s> .
+<urn:ex:s262> <urn:ex:p> <file:///a/bb/ccc/g#s> .
+<urn:ex:s263> <urn:ex:p> <file:///a/bb/ccc/g?y#s> .
+<urn:ex:s264> <urn:ex:p> <file:///a/bb/ccc/;x> .
+<urn:ex:s265> <urn:ex:p> <file:///a/bb/ccc/g;x> .
+<urn:ex:s266> <urn:ex:p> <file:///a/bb/ccc/g;x?y#s> .
+<urn:ex:s267> <urn:ex:p> <file:///a/bb/ccc/d;p?q> .
+<urn:ex:s268> <urn:ex:p> <file:///a/bb/ccc/> .
+<urn:ex:s269> <urn:ex:p> <file:///a/bb/ccc/> .
+<urn:ex:s270> <urn:ex:p> <file:///a/bb/> .
+<urn:ex:s271> <urn:ex:p> <file:///a/bb/> .
+<urn:ex:s272> <urn:ex:p> <file:///a/bb/g> .
+<urn:ex:s273> <urn:ex:p> <file:///a/> .
+<urn:ex:s274> <urn:ex:p> <file:///a/> .
+<urn:ex:s275> <urn:ex:p> <file:///a/g> .
 
-<urn:ex:s276> <urn:ex:p> <file:///g>.
-<urn:ex:s277> <urn:ex:p> <file:///g>.
-<urn:ex:s278> <urn:ex:p> <file:///g>.
-<urn:ex:s279> <urn:ex:p> <file:///g>.
-<urn:ex:s280> <urn:ex:p> <file:///a/bb/ccc/g.>.
-<urn:ex:s281> <urn:ex:p> <file:///a/bb/ccc/.g>.
-<urn:ex:s282> <urn:ex:p> <file:///a/bb/ccc/g..>.
-<urn:ex:s283> <urn:ex:p> <file:///a/bb/ccc/..g>.
-<urn:ex:s284> <urn:ex:p> <file:///a/bb/g>.
-<urn:ex:s285> <urn:ex:p> <file:///a/bb/ccc/g/>.
-<urn:ex:s286> <urn:ex:p> <file:///a/bb/ccc/g/h>.
-<urn:ex:s287> <urn:ex:p> <file:///a/bb/ccc/h>.
-<urn:ex:s288> <urn:ex:p> <file:///a/bb/ccc/g;x=1/y>.
-<urn:ex:s289> <urn:ex:p> <file:///a/bb/ccc/y>.
-<urn:ex:s290> <urn:ex:p> <file:///a/bb/ccc/g?y/./x>.
-<urn:ex:s291> <urn:ex:p> <file:///a/bb/ccc/g?y/../x>.
-<urn:ex:s292> <urn:ex:p> <file:///a/bb/ccc/g#s/./x>.
-<urn:ex:s293> <urn:ex:p> <file:///a/bb/ccc/g#s/../x>.
-<urn:ex:s294> <urn:ex:p> <http:g>.
+<urn:ex:s276> <urn:ex:p> <file:///g> .
+<urn:ex:s277> <urn:ex:p> <file:///g> .
+<urn:ex:s278> <urn:ex:p> <file:///g> .
+<urn:ex:s279> <urn:ex:p> <file:///g> .
+<urn:ex:s280> <urn:ex:p> <file:///a/bb/ccc/g.> .
+<urn:ex:s281> <urn:ex:p> <file:///a/bb/ccc/.g> .
+<urn:ex:s282> <urn:ex:p> <file:///a/bb/ccc/g..> .
+<urn:ex:s283> <urn:ex:p> <file:///a/bb/ccc/..g> .
+<urn:ex:s284> <urn:ex:p> <file:///a/bb/g> .
+<urn:ex:s285> <urn:ex:p> <file:///a/bb/ccc/g/> .
+<urn:ex:s286> <urn:ex:p> <file:///a/bb/ccc/g/h> .
+<urn:ex:s287> <urn:ex:p> <file:///a/bb/ccc/h> .
+<urn:ex:s288> <urn:ex:p> <file:///a/bb/ccc/g;x=1/y> .
+<urn:ex:s289> <urn:ex:p> <file:///a/bb/ccc/y> .
+<urn:ex:s290> <urn:ex:p> <file:///a/bb/ccc/g?y/./x> .
+<urn:ex:s291> <urn:ex:p> <file:///a/bb/ccc/g?y/../x> .
+<urn:ex:s292> <urn:ex:p> <file:///a/bb/ccc/g#s/./x> .
+<urn:ex:s293> <urn:ex:p> <file:///a/bb/ccc/g#s/../x> .
+<urn:ex:s294> <urn:ex:p> <http:g> .

--- a/rdf/rdf11/rdf-turtle/IRI-resolution-08.nt
+++ b/rdf/rdf11/rdf-turtle/IRI-resolution-08.nt
@@ -4,11 +4,9 @@
 <urn:ex:s298> <urn:ex:p> <http://abc/> .
 <urn:ex:s299> <urn:ex:p> <http://abc/?a=b> .
 <urn:ex:s300> <urn:ex:p> <http://abc/#a=b> .
-
 <urn:ex:s301> <urn:ex:p> <http://ab//de//xyz> .
 <urn:ex:s302> <urn:ex:p> <http://ab//de//xyz> .
 <urn:ex:s303> <urn:ex:p> <http://ab//de/xyz> .
-
 <urn:ex:s304> <urn:ex:p> <http://abc/d:f/xyz> .
 <urn:ex:s305> <urn:ex:p> <http://abc/d:f/xyz> .
 <urn:ex:s306> <urn:ex:p> <http://abc/xyz> .

--- a/rdf/rdf11/rdf-turtle/IRI-resolution-08.nt
+++ b/rdf/rdf11/rdf-turtle/IRI-resolution-08.nt
@@ -1,14 +1,14 @@
-<urn:ex:s295> <urn:ex:p> <http://abc/def/>.
-<urn:ex:s296> <urn:ex:p> <http://abc/def/?a=b>.
-<urn:ex:s297> <urn:ex:p> <http://abc/def/#a=b>.
-<urn:ex:s298> <urn:ex:p> <http://abc/>.
-<urn:ex:s299> <urn:ex:p> <http://abc/?a=b>.
-<urn:ex:s300> <urn:ex:p> <http://abc/#a=b>.
+<urn:ex:s295> <urn:ex:p> <http://abc/def/> .
+<urn:ex:s296> <urn:ex:p> <http://abc/def/?a=b> .
+<urn:ex:s297> <urn:ex:p> <http://abc/def/#a=b> .
+<urn:ex:s298> <urn:ex:p> <http://abc/> .
+<urn:ex:s299> <urn:ex:p> <http://abc/?a=b> .
+<urn:ex:s300> <urn:ex:p> <http://abc/#a=b> .
 
-<urn:ex:s301> <urn:ex:p> <http://ab//de//xyz>.
-<urn:ex:s302> <urn:ex:p> <http://ab//de//xyz>.
-<urn:ex:s303> <urn:ex:p> <http://ab//de/xyz>.
+<urn:ex:s301> <urn:ex:p> <http://ab//de//xyz> .
+<urn:ex:s302> <urn:ex:p> <http://ab//de//xyz> .
+<urn:ex:s303> <urn:ex:p> <http://ab//de/xyz> .
 
-<urn:ex:s304> <urn:ex:p> <http://abc/d:f/xyz>.
-<urn:ex:s305> <urn:ex:p> <http://abc/d:f/xyz>.
-<urn:ex:s306> <urn:ex:p> <http://abc/xyz>.
+<urn:ex:s304> <urn:ex:p> <http://abc/d:f/xyz> .
+<urn:ex:s305> <urn:ex:p> <http://abc/d:f/xyz> .
+<urn:ex:s306> <urn:ex:p> <http://abc/xyz> .

--- a/rdf/rdf11/rdf-turtle/manifest.ttl
+++ b/rdf/rdf11/rdf-turtle/manifest.ttl
@@ -2574,91 +2574,104 @@
     rdfs:comment "Blank node label must not end in dot" ;
     mf:name "turtle-syntax-bad-blank-label-dot-end" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-bad-blank-label-dot-end.ttl> .
+    mf:action <turtle-syntax-bad-blank-label-dot-end.ttl> ;
+    .
 
 <#turtle-syntax-bad-number-dot-in-anon>
     rdf:type rdft:TestTurtleNegativeSyntax ;
     rdfs:comment "Dot delimeter may not appear in anonymous nodes" ;
     mf:name "turtle-syntax-bad-number-dot-in-anon" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-bad-number-dot-in-anon.ttl> .
+    mf:action <turtle-syntax-bad-number-dot-in-anon.ttl> ;
+    .
 
 <#turtle-syntax-bad-ln-dash-start>
     rdf:type rdft:TestTurtleNegativeSyntax ;
     rdfs:comment "Local name must not begin with dash" ;
     mf:name "turtle-syntax-bad-ln-dash-start" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-bad-ln-dash-start.ttl> .
+    mf:action <turtle-syntax-bad-ln-dash-start.ttl> ;
+    .
 
 <#turtle-syntax-bad-ln-escape>
     rdf:type rdft:TestTurtleNegativeSyntax ;
     rdfs:comment "Bad hex escape in local name" ;
     mf:name "turtle-syntax-bad-ln-escape" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-bad-ln-escape.ttl> .
+    mf:action <turtle-syntax-bad-ln-escape.ttl> ;
+    .
 
 <#turtle-syntax-bad-ln-escape-start>
     rdf:type rdft:TestTurtleNegativeSyntax ;
     rdfs:comment "Bad hex escape at start of local name" ;
     mf:name "turtle-syntax-bad-ln-escape-start" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-bad-ln-escape-start.ttl> .
+    mf:action <turtle-syntax-bad-ln-escape-start.ttl> ;
+    .
 
 <#turtle-syntax-bad-ns-dot-end>
     rdf:type rdft:TestTurtleNegativeSyntax ;
     rdfs:comment "Prefix must not end in dot" ;
     mf:name "turtle-syntax-bad-ns-dot-end" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-bad-ns-dot-end.ttl> .
+    mf:action <turtle-syntax-bad-ns-dot-end.ttl> ;
+    .
 
 <#turtle-syntax-bad-ns-dot-start>
     rdf:type rdft:TestTurtleNegativeSyntax ;
     rdfs:comment "Prefix must not start with dot" ;
     mf:name "turtle-syntax-bad-ns-dot-start" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-bad-ns-dot-start.ttl> .
+    mf:action <turtle-syntax-bad-ns-dot-start.ttl> ;
+    .
 
 <#turtle-syntax-bad-missing-ns-dot-end>
     rdf:type rdft:TestTurtleNegativeSyntax ;
     rdfs:comment "Prefix must not end in dot (error in triple, not prefix directive like turtle-syntax-bad-ns-dot-end)" ;
     mf:name "turtle-syntax-bad-missing-ns-dot-end" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-bad-missing-ns-dot-end.ttl> .
+    mf:action <turtle-syntax-bad-missing-ns-dot-end.ttl> ;
+    .
 
 <#turtle-syntax-bad-missing-ns-dot-start>
     rdf:type rdft:TestTurtleNegativeSyntax ;
     rdfs:comment "Prefix must not start with dot (error in triple, not prefix directive like turtle-syntax-bad-ns-dot-end)" ;
     mf:name "turtle-syntax-bad-missing-ns-dot-start" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-bad-missing-ns-dot-start.ttl> .
+    mf:action <turtle-syntax-bad-missing-ns-dot-start.ttl> ;
+    .
 
 <#turtle-syntax-ln-dots>
     rdf:type rdft:TestTurtlePositiveSyntax ;
     rdfs:comment "Dots in pname local names" ;
     mf:name "turtle-syntax-ln-dots" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-ln-dots.ttl> .
+    mf:action <turtle-syntax-ln-dots.ttl> ;
+    .
 
 <#turtle-syntax-ln-colons>
     rdf:type rdft:TestTurtlePositiveSyntax ;
     rdfs:comment "Colons in pname local names" ;
     mf:name "turtle-syntax-ln-colons" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-ln-colons.ttl> .
+    mf:action <turtle-syntax-ln-colons.ttl> ;
+    .
 
 <#turtle-syntax-ns-dots>
     rdf:type rdft:TestTurtlePositiveSyntax ;
     rdfs:comment "Dots in namespace names" ;
     mf:name "turtle-syntax-ns-dots" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-ns-dots.ttl> .
+    mf:action <turtle-syntax-ns-dots.ttl> ;
+    .
 
 <#turtle-syntax-blank-label>
     rdf:type rdft:TestTurtlePositiveSyntax ;
     rdfs:comment "Characters allowed in blank node labels" ;
     mf:name "turtle-syntax-blank-label" ;
     rdft:approval rdft:Approved ;
-    mf:action <turtle-syntax-blank-label.ttl> .
+    mf:action <turtle-syntax-blank-label.ttl> ;
+    .
 
 # IRI resolution tests
 <#IRI-resolution-01>
@@ -2667,7 +2680,8 @@
     mf:name "IRI-resolution-01" ;
     rdft:approval rdft:Proposed ;
     mf:action <IRI-resolution-01.ttl> ;
-    mf:result <IRI-resolution-01.nt> .
+    mf:result <IRI-resolution-01.nt> ;
+    .
 
 <#IRI-resolution-02>
     rdf:type rdft:TestTurtleEval ;
@@ -2675,7 +2689,8 @@
     mf:name "IRI-resolution-02" ;
     rdft:approval rdft:Proposed ;
     mf:action <IRI-resolution-02.ttl> ;
-    mf:result <IRI-resolution-02.nt> .
+    mf:result <IRI-resolution-02.nt> ;
+    .
 
 <#IRI-resolution-07>
     rdf:type rdft:TestTurtleEval ;
@@ -2683,7 +2698,8 @@
     mf:name "IRI-resolution-07" ;
     rdft:approval rdft:Proposed ;
     mf:action <IRI-resolution-07.ttl> ;
-    mf:result <IRI-resolution-07.nt> .
+    mf:result <IRI-resolution-07.nt> ;
+    .
 
 <#IRI-resolution-08>
     rdf:type rdft:TestTurtleEval ;
@@ -2691,4 +2707,5 @@
     mf:name "IRI-resolution-08" ;
     rdft:approval rdft:Proposed ;
     mf:action <IRI-resolution-08.ttl> ;
-    mf:result <IRI-resolution-08.nt> .
+    mf:result <IRI-resolution-08.nt> ;
+    .

--- a/rdf/rdf11/rdf-turtle/manifest.ttl
+++ b/rdf/rdf11/rdf-turtle/manifest.ttl
@@ -352,2220 +352,2220 @@
 
 # atomic tests
 <#IRI_subject> rdf:type rdft:TestTurtleEval ;
-   mf:name      "IRI_subject" ;
-   rdfs:comment "IRI subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <IRI_subject.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "IRI_subject" ;
+    rdfs:comment "IRI subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <IRI_subject.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#IRI_with_four_digit_numeric_escape> rdf:type rdft:TestTurtleEval ;
-   mf:name      "IRI_with_four_digit_numeric_escape" ;
-   rdfs:comment "IRI with four digit numeric escape (\\u)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <IRI_with_four_digit_numeric_escape.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "IRI_with_four_digit_numeric_escape" ;
+    rdfs:comment "IRI with four digit numeric escape (\\u)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <IRI_with_four_digit_numeric_escape.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#IRI_with_eight_digit_numeric_escape> rdf:type rdft:TestTurtleEval ;
-   mf:name      "IRI_with_eight_digit_numeric_escape" ;
-   rdfs:comment "IRI with eight digit numeric escape (\\U)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <IRI_with_eight_digit_numeric_escape.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "IRI_with_eight_digit_numeric_escape" ;
+    rdfs:comment "IRI with eight digit numeric escape (\\U)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <IRI_with_eight_digit_numeric_escape.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#IRI_with_all_punctuation> rdf:type rdft:TestTurtleEval ;
-   mf:name      "IRI_with_all_punctuation" ;
-   rdfs:comment "IRI with all punctuation" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <IRI_with_all_punctuation.ttl> ;
-   mf:result    <IRI_with_all_punctuation.nt> ;
-   .
+    mf:name      "IRI_with_all_punctuation" ;
+    rdfs:comment "IRI with all punctuation" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <IRI_with_all_punctuation.ttl> ;
+    mf:result    <IRI_with_all_punctuation.nt> ;
+    .
 
 <#bareword_a_predicate> rdf:type rdft:TestTurtleEval ;
-   mf:name      "bareword_a_predicate" ;
-   rdfs:comment "bareword a predicate" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <bareword_a_predicate.ttl> ;
-   mf:result    <bareword_a_predicate.nt> ;
-   .
+    mf:name      "bareword_a_predicate" ;
+    rdfs:comment "bareword a predicate" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <bareword_a_predicate.ttl> ;
+    mf:result    <bareword_a_predicate.nt> ;
+    .
 
 <#old_style_prefix> rdf:type rdft:TestTurtleEval ;
-   mf:name      "old_style_prefix" ;
-   rdfs:comment "old-style prefix" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <old_style_prefix.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "old_style_prefix" ;
+    rdfs:comment "old-style prefix" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <old_style_prefix.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#SPARQL_style_prefix> rdf:type rdft:TestTurtleEval ;
-   mf:name      "SPARQL_style_prefix" ;
-   rdfs:comment "SPARQL-style prefix" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <SPARQL_style_prefix.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "SPARQL_style_prefix" ;
+    rdfs:comment "SPARQL-style prefix" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <SPARQL_style_prefix.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#prefixed_IRI_predicate> rdf:type rdft:TestTurtleEval ;
-   mf:name      "prefixed_IRI_predicate" ;
-   rdfs:comment "prefixed IRI predicate" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefixed_IRI_predicate.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "prefixed_IRI_predicate" ;
+    rdfs:comment "prefixed IRI predicate" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefixed_IRI_predicate.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#prefixed_IRI_object> rdf:type rdft:TestTurtleEval ;
-   mf:name      "prefixed_IRI_object" ;
-   rdfs:comment "prefixed IRI object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefixed_IRI_object.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "prefixed_IRI_object" ;
+    rdfs:comment "prefixed IRI object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefixed_IRI_object.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#prefix_only_IRI> rdf:type rdft:TestTurtleEval ;
-   mf:name      "prefix_only_IRI" ;
-   rdfs:comment "prefix-only IRI (p:)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefix_only_IRI.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "prefix_only_IRI" ;
+    rdfs:comment "prefix-only IRI (p:)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefix_only_IRI.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#prefix_with_PN_CHARS_BASE_character_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "prefix_with_PN_CHARS_BASE_character_boundaries" ;
-   rdfs:comment "prefix with PN CHARS BASE character boundaries (prefix: AZazÀÖØöø...:)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefix_with_PN_CHARS_BASE_character_boundaries.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "prefix_with_PN_CHARS_BASE_character_boundaries" ;
+    rdfs:comment "prefix with PN CHARS BASE character boundaries (prefix: AZazÀÖØöø...:)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefix_with_PN_CHARS_BASE_character_boundaries.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#prefix_with_non_leading_extras> rdf:type rdft:TestTurtleEval ;
-   mf:name      "prefix_with_non_leading_extras" ;
-   rdfs:comment "prefix with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefix_with_non_leading_extras.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "prefix_with_non_leading_extras" ;
+    rdfs:comment "prefix with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefix_with_non_leading_extras.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries" ;
-   rdfs:comment "localName with assigned, NFC-normalized, basic-multilingual-plane PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries.ttl> ;
-   mf:result    <localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries.nt> ;
-   .
+    mf:name      "localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries" ;
+    rdfs:comment "localName with assigned, NFC-normalized, basic-multilingual-plane PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries.ttl> ;
+    mf:result    <localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries.nt> ;
+    .
 
 <#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries" ;
-   rdfs:comment "localName with assigned, NFC-normalized PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries.ttl> ;
-   mf:result    <localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries.nt> ;
-   .
+    mf:name      "localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries" ;
+    rdfs:comment "localName with assigned, NFC-normalized PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries.ttl> ;
+    mf:result    <localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries.nt> ;
+    .
 
 <#localName_with_nfc_PN_CHARS_BASE_character_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "localName_with_nfc_PN_CHARS_BASE_character_boundaries" ;
-   rdfs:comment "localName with nfc-normalize PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_nfc_PN_CHARS_BASE_character_boundaries.ttl> ;
-   mf:result    <localName_with_nfc_PN_CHARS_BASE_character_boundaries.nt> ;
-   .
+    mf:name      "localName_with_nfc_PN_CHARS_BASE_character_boundaries" ;
+    rdfs:comment "localName with nfc-normalize PN CHARS BASE character boundaries (p:AZazÀÖØöø...)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_nfc_PN_CHARS_BASE_character_boundaries.ttl> ;
+    mf:result    <localName_with_nfc_PN_CHARS_BASE_character_boundaries.nt> ;
+    .
 
 <#default_namespace_IRI> rdf:type rdft:TestTurtleEval ;
-   mf:name      "default_namespace_IRI" ;
-   rdfs:comment "default namespace IRI (:ln)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <default_namespace_IRI.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "default_namespace_IRI" ;
+    rdfs:comment "default namespace IRI (:ln)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <default_namespace_IRI.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#prefix_reassigned_and_used> rdf:type rdft:TestTurtleEval ;
-   mf:name      "prefix_reassigned_and_used" ;
-   rdfs:comment "prefix reassigned and used" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefix_reassigned_and_used.ttl> ;
-   mf:result    <prefix_reassigned_and_used.nt> ;
-   .
+    mf:name      "prefix_reassigned_and_used" ;
+    rdfs:comment "prefix reassigned and used" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefix_reassigned_and_used.ttl> ;
+    mf:result    <prefix_reassigned_and_used.nt> ;
+    .
 
 <#reserved_escaped_localName> rdf:type rdft:TestTurtleEval ;
-   mf:name      "reserved_escaped_localName" ;
-   rdfs:comment "reserved-escaped local name" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <reserved_escaped_localName.ttl> ;
-   mf:result    <reserved_escaped_localName.nt> ;
-   .
+    mf:name      "reserved_escaped_localName" ;
+    rdfs:comment "reserved-escaped local name" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <reserved_escaped_localName.ttl> ;
+    mf:result    <reserved_escaped_localName.nt> ;
+    .
 
 <#percent_escaped_localName> rdf:type rdft:TestTurtleEval ;
-   mf:name      "percent_escaped_localName" ;
-   rdfs:comment "percent-escaped local name" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <percent_escaped_localName.ttl> ;
-   mf:result    <percent_escaped_localName.nt> ;
-   .
+    mf:name      "percent_escaped_localName" ;
+    rdfs:comment "percent-escaped local name" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <percent_escaped_localName.ttl> ;
+    mf:result    <percent_escaped_localName.nt> ;
+    .
 
 <#HYPHEN_MINUS_in_localName> rdf:type rdft:TestTurtleEval ;
-   mf:name      "HYPHEN_MINUS_in_localName" ;
-   rdfs:comment "HYPHEN-MINUS in local name" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <HYPHEN_MINUS_in_localName.ttl> ;
-   mf:result    <HYPHEN_MINUS_in_localName.nt> ;
-   .
+    mf:name      "HYPHEN_MINUS_in_localName" ;
+    rdfs:comment "HYPHEN-MINUS in local name" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <HYPHEN_MINUS_in_localName.ttl> ;
+    mf:result    <HYPHEN_MINUS_in_localName.nt> ;
+    .
 
 <#underscore_in_localName> rdf:type rdft:TestTurtleEval ;
-   mf:name      "underscore_in_localName" ;
-   rdfs:comment "underscore in local name" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <underscore_in_localName.ttl> ;
-   mf:result    <underscore_in_localName.nt> ;
-   .
+    mf:name      "underscore_in_localName" ;
+    rdfs:comment "underscore in local name" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <underscore_in_localName.ttl> ;
+    mf:result    <underscore_in_localName.nt> ;
+    .
 
 <#localname_with_COLON> rdf:type rdft:TestTurtleEval ;
-   mf:name      "localname_with_COLON" ;
-   rdfs:comment "localname with COLON" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localname_with_COLON.ttl> ;
-   mf:result    <localname_with_COLON.nt> ;
-   .
+    mf:name      "localname_with_COLON" ;
+    rdfs:comment "localname with COLON" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localname_with_COLON.ttl> ;
+    mf:result    <localname_with_COLON.nt> ;
+    .
 
 <#localName_with_leading_underscore> rdf:type rdft:TestTurtleEval ;
-   mf:name      "localName_with_leading_underscore" ;
-   rdfs:comment "localName with leading underscore (p:_)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_leading_underscore.ttl> ;
-   mf:result    <localName_with_leading_underscore.nt> ;
-   .
+    mf:name      "localName_with_leading_underscore" ;
+    rdfs:comment "localName with leading underscore (p:_)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_leading_underscore.ttl> ;
+    mf:result    <localName_with_leading_underscore.nt> ;
+    .
 
 <#localName_with_leading_digit> rdf:type rdft:TestTurtleEval ;
-   mf:name      "localName_with_leading_digit" ;
-   rdfs:comment "localName with leading digit (p:_)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_leading_digit.ttl> ;
-   mf:result    <localName_with_leading_digit.nt> ;
-   .
+    mf:name      "localName_with_leading_digit" ;
+    rdfs:comment "localName with leading digit (p:_)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_leading_digit.ttl> ;
+    mf:result    <localName_with_leading_digit.nt> ;
+    .
 
 <#localName_with_non_leading_extras> rdf:type rdft:TestTurtleEval ;
-   mf:name      "localName_with_non_leading_extras" ;
-   rdfs:comment "localName with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <localName_with_non_leading_extras.ttl> ;
-   mf:result    <localName_with_non_leading_extras.nt> ;
-   .
+    mf:name      "localName_with_non_leading_extras" ;
+    rdfs:comment "localName with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <localName_with_non_leading_extras.ttl> ;
+    mf:result    <localName_with_non_leading_extras.nt> ;
+    .
 
 <#old_style_base> rdf:type rdft:TestTurtleEval ;
-   mf:name      "old_style_base" ;
-   rdfs:comment "old-style base" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <old_style_base.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "old_style_base" ;
+    rdfs:comment "old-style base" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <old_style_base.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#SPARQL_style_base> rdf:type rdft:TestTurtleEval ;
-   mf:name      "SPARQL_style_base" ;
-   rdfs:comment "SPARQL-style base" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <SPARQL_style_base.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "SPARQL_style_base" ;
+    rdfs:comment "SPARQL-style base" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <SPARQL_style_base.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#labeled_blank_node_subject> rdf:type rdft:TestTurtleEval ;
-   mf:name      "labeled_blank_node_subject" ;
-   rdfs:comment "labeled blank node subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_subject.ttl> ;
-   mf:result    <labeled_blank_node_subject.nt> ;
-   .
+    mf:name      "labeled_blank_node_subject" ;
+    rdfs:comment "labeled blank node subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_subject.ttl> ;
+    mf:result    <labeled_blank_node_subject.nt> ;
+    .
 
 <#labeled_blank_node_object> rdf:type rdft:TestTurtleEval ;
-   mf:name      "labeled_blank_node_object" ;
-   rdfs:comment "labeled blank node object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_object.ttl> ;
-   mf:result    <labeled_blank_node_object.nt> ;
-   .
+    mf:name      "labeled_blank_node_object" ;
+    rdfs:comment "labeled blank node object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_object.ttl> ;
+    mf:result    <labeled_blank_node_object.nt> ;
+    .
 
 <#labeled_blank_node_with_PN_CHARS_BASE_character_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "labeled_blank_node_with_PN_CHARS_BASE_character_boundaries" ;
-   rdfs:comment "labeled blank node with PN_CHARS_BASE character boundaries (_:AZazÀÖØöø...)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_with_PN_CHARS_BASE_character_boundaries.ttl> ;
-   mf:result    <labeled_blank_node_object.nt> ;
-   .
+    mf:name      "labeled_blank_node_with_PN_CHARS_BASE_character_boundaries" ;
+    rdfs:comment "labeled blank node with PN_CHARS_BASE character boundaries (_:AZazÀÖØöø...)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_with_PN_CHARS_BASE_character_boundaries.ttl> ;
+    mf:result    <labeled_blank_node_object.nt> ;
+    .
 
 <#labeled_blank_node_with_leading_underscore> rdf:type rdft:TestTurtleEval ;
-   mf:name      "labeled_blank_node_with_leading_underscore" ;
-   rdfs:comment "labeled blank node with_leading_underscore (_:_)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_with_leading_underscore.ttl> ;
-   mf:result    <labeled_blank_node_object.nt> ;
-   .
+    mf:name      "labeled_blank_node_with_leading_underscore" ;
+    rdfs:comment "labeled blank node with_leading_underscore (_:_)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_with_leading_underscore.ttl> ;
+    mf:result    <labeled_blank_node_object.nt> ;
+    .
 
 <#labeled_blank_node_with_leading_digit> rdf:type rdft:TestTurtleEval ;
-   mf:name      "labeled_blank_node_with_leading_digit" ;
-   rdfs:comment "labeled blank node with_leading_digit (_:0)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_with_leading_digit.ttl> ;
-   mf:result    <labeled_blank_node_object.nt> ;
-   .
+    mf:name      "labeled_blank_node_with_leading_digit" ;
+    rdfs:comment "labeled blank node with_leading_digit (_:0)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_with_leading_digit.ttl> ;
+    mf:result    <labeled_blank_node_object.nt> ;
+    .
 
 <#labeled_blank_node_with_non_leading_extras> rdf:type rdft:TestTurtleEval ;
-   mf:name      "labeled_blank_node_with_non_leading_extras" ;
-   rdfs:comment "labeled blank node with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <labeled_blank_node_with_non_leading_extras.ttl> ;
-   mf:result    <labeled_blank_node_object.nt> ;
-   .
+    mf:name      "labeled_blank_node_with_non_leading_extras" ;
+    rdfs:comment "labeled blank node with_non_leading_extras (_:a·̀ͯ‿.⁀)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <labeled_blank_node_with_non_leading_extras.ttl> ;
+    mf:result    <labeled_blank_node_object.nt> ;
+    .
 
 <#anonymous_blank_node_subject> rdf:type rdft:TestTurtleEval ;
-   mf:name      "anonymous_blank_node_subject" ;
-   rdfs:comment "anonymous blank node subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <anonymous_blank_node_subject.ttl> ;
-   mf:result    <labeled_blank_node_subject.nt> ;
-   .
+    mf:name      "anonymous_blank_node_subject" ;
+    rdfs:comment "anonymous blank node subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <anonymous_blank_node_subject.ttl> ;
+    mf:result    <labeled_blank_node_subject.nt> ;
+    .
 
 <#anonymous_blank_node_object> rdf:type rdft:TestTurtleEval ;
-   mf:name      "anonymous_blank_node_object" ;
-   rdfs:comment "anonymous blank node object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <anonymous_blank_node_object.ttl> ;
-   mf:result    <labeled_blank_node_object.nt> ;
-   .
+    mf:name      "anonymous_blank_node_object" ;
+    rdfs:comment "anonymous blank node object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <anonymous_blank_node_object.ttl> ;
+    mf:result    <labeled_blank_node_object.nt> ;
+    .
 
 <#sole_blankNodePropertyList> rdf:type rdft:TestTurtleEval ;
-   mf:name      "sole_blankNodePropertyList" ;
-   rdfs:comment "sole blankNodePropertyList [ <p> <o> ] ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <sole_blankNodePropertyList.ttl> ;
-   mf:result    <labeled_blank_node_subject.nt> ;
-   .
+    mf:name      "sole_blankNodePropertyList" ;
+    rdfs:comment "sole blankNodePropertyList [ <p> <o> ] ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <sole_blankNodePropertyList.ttl> ;
+    mf:result    <labeled_blank_node_subject.nt> ;
+    .
 
 <#blankNodePropertyList_as_subject> rdf:type rdft:TestTurtleEval ;
-   mf:name      "blankNodePropertyList_as_subject" ;
-   rdfs:comment "blankNodePropertyList as subject [ … ] <p> <o> ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_as_subject.ttl> ;
-   mf:result    <blankNodePropertyList_as_subject.nt> ;
-   .
+    mf:name      "blankNodePropertyList_as_subject" ;
+    rdfs:comment "blankNodePropertyList as subject [ … ] <p> <o> ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_as_subject.ttl> ;
+    mf:result    <blankNodePropertyList_as_subject.nt> ;
+    .
 
 <#blankNodePropertyList_as_object> rdf:type rdft:TestTurtleEval ;
-   mf:name      "blankNodePropertyList_as_object" ;
-   rdfs:comment "blankNodePropertyList as object <s> <p> [ … ] ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_as_object.ttl> ;
-   mf:result    <blankNodePropertyList_as_object.nt> ;
-   .
+    mf:name      "blankNodePropertyList_as_object" ;
+    rdfs:comment "blankNodePropertyList as object <s> <p> [ … ] ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_as_object.ttl> ;
+    mf:result    <blankNodePropertyList_as_object.nt> ;
+    .
 
 <#blankNodePropertyList_as_object_containing_objectList> rdf:type rdft:TestTurtleEval ;
-   mf:name      "blankNodePropertyList_as_object_containing_objectList" ;
-   rdfs:comment "blankNodePropertyList as object containing objectList <s> <p> [ <p2> <o>,<o2> ] ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_as_object_containing_objectList.ttl> ;
-   mf:result    <blankNodePropertyList_as_object_containing_objectList.nt> ;
-   .
+    mf:name      "blankNodePropertyList_as_object_containing_objectList" ;
+    rdfs:comment "blankNodePropertyList as object containing objectList <s> <p> [ <p2> <o>,<o2> ] ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_as_object_containing_objectList.ttl> ;
+    mf:result    <blankNodePropertyList_as_object_containing_objectList.nt> ;
+    .
 
 <#blankNodePropertyList_as_object_containing_objectList_of_two_objects> rdf:type rdft:TestTurtleEval ;
-   mf:name      "blankNodePropertyList_as_object_containing_objectList_of_two_objects" ;
-   rdfs:comment "blankNodePropertyList as object containing objectList of two objects <s> <p> [ <p2 <o> ] , <o2> ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_as_object_containing_objectList_of_two_objects.ttl> ;
-   mf:result    <blankNodePropertyList_as_object_containing_objectList_of_two_objects.nt> ;
-   .
+    mf:name      "blankNodePropertyList_as_object_containing_objectList_of_two_objects" ;
+    rdfs:comment "blankNodePropertyList as object containing objectList of two objects <s> <p> [ <p2 <o> ] , <o2> ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_as_object_containing_objectList_of_two_objects.ttl> ;
+    mf:result    <blankNodePropertyList_as_object_containing_objectList_of_two_objects.nt> ;
+    .
 
 <#blankNodePropertyList_with_multiple_triples> rdf:type rdft:TestTurtleEval ;
-   mf:name      "blankNodePropertyList_with_multiple_triples" ;
-   rdfs:comment "blankNodePropertyList with multiple triples [ <s> <p> ; <s2> <p2> ]" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_with_multiple_triples.ttl> ;
-   mf:result    <blankNodePropertyList_with_multiple_triples.nt> ;
-   .
+    mf:name      "blankNodePropertyList_with_multiple_triples" ;
+    rdfs:comment "blankNodePropertyList with multiple triples [ <s> <p> ; <s2> <p2> ]" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_with_multiple_triples.ttl> ;
+    mf:result    <blankNodePropertyList_with_multiple_triples.nt> ;
+    .
 
 <#nested_blankNodePropertyLists> rdf:type rdft:TestTurtleEval ;
-   mf:name      "nested_blankNodePropertyLists" ;
-   rdfs:comment "nested blankNodePropertyLists [ <p1> [ <p2> <o2> ] ; <p3> <o3> ]" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nested_blankNodePropertyLists.ttl> ;
-   mf:result    <nested_blankNodePropertyLists.nt> ;
-   .
+    mf:name      "nested_blankNodePropertyLists" ;
+    rdfs:comment "nested blankNodePropertyLists [ <p1> [ <p2> <o2> ] ; <p3> <o3> ]" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nested_blankNodePropertyLists.ttl> ;
+    mf:result    <nested_blankNodePropertyLists.nt> ;
+    .
 
 <#blankNodePropertyList_containing_collection> rdf:type rdft:TestTurtleEval ;
-   mf:name      "blankNodePropertyList_containing_collection" ;
-   rdfs:comment "blankNodePropertyList containing collection [ <p1> ( … ) ]" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <blankNodePropertyList_containing_collection.ttl> ;
-   mf:result    <blankNodePropertyList_containing_collection.nt> ;
-   .
+    mf:name      "blankNodePropertyList_containing_collection" ;
+    rdfs:comment "blankNodePropertyList containing collection [ <p1> ( … ) ]" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <blankNodePropertyList_containing_collection.ttl> ;
+    mf:result    <blankNodePropertyList_containing_collection.nt> ;
+    .
 
 <#collection_subject> rdf:type rdft:TestTurtleEval ;
-   mf:name      "collection_subject" ;
-   rdfs:comment "collection subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <collection_subject.ttl> ;
-   mf:result    <collection_subject.nt> ;
-   .
+    mf:name      "collection_subject" ;
+    rdfs:comment "collection subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <collection_subject.ttl> ;
+    mf:result    <collection_subject.nt> ;
+    .
 
 <#collection_object> rdf:type rdft:TestTurtleEval ;
-   mf:name      "collection_object" ;
-   rdfs:comment "collection object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <collection_object.ttl> ;
-   mf:result    <collection_object.nt> ;
-   .
+    mf:name      "collection_object" ;
+    rdfs:comment "collection object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <collection_object.ttl> ;
+    mf:result    <collection_object.nt> ;
+    .
 
 <#empty_collection> rdf:type rdft:TestTurtleEval ;
-   mf:name      "empty_collection" ;
-   rdfs:comment "empty collection ()" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <empty_collection.ttl> ;
-   mf:result    <empty_collection.nt> ;
-   .
+    mf:name      "empty_collection" ;
+    rdfs:comment "empty collection ()" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <empty_collection.ttl> ;
+    mf:result    <empty_collection.nt> ;
+    .
 
 <#nested_collection> rdf:type rdft:TestTurtleEval ;
-   mf:name      "nested_collection" ;
-   rdfs:comment "nested collection (())" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <nested_collection.ttl> ;
-   mf:result    <nested_collection.nt> ;
-   .
+    mf:name      "nested_collection" ;
+    rdfs:comment "nested collection (())" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <nested_collection.ttl> ;
+    mf:result    <nested_collection.nt> ;
+    .
 
 <#first> rdf:type rdft:TestTurtleEval ;
-   mf:name      "first" ;
-   rdfs:comment "first, not last, non-empty nested collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <first.ttl> ;
-   mf:result    <first.nt> ;
-   .
+    mf:name      "first" ;
+    rdfs:comment "first, not last, non-empty nested collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <first.ttl> ;
+    mf:result    <first.nt> ;
+    .
 
 <#last> rdf:type rdft:TestTurtleEval ;
-   mf:name      "last" ;
-   rdfs:comment "last, not first, non-empty nested collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <last.ttl> ;
-   mf:result    <last.nt> ;
-   .
+    mf:name      "last" ;
+    rdfs:comment "last, not first, non-empty nested collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <last.ttl> ;
+    mf:result    <last.nt> ;
+    .
 
 <#LITERAL1> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL1" ;
-   rdfs:comment "LITERAL1 'x'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL1.ttl> ;
-   mf:result    <LITERAL1.nt> ;
-   .
+    mf:name      "LITERAL1" ;
+    rdfs:comment "LITERAL1 'x'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL1.ttl> ;
+    mf:result    <LITERAL1.nt> ;
+    .
 
 <#LITERAL1_ascii_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL1_ascii_boundaries" ;
-   rdfs:comment "LITERAL1_ascii_boundaries '\\x00\\x09\\x0b\\x0c\\x0e\\x26\\x28...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL1_ascii_boundaries.ttl> ;
-   mf:result    <LITERAL1_ascii_boundaries.nt> ;
-   .
+    mf:name      "LITERAL1_ascii_boundaries" ;
+    rdfs:comment "LITERAL1_ascii_boundaries '\\x00\\x09\\x0b\\x0c\\x0e\\x26\\x28...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL1_ascii_boundaries.ttl> ;
+    mf:result    <LITERAL1_ascii_boundaries.nt> ;
+    .
 
 <#LITERAL1_with_UTF8_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL1_with_UTF8_boundaries" ;
-   rdfs:comment "LITERAL1_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL1_with_UTF8_boundaries.ttl> ;
-   mf:result    <LITERAL_with_UTF8_boundaries.nt> ;
-   .
+    mf:name      "LITERAL1_with_UTF8_boundaries" ;
+    rdfs:comment "LITERAL1_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL1_with_UTF8_boundaries.ttl> ;
+    mf:result    <LITERAL_with_UTF8_boundaries.nt> ;
+    .
 
 <#LITERAL1_all_controls> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL1_all_controls" ;
-   rdfs:comment "LITERAL1_all_controls '\\x00\\x01\\x02\\x03\\x04...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL1_all_controls.ttl> ;
-   mf:result    <LITERAL1_all_controls.nt> ;
-   .
+    mf:name      "LITERAL1_all_controls" ;
+    rdfs:comment "LITERAL1_all_controls '\\x00\\x01\\x02\\x03\\x04...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL1_all_controls.ttl> ;
+    mf:result    <LITERAL1_all_controls.nt> ;
+    .
 
 <#LITERAL1_all_punctuation> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL1_all_punctuation" ;
-   rdfs:comment "LITERAL1_all_punctuation '!\"#$%&()...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL1_all_punctuation.ttl> ;
-   mf:result    <LITERAL1_all_punctuation.nt> ;
-   .
+    mf:name      "LITERAL1_all_punctuation" ;
+    rdfs:comment "LITERAL1_all_punctuation '!\"#$%&()...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL1_all_punctuation.ttl> ;
+    mf:result    <LITERAL1_all_punctuation.nt> ;
+    .
 
 <#LITERAL_LONG1> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL_LONG1" ;
-   rdfs:comment "LITERAL_LONG1 '''x'''" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG1.ttl> ;
-   mf:result    <LITERAL1.nt> ;
-   .
+    mf:name      "LITERAL_LONG1" ;
+    rdfs:comment "LITERAL_LONG1 '''x'''" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG1.ttl> ;
+    mf:result    <LITERAL1.nt> ;
+    .
 
 <#LITERAL_LONG1_ascii_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL_LONG1_ascii_boundaries" ;
-   rdfs:comment "LITERAL_LONG1_ascii_boundaries '\\x00\\x26\\x28...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG1_ascii_boundaries.ttl> ;
-   mf:result    <LITERAL_LONG1_ascii_boundaries.nt> ;
-   .
+    mf:name      "LITERAL_LONG1_ascii_boundaries" ;
+    rdfs:comment "LITERAL_LONG1_ascii_boundaries '\\x00\\x26\\x28...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG1_ascii_boundaries.ttl> ;
+    mf:result    <LITERAL_LONG1_ascii_boundaries.nt> ;
+    .
 
 <#LITERAL_LONG1_with_UTF8_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL_LONG1_with_UTF8_boundaries" ;
-   rdfs:comment "LITERAL_LONG1_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG1_with_UTF8_boundaries.ttl> ;
-   mf:result    <LITERAL_with_UTF8_boundaries.nt> ;
-   .
+    mf:name      "LITERAL_LONG1_with_UTF8_boundaries" ;
+    rdfs:comment "LITERAL_LONG1_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG1_with_UTF8_boundaries.ttl> ;
+    mf:result    <LITERAL_with_UTF8_boundaries.nt> ;
+    .
 
 <#LITERAL_LONG1_with_1_squote> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL_LONG1_with_1_squote" ;
-   rdfs:comment "LITERAL_LONG1 with 1 squote '''a'b'''" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG1_with_1_squote.ttl> ;
-   mf:result    <LITERAL_LONG1_with_1_squote.nt> ;
-   .
+    mf:name      "LITERAL_LONG1_with_1_squote" ;
+    rdfs:comment "LITERAL_LONG1 with 1 squote '''a'b'''" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG1_with_1_squote.ttl> ;
+    mf:result    <LITERAL_LONG1_with_1_squote.nt> ;
+    .
 
 <#LITERAL_LONG1_with_2_squotes> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL_LONG1_with_2_squotes" ;
-   rdfs:comment "LITERAL_LONG1 with 2 squotes '''a''b'''" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG1_with_2_squotes.ttl> ;
-   mf:result    <LITERAL_LONG1_with_2_squotes.nt> ;
-   .
+    mf:name      "LITERAL_LONG1_with_2_squotes" ;
+    rdfs:comment "LITERAL_LONG1 with 2 squotes '''a''b'''" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG1_with_2_squotes.ttl> ;
+    mf:result    <LITERAL_LONG1_with_2_squotes.nt> ;
+    .
 
 <#LITERAL2> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL2" ;
-   rdfs:comment "LITERAL2 \"x\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL2.ttl> ;
-   mf:result    <LITERAL1.nt> ;
-   .
+    mf:name      "LITERAL2" ;
+    rdfs:comment "LITERAL2 \"x\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL2.ttl> ;
+    mf:result    <LITERAL1.nt> ;
+    .
 
 <#LITERAL2_ascii_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL2_ascii_boundaries" ;
-   rdfs:comment "LITERAL2_ascii_boundaries '\\x00\\x09\\x0b\\x0c\\x0e\\x21\\x23...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL2_ascii_boundaries.ttl> ;
-   mf:result    <LITERAL2_ascii_boundaries.nt> ;
-   .
+    mf:name      "LITERAL2_ascii_boundaries" ;
+    rdfs:comment "LITERAL2_ascii_boundaries '\\x00\\x09\\x0b\\x0c\\x0e\\x21\\x23...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL2_ascii_boundaries.ttl> ;
+    mf:result    <LITERAL2_ascii_boundaries.nt> ;
+    .
 
 <#LITERAL2_with_UTF8_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL2_with_UTF8_boundaries" ;
-   rdfs:comment "LITERAL2_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL2_with_UTF8_boundaries.ttl> ;
-   mf:result    <LITERAL_with_UTF8_boundaries.nt> ;
-   .
+    mf:name      "LITERAL2_with_UTF8_boundaries" ;
+    rdfs:comment "LITERAL2_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL2_with_UTF8_boundaries.ttl> ;
+    mf:result    <LITERAL_with_UTF8_boundaries.nt> ;
+    .
 
 <#LITERAL_LONG2> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL_LONG2" ;
-   rdfs:comment "LITERAL_LONG2 \"\"\"x\"\"\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2.ttl> ;
-   mf:result    <LITERAL1.nt> ;
-   .
+    mf:name      "LITERAL_LONG2" ;
+    rdfs:comment "LITERAL_LONG2 \"\"\"x\"\"\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2.ttl> ;
+    mf:result    <LITERAL1.nt> ;
+    .
 
 <#LITERAL_LONG2_ascii_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL_LONG2_ascii_boundaries" ;
-   rdfs:comment "LITERAL_LONG2_ascii_boundaries '\\x00\\x21\\x23...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2_ascii_boundaries.ttl> ;
-   mf:result    <LITERAL_LONG2_ascii_boundaries.nt> ;
-   .
+    mf:name      "LITERAL_LONG2_ascii_boundaries" ;
+    rdfs:comment "LITERAL_LONG2_ascii_boundaries '\\x00\\x21\\x23...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2_ascii_boundaries.ttl> ;
+    mf:result    <LITERAL_LONG2_ascii_boundaries.nt> ;
+    .
 
 <#LITERAL_LONG2_with_UTF8_boundaries> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL_LONG2_with_UTF8_boundaries" ;
-   rdfs:comment "LITERAL_LONG2_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2_with_UTF8_boundaries.ttl> ;
-   mf:result    <LITERAL_with_UTF8_boundaries.nt> ;
-   .
+    mf:name      "LITERAL_LONG2_with_UTF8_boundaries" ;
+    rdfs:comment "LITERAL_LONG2_with_UTF8_boundaries '\\x80\\x7ff\\x800\\xfff...'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2_with_UTF8_boundaries.ttl> ;
+    mf:result    <LITERAL_with_UTF8_boundaries.nt> ;
+    .
 
 <#LITERAL_LONG2_with_1_squote> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL_LONG2_with_1_squote" ;
-   rdfs:comment "LITERAL_LONG2 with 1 squote \"\"\"a\"b\"\"\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2_with_1_squote.ttl> ;
-   mf:result    <LITERAL_LONG2_with_1_squote.nt> ;
-   .
+    mf:name      "LITERAL_LONG2_with_1_squote" ;
+    rdfs:comment "LITERAL_LONG2 with 1 squote \"\"\"a\"b\"\"\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2_with_1_squote.ttl> ;
+    mf:result    <LITERAL_LONG2_with_1_squote.nt> ;
+    .
 
 <#LITERAL_LONG2_with_2_squotes> rdf:type rdft:TestTurtleEval ;
-   mf:name      "LITERAL_LONG2_with_2_squotes" ;
-   rdfs:comment "LITERAL_LONG2 with 2 squotes \"\"\"a\"\"b\"\"\"" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2_with_2_squotes.ttl> ;
-   mf:result    <LITERAL_LONG2_with_2_squotes.nt> ;
-   .
+    mf:name      "LITERAL_LONG2_with_2_squotes" ;
+    rdfs:comment "LITERAL_LONG2 with 2 squotes \"\"\"a\"\"b\"\"\"" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2_with_2_squotes.ttl> ;
+    mf:result    <LITERAL_LONG2_with_2_squotes.nt> ;
+    .
 
 <#literal_with_CHARACTER_TABULATION> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_CHARACTER_TABULATION" ;
-   rdfs:comment "literal with CHARACTER TABULATION" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_CHARACTER_TABULATION.ttl> ;
-   mf:result    <literal_with_CHARACTER_TABULATION.nt> ;
-   .
+    mf:name      "literal_with_CHARACTER_TABULATION" ;
+    rdfs:comment "literal with CHARACTER TABULATION" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_CHARACTER_TABULATION.ttl> ;
+    mf:result    <literal_with_CHARACTER_TABULATION.nt> ;
+    .
 
 <#literal_with_BACKSPACE> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_BACKSPACE" ;
-   rdfs:comment "literal with BACKSPACE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_BACKSPACE.ttl> ;
-   mf:result    <literal_with_BACKSPACE.nt> ;
-   .
+    mf:name      "literal_with_BACKSPACE" ;
+    rdfs:comment "literal with BACKSPACE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_BACKSPACE.ttl> ;
+    mf:result    <literal_with_BACKSPACE.nt> ;
+    .
 
 <#literal_with_LINE_FEED> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_LINE_FEED" ;
-   rdfs:comment "literal with LINE FEED" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_LINE_FEED.ttl> ;
-   mf:result    <literal_with_LINE_FEED.nt> ;
-   .
+    mf:name      "literal_with_LINE_FEED" ;
+    rdfs:comment "literal with LINE FEED" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_LINE_FEED.ttl> ;
+    mf:result    <literal_with_LINE_FEED.nt> ;
+    .
 
 <#literal_with_CARRIAGE_RETURN> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_CARRIAGE_RETURN" ;
-   rdfs:comment "literal with CARRIAGE RETURN" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_CARRIAGE_RETURN.ttl> ;
-   mf:result    <literal_with_CARRIAGE_RETURN.nt> ;
-   .
+    mf:name      "literal_with_CARRIAGE_RETURN" ;
+    rdfs:comment "literal with CARRIAGE RETURN" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_CARRIAGE_RETURN.ttl> ;
+    mf:result    <literal_with_CARRIAGE_RETURN.nt> ;
+    .
 
 <#literal_with_FORM_FEED> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_FORM_FEED" ;
-   rdfs:comment "literal with FORM FEED" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_FORM_FEED.ttl> ;
-   mf:result    <literal_with_FORM_FEED.nt> ;
-   .
+    mf:name      "literal_with_FORM_FEED" ;
+    rdfs:comment "literal with FORM FEED" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_FORM_FEED.ttl> ;
+    mf:result    <literal_with_FORM_FEED.nt> ;
+    .
 
 <#literal_with_REVERSE_SOLIDUS> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_REVERSE_SOLIDUS" ;
-   rdfs:comment "literal with REVERSE SOLIDUS" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_REVERSE_SOLIDUS.ttl> ;
-   mf:result    <literal_with_REVERSE_SOLIDUS.nt> ;
-   .
+    mf:name      "literal_with_REVERSE_SOLIDUS" ;
+    rdfs:comment "literal with REVERSE SOLIDUS" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_REVERSE_SOLIDUS.ttl> ;
+    mf:result    <literal_with_REVERSE_SOLIDUS.nt> ;
+    .
 
 <#literal_with_escaped_CHARACTER_TABULATION> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_escaped_CHARACTER_TABULATION" ;
-   rdfs:comment "literal with escaped CHARACTER TABULATION" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_escaped_CHARACTER_TABULATION.ttl> ;
-   mf:result    <literal_with_CHARACTER_TABULATION.nt> ;
-   .
+    mf:name      "literal_with_escaped_CHARACTER_TABULATION" ;
+    rdfs:comment "literal with escaped CHARACTER TABULATION" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_escaped_CHARACTER_TABULATION.ttl> ;
+    mf:result    <literal_with_CHARACTER_TABULATION.nt> ;
+    .
 
 <#literal_with_escaped_BACKSPACE> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_escaped_BACKSPACE" ;
-   rdfs:comment "literal with escaped BACKSPACE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_escaped_BACKSPACE.ttl> ;
-   mf:result    <literal_with_BACKSPACE.nt> ;
-   .
+    mf:name      "literal_with_escaped_BACKSPACE" ;
+    rdfs:comment "literal with escaped BACKSPACE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_escaped_BACKSPACE.ttl> ;
+    mf:result    <literal_with_BACKSPACE.nt> ;
+    .
 
 <#literal_with_escaped_LINE_FEED> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_escaped_LINE_FEED" ;
-   rdfs:comment "literal with escaped LINE FEED" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_escaped_LINE_FEED.ttl> ;
-   mf:result    <literal_with_LINE_FEED.nt> ;
-   .
+    mf:name      "literal_with_escaped_LINE_FEED" ;
+    rdfs:comment "literal with escaped LINE FEED" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_escaped_LINE_FEED.ttl> ;
+    mf:result    <literal_with_LINE_FEED.nt> ;
+    .
 
 <#literal_with_escaped_CARRIAGE_RETURN> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_escaped_CARRIAGE_RETURN" ;
-   rdfs:comment "literal with escaped CARRIAGE RETURN" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_escaped_CARRIAGE_RETURN.ttl> ;
-   mf:result    <literal_with_CARRIAGE_RETURN.nt> ;
-   .
+    mf:name      "literal_with_escaped_CARRIAGE_RETURN" ;
+    rdfs:comment "literal with escaped CARRIAGE RETURN" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_escaped_CARRIAGE_RETURN.ttl> ;
+    mf:result    <literal_with_CARRIAGE_RETURN.nt> ;
+    .
 
 <#literal_with_escaped_FORM_FEED> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_escaped_FORM_FEED" ;
-   rdfs:comment "literal with escaped FORM FEED" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_escaped_FORM_FEED.ttl> ;
-   mf:result    <literal_with_FORM_FEED.nt> ;
-   .
+    mf:name      "literal_with_escaped_FORM_FEED" ;
+    rdfs:comment "literal with escaped FORM FEED" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_escaped_FORM_FEED.ttl> ;
+    mf:result    <literal_with_FORM_FEED.nt> ;
+    .
 
 <#literal_with_numeric_escape4> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_numeric_escape4" ;
-   rdfs:comment "literal with numeric escape4 \\u" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_numeric_escape4.ttl> ;
-   mf:result    <literal_with_numeric_escape4.nt> ;
-   .
+    mf:name      "literal_with_numeric_escape4" ;
+    rdfs:comment "literal with numeric escape4 \\u" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_numeric_escape4.ttl> ;
+    mf:result    <literal_with_numeric_escape4.nt> ;
+    .
 
 <#literal_with_numeric_escape8> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_with_numeric_escape8" ;
-   rdfs:comment "literal with numeric escape8 \\U" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_with_numeric_escape8.ttl> ;
-   mf:result    <literal_with_numeric_escape4.nt> ;
-   .
+    mf:name      "literal_with_numeric_escape8" ;
+    rdfs:comment "literal with numeric escape8 \\U" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_with_numeric_escape8.ttl> ;
+    mf:result    <literal_with_numeric_escape4.nt> ;
+    .
 
 <#IRIREF_datatype> rdf:type rdft:TestTurtleEval ;
-   mf:name      "IRIREF_datatype" ;
-   rdfs:comment "IRIREF datatype \"\"^^<t>" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <IRIREF_datatype.ttl> ;
-   mf:result    <IRIREF_datatype.nt> ;
-   .
+    mf:name      "IRIREF_datatype" ;
+    rdfs:comment "IRIREF datatype \"\"^^<t>" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <IRIREF_datatype.ttl> ;
+    mf:result    <IRIREF_datatype.nt> ;
+    .
 
 <#prefixed_name_datatype> rdf:type rdft:TestTurtleEval ;
-   mf:name      "prefixed_name_datatype" ;
-   rdfs:comment "prefixed name datatype \"\"^^p:t" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <prefixed_name_datatype.ttl> ;
-   mf:result    <IRIREF_datatype.nt> ;
-   .
+    mf:name      "prefixed_name_datatype" ;
+    rdfs:comment "prefixed name datatype \"\"^^p:t" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <prefixed_name_datatype.ttl> ;
+    mf:result    <IRIREF_datatype.nt> ;
+    .
 
 <#bareword_integer> rdf:type rdft:TestTurtleEval ;
-   mf:name      "bareword_integer" ;
-   rdfs:comment "bareword integer" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <bareword_integer.ttl> ;
-   mf:result    <IRIREF_datatype.nt> ;
-   .
+    mf:name      "bareword_integer" ;
+    rdfs:comment "bareword integer" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <bareword_integer.ttl> ;
+    mf:result    <IRIREF_datatype.nt> ;
+    .
 
 <#bareword_decimal> rdf:type rdft:TestTurtleEval ;
-   mf:name      "bareword_decimal" ;
-   rdfs:comment "bareword decimal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <bareword_decimal.ttl> ;
-   mf:result    <bareword_decimal.nt> ;
-   .
+    mf:name      "bareword_decimal" ;
+    rdfs:comment "bareword decimal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <bareword_decimal.ttl> ;
+    mf:result    <bareword_decimal.nt> ;
+    .
 
 <#bareword_double> rdf:type rdft:TestTurtleEval ;
-   mf:name      "bareword_double" ;
-   rdfs:comment "bareword double" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <bareword_double.ttl> ;
-   mf:result    <bareword_double.nt> ;
-   .
+    mf:name      "bareword_double" ;
+    rdfs:comment "bareword double" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <bareword_double.ttl> ;
+    mf:result    <bareword_double.nt> ;
+    .
 
 <#double_lower_case_e> rdf:type rdft:TestTurtleEval ;
-   mf:name      "double_lower_case_e" ;
-   rdfs:comment "double lower case e" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <double_lower_case_e.ttl> ;
-   mf:result    <double_lower_case_e.nt> ;
-   .
+    mf:name      "double_lower_case_e" ;
+    rdfs:comment "double lower case e" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <double_lower_case_e.ttl> ;
+    mf:result    <double_lower_case_e.nt> ;
+    .
 
 <#negative_numeric> rdf:type rdft:TestTurtleEval ;
-   mf:name      "negative_numeric" ;
-   rdfs:comment "negative numeric" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <negative_numeric.ttl> ;
-   mf:result    <negative_numeric.nt> ;
-   .
+    mf:name      "negative_numeric" ;
+    rdfs:comment "negative numeric" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <negative_numeric.ttl> ;
+    mf:result    <negative_numeric.nt> ;
+    .
 
 <#positive_numeric> rdf:type rdft:TestTurtleEval ;
-   mf:name      "positive_numeric" ;
-   rdfs:comment "positive numeric" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <positive_numeric.ttl> ;
-   mf:result    <positive_numeric.nt> ;
-   .
+    mf:name      "positive_numeric" ;
+    rdfs:comment "positive numeric" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <positive_numeric.ttl> ;
+    mf:result    <positive_numeric.nt> ;
+    .
 
 <#numeric_with_leading_0> rdf:type rdft:TestTurtleEval ;
-   mf:name      "numeric_with_leading_0" ;
-   rdfs:comment "numeric with leading 0" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <numeric_with_leading_0.ttl> ;
-   mf:result    <numeric_with_leading_0.nt> ;
-   .
+    mf:name      "numeric_with_leading_0" ;
+    rdfs:comment "numeric with leading 0" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <numeric_with_leading_0.ttl> ;
+    mf:result    <numeric_with_leading_0.nt> ;
+    .
 
 <#literal_true> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_true" ;
-   rdfs:comment "literal true" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_true.ttl> ;
-   mf:result    <literal_true.nt> ;
-   .
+    mf:name      "literal_true" ;
+    rdfs:comment "literal true" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_true.ttl> ;
+    mf:result    <literal_true.nt> ;
+    .
 
 <#literal_false> rdf:type rdft:TestTurtleEval ;
-   mf:name      "literal_false" ;
-   rdfs:comment "literal false" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <literal_false.ttl> ;
-   mf:result    <literal_false.nt> ;
-   .
+    mf:name      "literal_false" ;
+    rdfs:comment "literal false" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <literal_false.ttl> ;
+    mf:result    <literal_false.nt> ;
+    .
 
 <#langtagged_non_LONG> rdf:type rdft:TestTurtleEval ;
-   mf:name      "langtagged_non_LONG" ;
-   rdfs:comment "langtagged non-LONG \"x\"@en" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <langtagged_non_LONG.ttl> ;
-   mf:result    <langtagged_non_LONG.nt> ;
-   .
+    mf:name      "langtagged_non_LONG" ;
+    rdfs:comment "langtagged non-LONG \"x\"@en" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <langtagged_non_LONG.ttl> ;
+    mf:result    <langtagged_non_LONG.nt> ;
+    .
 
 <#langtagged_LONG> rdf:type rdft:TestTurtleEval ;
-   mf:name      "langtagged_LONG" ;
-   rdfs:comment "langtagged LONG \"\"\"x\"\"\"@en" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <langtagged_LONG.ttl> ;
-   mf:result    <langtagged_non_LONG.nt> ;
-   .
+    mf:name      "langtagged_LONG" ;
+    rdfs:comment "langtagged LONG \"\"\"x\"\"\"@en" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <langtagged_LONG.ttl> ;
+    mf:result    <langtagged_non_LONG.nt> ;
+    .
 
 <#lantag_with_subtag> rdf:type rdft:TestTurtleEval ;
-   mf:name      "lantag_with_subtag" ;
-   rdfs:comment "lantag with subtag \"x\"@en-us" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <lantag_with_subtag.ttl> ;
-   mf:result    <lantag_with_subtag.nt> ;
-   .
+    mf:name      "lantag_with_subtag" ;
+    rdfs:comment "lantag with subtag \"x\"@en-us" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <lantag_with_subtag.ttl> ;
+    mf:result    <lantag_with_subtag.nt> ;
+    .
 
 <#objectList_with_two_objects> rdf:type rdft:TestTurtleEval ;
-   mf:name      "objectList_with_two_objects" ;
-   rdfs:comment "objectList with two objects … <o1>,<o2>" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <objectList_with_two_objects.ttl> ;
-   mf:result    <objectList_with_two_objects.nt> ;
-   .
+    mf:name      "objectList_with_two_objects" ;
+    rdfs:comment "objectList with two objects … <o1>,<o2>" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <objectList_with_two_objects.ttl> ;
+    mf:result    <objectList_with_two_objects.nt> ;
+    .
 
 <#predicateObjectList_with_two_objectLists> rdf:type rdft:TestTurtleEval ;
-   mf:name      "predicateObjectList_with_two_objectLists" ;
-   rdfs:comment "predicateObjectList with two objectLists … <o1>,<o2>" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <predicateObjectList_with_two_objectLists.ttl> ;
-   mf:result    <predicateObjectList_with_two_objectLists.nt> ;
-   .
+    mf:name      "predicateObjectList_with_two_objectLists" ;
+    rdfs:comment "predicateObjectList with two objectLists … <o1>,<o2>" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <predicateObjectList_with_two_objectLists.ttl> ;
+    mf:result    <predicateObjectList_with_two_objectLists.nt> ;
+    .
 
 <#predicateObjectList_with_blankNodePropertyList_as_object> rdf:type rdft:TestTurtleEval ;
-   mf:name      "predicateObjectList_with_blankNodePropertyList_as_object" ;
-   rdfs:comment "predicateObjectList_with_blankNodePropertyList_as_object <s> <p> [ <p2> <o> ] ; <p3> [ <p4> <o2> , <o3> ] " ;
-   rdft:approval rdft:Approved ;
-   mf:action    <predicateObjectList_with_blankNodePropertyList_as_object.ttl> ;
-   mf:result    <predicateObjectList_with_blankNodePropertyList_as_object.nt> ;
-   .
+    mf:name      "predicateObjectList_with_blankNodePropertyList_as_object" ;
+    rdfs:comment "predicateObjectList_with_blankNodePropertyList_as_object <s> <p> [ <p2> <o> ] ; <p3> [ <p4> <o2> , <o3> ] " ;
+    rdft:approval rdft:Approved ;
+    mf:action    <predicateObjectList_with_blankNodePropertyList_as_object.ttl> ;
+    mf:result    <predicateObjectList_with_blankNodePropertyList_as_object.nt> ;
+    .
 
 <#repeated_semis_at_end> rdf:type rdft:TestTurtleEval ;
-   mf:name      "repeated_semis_at_end" ;
-   rdfs:comment "repeated semis at end <s> <p> <o> ;; <p2> <o2> ." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <repeated_semis_at_end.ttl> ;
-   mf:result    <predicateObjectList_with_two_objectLists.nt> ;
-   .
+    mf:name      "repeated_semis_at_end" ;
+    rdfs:comment "repeated semis at end <s> <p> <o> ;; <p2> <o2> ." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <repeated_semis_at_end.ttl> ;
+    mf:result    <predicateObjectList_with_two_objectLists.nt> ;
+    .
 
 <#repeated_semis_not_at_end> rdf:type rdft:TestTurtleEval ;
-   mf:name      "repeated_semis_not_at_end" ;
-   rdfs:comment "repeated semis not at end <s> <p> <o> ;;." ;
-   rdft:approval rdft:Approved ;
-   mf:action    <repeated_semis_not_at_end.ttl> ;
-   mf:result    <repeated_semis_not_at_end.nt> ;
-   .
+    mf:name      "repeated_semis_not_at_end" ;
+    rdfs:comment "repeated semis not at end <s> <p> <o> ;;." ;
+    rdft:approval rdft:Approved ;
+    mf:action    <repeated_semis_not_at_end.ttl> ;
+    mf:result    <repeated_semis_not_at_end.nt> ;
+    .
 
 # original tests-ttl
 <#turtle-syntax-file-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-file-01" ;
-   rdfs:comment "Empty file" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-file-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-file-01" ;
+    rdfs:comment "Empty file" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-file-01.ttl> ;
+    .
 
 <#turtle-syntax-file-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-file-02" ;
-   rdfs:comment "Only comment" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-file-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-file-02" ;
+    rdfs:comment "Only comment" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-file-02.ttl> ;
+    .
 
 <#turtle-syntax-file-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-file-03" ;
-   rdfs:comment "One comment, one empty line" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-file-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-file-03" ;
+    rdfs:comment "One comment, one empty line" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-file-03.ttl> ;
+    .
 
 <#turtle-syntax-uri-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-uri-01" ;
-   rdfs:comment "Only IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-uri-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-uri-01" ;
+    rdfs:comment "Only IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-uri-01.ttl> ;
+    .
 
 <#turtle-syntax-uri-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-uri-02" ;
-   rdfs:comment "IRIs with Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-uri-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-uri-02" ;
+    rdfs:comment "IRIs with Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-uri-02.ttl> ;
+    .
 
 <#turtle-syntax-uri-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-uri-03" ;
-   rdfs:comment "IRIs with long Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-uri-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-uri-03" ;
+    rdfs:comment "IRIs with long Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-uri-03.ttl> ;
+    .
 
 <#turtle-syntax-uri-04> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-uri-04" ;
-   rdfs:comment "Legal IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-uri-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-uri-04" ;
+    rdfs:comment "Legal IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-uri-04.ttl> ;
+    .
 
 <#turtle-syntax-base-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-base-01" ;
-   rdfs:comment "@base" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-base-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-base-01" ;
+    rdfs:comment "@base" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-base-01.ttl> ;
+    .
 
 <#turtle-syntax-base-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-base-02" ;
-   rdfs:comment "BASE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-base-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-base-02" ;
+    rdfs:comment "BASE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-base-02.ttl> ;
+    .
 
 <#turtle-syntax-base-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-base-03" ;
-   rdfs:comment "@base with relative IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-base-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-base-03" ;
+    rdfs:comment "@base with relative IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-base-03.ttl> ;
+    .
 
 <#turtle-syntax-base-04> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-base-04" ;
-   rdfs:comment "base with relative IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-base-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-base-04" ;
+    rdfs:comment "base with relative IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-base-04.ttl> ;
+    .
 
 <#turtle-syntax-prefix-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-prefix-01" ;
-   rdfs:comment "@prefix" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-prefix-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-prefix-01" ;
+    rdfs:comment "@prefix" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-prefix-01.ttl> ;
+    .
 
 <#turtle-syntax-prefix-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-prefix-02" ;
-   rdfs:comment "PreFIX" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-prefix-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-prefix-02" ;
+    rdfs:comment "PreFIX" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-prefix-02.ttl> ;
+    .
 
 <#turtle-syntax-prefix-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-prefix-03" ;
-   rdfs:comment "Empty PREFIX" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-prefix-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-prefix-03" ;
+    rdfs:comment "Empty PREFIX" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-prefix-03.ttl> ;
+    .
 
 <#turtle-syntax-prefix-04> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-prefix-04" ;
-   rdfs:comment "Empty @prefix with % escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-prefix-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-prefix-04" ;
+    rdfs:comment "Empty @prefix with % escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-prefix-04.ttl> ;
+    .
 
 <#turtle-syntax-prefix-05> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-prefix-05" ;
-   rdfs:comment "@prefix with no suffix" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-prefix-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-prefix-05" ;
+    rdfs:comment "@prefix with no suffix" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-prefix-05.ttl> ;
+    .
 
 <#turtle-syntax-prefix-06> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-prefix-06" ;
-   rdfs:comment "colon is a legal pname character" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-prefix-06.ttl> ;
-   .
+    mf:name    "turtle-syntax-prefix-06" ;
+    rdfs:comment "colon is a legal pname character" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-prefix-06.ttl> ;
+    .
 
 <#turtle-syntax-prefix-07> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-prefix-07" ;
-   rdfs:comment "dash is a legal pname character" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-prefix-07.ttl> ;
-   .
+    mf:name    "turtle-syntax-prefix-07" ;
+    rdfs:comment "dash is a legal pname character" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-prefix-07.ttl> ;
+    .
 
 <#turtle-syntax-prefix-08> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-prefix-08" ;
-   rdfs:comment "underscore is a legal pname character" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-prefix-08.ttl> ;
-   .
+    mf:name    "turtle-syntax-prefix-08" ;
+    rdfs:comment "underscore is a legal pname character" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-prefix-08.ttl> ;
+    .
 
 <#turtle-syntax-prefix-09> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-prefix-09" ;
-   rdfs:comment "percents in pnames" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-prefix-09.ttl> ;
-   .
+    mf:name    "turtle-syntax-prefix-09" ;
+    rdfs:comment "percents in pnames" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-prefix-09.ttl> ;
+    .
 
 <#turtle-syntax-string-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-01" ;
-   rdfs:comment "string literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-01" ;
+    rdfs:comment "string literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-01.ttl> ;
+    .
 
 <#turtle-syntax-string-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-02" ;
-   rdfs:comment "langString literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-02" ;
+    rdfs:comment "langString literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-02.ttl> ;
+    .
 
 <#turtle-syntax-string-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-03" ;
-   rdfs:comment "langString literal with region" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-03" ;
+    rdfs:comment "langString literal with region" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-03.ttl> ;
+    .
 
 <#turtle-syntax-string-04> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-04" ;
-   rdfs:comment "squote string literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-04" ;
+    rdfs:comment "squote string literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-04.ttl> ;
+    .
 
 <#turtle-syntax-string-05> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-05" ;
-   rdfs:comment "squote langString literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-05" ;
+    rdfs:comment "squote langString literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-05.ttl> ;
+    .
 
 <#turtle-syntax-string-06> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-06" ;
-   rdfs:comment "squote langString literal with region" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-06.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-06" ;
+    rdfs:comment "squote langString literal with region" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-06.ttl> ;
+    .
 
 <#turtle-syntax-string-07> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-07" ;
-   rdfs:comment "long string literal with embedded single- and double-quotes" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-07.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-07" ;
+    rdfs:comment "long string literal with embedded single- and double-quotes" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-07.ttl> ;
+    .
 
 <#turtle-syntax-string-08> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-08" ;
-   rdfs:comment "long string literal with embedded newline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-08.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-08" ;
+    rdfs:comment "long string literal with embedded newline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-08.ttl> ;
+    .
 
 <#turtle-syntax-string-09> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-09" ;
-   rdfs:comment "squote long string literal with embedded single- and double-quotes" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-09.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-09" ;
+    rdfs:comment "squote long string literal with embedded single- and double-quotes" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-09.ttl> ;
+    .
 
 <#turtle-syntax-string-10> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-10" ;
-   rdfs:comment "long langString literal with embedded newline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-10.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-10" ;
+    rdfs:comment "long langString literal with embedded newline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-10.ttl> ;
+    .
 
 <#turtle-syntax-string-11> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-string-11" ;
-   rdfs:comment "squote long langString literal with embedded newline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-string-11.ttl> ;
-   .
+    mf:name    "turtle-syntax-string-11" ;
+    rdfs:comment "squote long langString literal with embedded newline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-string-11.ttl> ;
+    .
 
 <#turtle-syntax-str-esc-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-str-esc-01" ;
-   rdfs:comment "string literal with escaped newline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-str-esc-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-str-esc-01" ;
+    rdfs:comment "string literal with escaped newline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-str-esc-01.ttl> ;
+    .
 
 <#turtle-syntax-str-esc-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-str-esc-02" ;
-   rdfs:comment "string literal with Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-str-esc-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-str-esc-02" ;
+    rdfs:comment "string literal with Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-str-esc-02.ttl> ;
+    .
 
 <#turtle-syntax-str-esc-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-str-esc-03" ;
-   rdfs:comment "string literal with long Unicode escape" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-str-esc-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-str-esc-03" ;
+    rdfs:comment "string literal with long Unicode escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-str-esc-03.ttl> ;
+    .
 
 <#turtle-syntax-pname-esc-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-pname-esc-01" ;
-   rdfs:comment "pname with back-slash escapes" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-pname-esc-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-pname-esc-01" ;
+    rdfs:comment "pname with back-slash escapes" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-pname-esc-01.ttl> ;
+    .
 
 <#turtle-syntax-pname-esc-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-pname-esc-02" ;
-   rdfs:comment "pname with back-slash escapes (2)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-pname-esc-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-pname-esc-02" ;
+    rdfs:comment "pname with back-slash escapes (2)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-pname-esc-02.ttl> ;
+    .
 
 <#turtle-syntax-pname-esc-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-pname-esc-03" ;
-   rdfs:comment "pname with back-slash escapes (3)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-pname-esc-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-pname-esc-03" ;
+    rdfs:comment "pname with back-slash escapes (3)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-pname-esc-03.ttl> ;
+    .
 
 <#turtle-syntax-bnode-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-bnode-01" ;
-   rdfs:comment "bnode subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bnode-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bnode-01" ;
+    rdfs:comment "bnode subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bnode-01.ttl> ;
+    .
 
 <#turtle-syntax-bnode-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-bnode-02" ;
-   rdfs:comment "bnode object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bnode-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bnode-02" ;
+    rdfs:comment "bnode object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bnode-02.ttl> ;
+    .
 
 <#turtle-syntax-bnode-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-bnode-03" ;
-   rdfs:comment "bnode property list object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bnode-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bnode-03" ;
+    rdfs:comment "bnode property list object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bnode-03.ttl> ;
+    .
 
 <#turtle-syntax-bnode-04> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-bnode-04" ;
-   rdfs:comment "bnode property list object (2)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bnode-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bnode-04" ;
+    rdfs:comment "bnode property list object (2)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bnode-04.ttl> ;
+    .
 
 <#turtle-syntax-bnode-05> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-bnode-05" ;
-   rdfs:comment "bnode property list subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bnode-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-bnode-05" ;
+    rdfs:comment "bnode property list subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bnode-05.ttl> ;
+    .
 
 <#turtle-syntax-bnode-06> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-bnode-06" ;
-   rdfs:comment "labeled bnode subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bnode-06.ttl> ;
-   .
+    mf:name    "turtle-syntax-bnode-06" ;
+    rdfs:comment "labeled bnode subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bnode-06.ttl> ;
+    .
 
 <#turtle-syntax-bnode-07> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-bnode-07" ;
-   rdfs:comment "labeled bnode subject and object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bnode-07.ttl> ;
-   .
+    mf:name    "turtle-syntax-bnode-07" ;
+    rdfs:comment "labeled bnode subject and object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bnode-07.ttl> ;
+    .
 
 <#turtle-syntax-bnode-08> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-bnode-08" ;
-   rdfs:comment "bare bnode property list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bnode-08.ttl> ;
-   .
+    mf:name    "turtle-syntax-bnode-08" ;
+    rdfs:comment "bare bnode property list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bnode-08.ttl> ;
+    .
 
 <#turtle-syntax-bnode-09> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-bnode-09" ;
-   rdfs:comment "bnode property list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bnode-09.ttl> ;
-   .
+    mf:name    "turtle-syntax-bnode-09" ;
+    rdfs:comment "bnode property list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bnode-09.ttl> ;
+    .
 
 <#turtle-syntax-bnode-10> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-bnode-10" ;
-   rdfs:comment "mixed bnode property list and triple" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bnode-10.ttl> ;
-   .
+    mf:name    "turtle-syntax-bnode-10" ;
+    rdfs:comment "mixed bnode property list and triple" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bnode-10.ttl> ;
+    .
 
 <#turtle-syntax-number-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-01" ;
-   rdfs:comment "integer literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-01" ;
+    rdfs:comment "integer literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-01.ttl> ;
+    .
 
 <#turtle-syntax-number-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-02" ;
-   rdfs:comment "negative integer literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-02" ;
+    rdfs:comment "negative integer literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-02.ttl> ;
+    .
 
 <#turtle-syntax-number-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-03" ;
-   rdfs:comment "positive integer literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-03" ;
+    rdfs:comment "positive integer literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-03.ttl> ;
+    .
 
 <#turtle-syntax-number-04> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-04" ;
-   rdfs:comment "decimal literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-04" ;
+    rdfs:comment "decimal literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-04.ttl> ;
+    .
 
 <#turtle-syntax-number-05> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-05" ;
-   rdfs:comment "decimal literal (no leading digits)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-05" ;
+    rdfs:comment "decimal literal (no leading digits)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-05.ttl> ;
+    .
 
 <#turtle-syntax-number-06> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-06" ;
-   rdfs:comment "negative decimal literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-06.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-06" ;
+    rdfs:comment "negative decimal literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-06.ttl> ;
+    .
 
 <#turtle-syntax-number-07> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-07" ;
-   rdfs:comment "positive decimal literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-07.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-07" ;
+    rdfs:comment "positive decimal literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-07.ttl> ;
+    .
 
 <#turtle-syntax-number-08> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-08" ;
-   rdfs:comment "integer literal with decimal lexical confusion" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-08.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-08" ;
+    rdfs:comment "integer literal with decimal lexical confusion" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-08.ttl> ;
+    .
 
 <#turtle-syntax-number-09> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-09" ;
-   rdfs:comment "double literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-09.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-09" ;
+    rdfs:comment "double literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-09.ttl> ;
+    .
 
 <#turtle-syntax-number-10> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-10" ;
-   rdfs:comment "negative double literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-10.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-10" ;
+    rdfs:comment "negative double literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-10.ttl> ;
+    .
 
 <#turtle-syntax-number-11> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-11" ;
-   rdfs:comment "double literal no fraction" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-11.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-11" ;
+    rdfs:comment "double literal no fraction" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-11.ttl> ;
+    .
 
 <#turtle-syntax-number-12> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-12" ;
-   rdfs:comment "double literal no leading zero" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-12.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-12" ;
+    rdfs:comment "double literal no leading zero" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-12.ttl> ;
+    .
 
 <#turtle-syntax-number-13> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-number-13" ;
-   rdfs:comment "decimal literal no leading zero" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-number-13.ttl> ;
-   .
+    mf:name    "turtle-syntax-number-13" ;
+    rdfs:comment "decimal literal no leading zero" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-number-13.ttl> ;
+    .
 
 <#turtle-syntax-datatypes-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-datatypes-01" ;
-   rdfs:comment "xsd:byte literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-datatypes-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-datatypes-01" ;
+    rdfs:comment "xsd:byte literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-datatypes-01.ttl> ;
+    .
 
 <#turtle-syntax-datatypes-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-datatypes-02" ;
-   rdfs:comment "integer as xsd:string" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-datatypes-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-datatypes-02" ;
+    rdfs:comment "integer as xsd:string" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-datatypes-02.ttl> ;
+    .
 
 <#turtle-syntax-kw-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-kw-01" ;
-   rdfs:comment "boolean literal (true)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-kw-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-kw-01" ;
+    rdfs:comment "boolean literal (true)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-kw-01.ttl> ;
+    .
 
 <#turtle-syntax-kw-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-kw-02" ;
-   rdfs:comment "boolean literal (false)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-kw-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-kw-02" ;
+    rdfs:comment "boolean literal (false)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-kw-02.ttl> ;
+    .
 
 <#turtle-syntax-kw-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-kw-03" ;
-   rdfs:comment "'a' as keyword" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-kw-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-kw-03" ;
+    rdfs:comment "'a' as keyword" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-kw-03.ttl> ;
+    .
 
 <#turtle-syntax-struct-01> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-struct-01" ;
-   rdfs:comment "object list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-struct-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-struct-01" ;
+    rdfs:comment "object list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-struct-01.ttl> ;
+    .
 
 <#turtle-syntax-struct-02> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-struct-02" ;
-   rdfs:comment "predicate list with object list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-struct-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-struct-02" ;
+    rdfs:comment "predicate list with object list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-struct-02.ttl> ;
+    .
 
 <#turtle-syntax-struct-03> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-struct-03" ;
-   rdfs:comment "predicate list with object list and dangling ';'" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-struct-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-struct-03" ;
+    rdfs:comment "predicate list with object list and dangling ';'" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-struct-03.ttl> ;
+    .
 
 <#turtle-syntax-struct-04> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-struct-04" ;
-   rdfs:comment "predicate list with multiple ;;" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-struct-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-struct-04" ;
+    rdfs:comment "predicate list with multiple ;;" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-struct-04.ttl> ;
+    .
 
 <#turtle-syntax-struct-05> rdf:type rdft:TestTurtlePositiveSyntax ;
-   mf:name    "turtle-syntax-struct-05" ;
-   rdfs:comment "predicate list with multiple ;;" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-struct-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-struct-05" ;
+    rdfs:comment "predicate list with multiple ;;" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-struct-05.ttl> ;
+    .
 
 <#turtle-eval-lists-01> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-eval-lists-01" ;
-   rdfs:comment "empty list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-eval-lists-01.ttl> ;
-   mf:result    <turtle-eval-lists-01.nt> ;
-   .
+    mf:name    "turtle-eval-lists-01" ;
+    rdfs:comment "empty list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-eval-lists-01.ttl> ;
+    mf:result    <turtle-eval-lists-01.nt> ;
+    .
 
 <#turtle-eval-lists-02> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-eval-lists-02" ;
-   rdfs:comment "mixed list" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-eval-lists-02.ttl> ;
-   mf:result    <turtle-eval-lists-02.nt> ;
-   .
+    mf:name    "turtle-eval-lists-02" ;
+    rdfs:comment "mixed list" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-eval-lists-02.ttl> ;
+    mf:result    <turtle-eval-lists-02.nt> ;
+    .
 
 <#turtle-eval-lists-03> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-eval-lists-03" ;
-   rdfs:comment "isomorphic list as subject and object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-eval-lists-03.ttl> ;
-   mf:result    <turtle-eval-lists-03.nt> ;
-   .
+    mf:name    "turtle-eval-lists-03" ;
+    rdfs:comment "isomorphic list as subject and object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-eval-lists-03.ttl> ;
+    mf:result    <turtle-eval-lists-03.nt> ;
+    .
 
 <#turtle-eval-lists-04> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-eval-lists-04" ;
-   rdfs:comment "lists of lists" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-eval-lists-04.ttl> ;
-   mf:result    <turtle-eval-lists-04.nt> ;
-   .
+    mf:name    "turtle-eval-lists-04" ;
+    rdfs:comment "lists of lists" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-eval-lists-04.ttl> ;
+    mf:result    <turtle-eval-lists-04.nt> ;
+    .
 
 <#turtle-eval-lists-05> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-eval-lists-05" ;
-   rdfs:comment "mixed lists with embedded lists" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-eval-lists-05.ttl> ;
-   mf:result    <turtle-eval-lists-05.nt> ;
-   .
+    mf:name    "turtle-eval-lists-05" ;
+    rdfs:comment "mixed lists with embedded lists" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-eval-lists-05.ttl> ;
+    mf:result    <turtle-eval-lists-05.nt> ;
+    .
 
 <#turtle-eval-lists-06> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-eval-lists-06" ;
-   rdfs:comment "list containing blank node with abbreviated term" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-eval-lists-06.ttl> ;
-   mf:result    <turtle-eval-lists-06.nt> ;
-   .
+    mf:name    "turtle-eval-lists-06" ;
+    rdfs:comment "list containing blank node with abbreviated term" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-eval-lists-06.ttl> ;
+    mf:result    <turtle-eval-lists-06.nt> ;
+    .
 
 <#turtle-syntax-bad-uri-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-uri-01" ;
-   rdfs:comment "Bad IRI : space (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-uri-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-uri-01" ;
+    rdfs:comment "Bad IRI : space (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-uri-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-uri-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-uri-02" ;
-   rdfs:comment "Bad IRI : bad escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-uri-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-uri-02" ;
+    rdfs:comment "Bad IRI : bad escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-uri-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-uri-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-uri-03" ;
-   rdfs:comment "Bad IRI : bad long escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-uri-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-uri-03" ;
+    rdfs:comment "Bad IRI : bad long escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-uri-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-uri-04> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-uri-04" ;
-   rdfs:comment "Bad IRI : character escapes not allowed (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-uri-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-uri-04" ;
+    rdfs:comment "Bad IRI : character escapes not allowed (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-uri-04.ttl> ;
+    .
 
 <#turtle-syntax-bad-uri-05> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-uri-05" ;
-   rdfs:comment "Bad IRI : character escapes not allowed (2) (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-uri-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-uri-05" ;
+    rdfs:comment "Bad IRI : character escapes not allowed (2) (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-uri-05.ttl> ;
+    .
 
 <#turtle-syntax-bad-uri-escape-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-uri-escape-01" ;
-   rdfs:comment "Bad IRI : good escape, bad character (negative evaluation test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-uri-escape-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-uri-escape-01" ;
+    rdfs:comment "Bad IRI : good escape, bad character (negative evaluation test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-uri-escape-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-uri-escape-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-uri-escape-02" ;
-   rdfs:comment "Bad IRI : hex 3C is < (negative evaluation test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-uri-escape-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-uri-escape-02" ;
+    rdfs:comment "Bad IRI : hex 3C is < (negative evaluation test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-uri-escape-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-uri-escape-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-uri-escape-03" ;
-   rdfs:comment "Bad IRI : hex 3E is  (negative evaluation test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-uri-escape-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-uri-escape-03" ;
+    rdfs:comment "Bad IRI : hex 3E is  (negative evaluation test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-uri-escape-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-uri-escape-04> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-uri-escape-04" ;
-   rdfs:comment "Bad IRI : {abc} (negative evaluation test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-uri-escape-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-uri-escape-04" ;
+    rdfs:comment "Bad IRI : {abc} (negative evaluation test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-uri-escape-04.ttl> ;
+    .
 
 <#turtle-syntax-bad-prefix-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-prefix-01" ;
-   rdfs:comment "No prefix (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-prefix-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-prefix-01" ;
+    rdfs:comment "No prefix (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-prefix-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-prefix-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-prefix-02" ;
-   rdfs:comment "No prefix (2) (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-prefix-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-prefix-02" ;
+    rdfs:comment "No prefix (2) (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-prefix-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-prefix-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-prefix-03" ;
-   rdfs:comment "@prefix without URI (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-prefix-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-prefix-03" ;
+    rdfs:comment "@prefix without URI (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-prefix-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-prefix-04> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-prefix-04" ;
-   rdfs:comment "@prefix without prefix name (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-prefix-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-prefix-04" ;
+    rdfs:comment "@prefix without prefix name (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-prefix-04.ttl> ;
+    .
 
 <#turtle-syntax-bad-prefix-05> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-prefix-05" ;
-   rdfs:comment "@prefix without ':' (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-prefix-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-prefix-05" ;
+    rdfs:comment "@prefix without ':' (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-prefix-05.ttl> ;
+    .
 
 <#turtle-syntax-bad-base-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-base-01" ;
-   rdfs:comment "@base without URI (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-base-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-base-01" ;
+    rdfs:comment "@base without URI (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-base-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-base-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-base-02" ;
-   rdfs:comment "@base in wrong case (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-base-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-base-02" ;
+    rdfs:comment "@base in wrong case (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-base-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-base-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-base-03" ;
-   rdfs:comment "BASE without URI (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-base-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-base-03" ;
+    rdfs:comment "BASE without URI (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-base-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-bnode-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name      "turtle-syntax-bad-bnode-01" ;
-   rdfs:comment "Colon in bnode label not allowed (negative test)" ;
-   mf:action    <turtle-syntax-bad-bnode-01.ttl> ;
-   .
+    mf:name      "turtle-syntax-bad-bnode-01" ;
+    rdfs:comment "Colon in bnode label not allowed (negative test)" ;
+    mf:action    <turtle-syntax-bad-bnode-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-bnode-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name      "turtle-syntax-bad-bnode-02" ;
-   rdfs:comment "Colon in bnode label not allowed (negative test)" ;
-   mf:action    <turtle-syntax-bad-bnode-02.ttl> ;
-   .
+    mf:name      "turtle-syntax-bad-bnode-02" ;
+    rdfs:comment "Colon in bnode label not allowed (negative test)" ;
+    mf:action    <turtle-syntax-bad-bnode-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-01" ;
-   rdfs:comment "Turtle is not TriG (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-01" ;
+    rdfs:comment "Turtle is not TriG (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-02" ;
-   rdfs:comment "Turtle is not N3 (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-02" ;
+    rdfs:comment "Turtle is not N3 (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-03" ;
-   rdfs:comment "Turtle is not NQuads (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-03" ;
+    rdfs:comment "Turtle is not NQuads (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-04> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-04" ;
-   rdfs:comment "Turtle does not allow literals-as-subjects (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-04" ;
+    rdfs:comment "Turtle does not allow literals-as-subjects (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-04.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-05> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-05" ;
-   rdfs:comment "Turtle does not allow literals-as-predicates (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-05" ;
+    rdfs:comment "Turtle does not allow literals-as-predicates (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-05.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-06> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-06" ;
-   rdfs:comment "Turtle does not allow bnodes-as-predicates (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-06.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-06" ;
+    rdfs:comment "Turtle does not allow bnodes-as-predicates (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-06.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-07> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-07" ;
-   rdfs:comment "Turtle does not allow labeled bnodes-as-predicates (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-07.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-07" ;
+    rdfs:comment "Turtle does not allow labeled bnodes-as-predicates (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-07.ttl> ;
+    .
 
 <#turtle-syntax-bad-kw-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-kw-01" ;
-   rdfs:comment "'A' is not a keyword (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-kw-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-kw-01" ;
+    rdfs:comment "'A' is not a keyword (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-kw-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-kw-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-kw-02" ;
-   rdfs:comment "'a' cannot be used as subject (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-kw-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-kw-02" ;
+    rdfs:comment "'a' cannot be used as subject (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-kw-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-kw-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-kw-03" ;
-   rdfs:comment "'a' cannot be used as object (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-kw-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-kw-03" ;
+    rdfs:comment "'a' cannot be used as object (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-kw-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-kw-04> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-kw-04" ;
-   rdfs:comment "'true' cannot be used as subject (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-kw-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-kw-04" ;
+    rdfs:comment "'true' cannot be used as subject (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-kw-04.ttl> ;
+    .
 
 <#turtle-syntax-bad-kw-05> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-kw-05" ;
-   rdfs:comment "'true' cannot be used as object (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-kw-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-kw-05" ;
+    rdfs:comment "'true' cannot be used as object (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-kw-05.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-01" ;
-   rdfs:comment "{} fomulae not in Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-01" ;
+    rdfs:comment "{} fomulae not in Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-02" ;
-   rdfs:comment "= is not Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-02" ;
+    rdfs:comment "= is not Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-03" ;
-   rdfs:comment "N3 paths not in Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-03" ;
+    rdfs:comment "N3 paths not in Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-04> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-04" ;
-   rdfs:comment "N3 paths not in Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-04" ;
+    rdfs:comment "N3 paths not in Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-04.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-05> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-05" ;
-   rdfs:comment "N3 is...of not in Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-05" ;
+    rdfs:comment "N3 is...of not in Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-05.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-06> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-06" ;
-   rdfs:comment "N3 paths not in Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-06.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-06" ;
+    rdfs:comment "N3 paths not in Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-06.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-07> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-07" ;
-   rdfs:comment "@keywords is not Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-07.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-07" ;
+    rdfs:comment "@keywords is not Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-07.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-08> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-08" ;
-   rdfs:comment "@keywords is not Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-08.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-08" ;
+    rdfs:comment "@keywords is not Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-08.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-09> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-09" ;
-   rdfs:comment "=> is not Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-09.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-09" ;
+    rdfs:comment "=> is not Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-09.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-10> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-10" ;
-   rdfs:comment "<= is not Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-10.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-10" ;
+    rdfs:comment "<= is not Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-10.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-11> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-11" ;
-   rdfs:comment "@forSome is not Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-11.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-11" ;
+    rdfs:comment "@forSome is not Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-11.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-12> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-12" ;
-   rdfs:comment "@forAll is not Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-12.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-12" ;
+    rdfs:comment "@forAll is not Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-12.ttl> ;
+    .
 
 <#turtle-syntax-bad-n3-extras-13> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-n3-extras-13" ;
-   rdfs:comment "@keywords is not Turtle (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-n3-extras-13.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-n3-extras-13" ;
+    rdfs:comment "@keywords is not Turtle (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-n3-extras-13.ttl> ;
+    .
 
 <#turtle-syntax-bad-numeric-escape-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-numeric-escape-01" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-numeric-escape-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-numeric-escape-01" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-numeric-escape-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-numeric-escape-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-numeric-escape-02" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-numeric-escape-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-numeric-escape-02" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-numeric-escape-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-numeric-escape-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-numeric-escape-03" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_SINGLE_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-numeric-escape-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-numeric-escape-03" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_SINGLE_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-numeric-escape-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-numeric-escape-04> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-numeric-escape-04" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_SINGLE_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-numeric-escape-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-numeric-escape-04" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_SINGLE_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-numeric-escape-04.ttl> ;
+    .
 
 <#turtle-syntax-bad-numeric-escape-05> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-numeric-escape-05" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_SINGLE_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-numeric-escape-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-numeric-escape-05" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_SINGLE_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-numeric-escape-05.ttl> ;
+    .
 
 <#turtle-syntax-bad-numeric-escape-06> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-numeric-escape-06" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_SINGLE_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-numeric-escape-06.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-numeric-escape-06" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_SINGLE_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-numeric-escape-06.ttl> ;
+    .
 
 <#turtle-syntax-bad-numeric-escape-07> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-numeric-escape-07" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-numeric-escape-07.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-numeric-escape-07" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-numeric-escape-07.ttl> ;
+    .
 
 <#turtle-syntax-bad-numeric-escape-08> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-numeric-escape-08" ;
-   rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_QUOTE" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-numeric-escape-08.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-numeric-escape-08" ;
+    rdfs:comment "Surrogates not allowed in STRING_LITERAL_LONG_QUOTE" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-numeric-escape-08.ttl> ;
+    .
 
 <#turtle-syntax-bad-numeric-escape-09> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-numeric-escape-09" ;
-   rdfs:comment "Surrogates not allowed in IRIREF" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-numeric-escape-09.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-numeric-escape-09" ;
+    rdfs:comment "Surrogates not allowed in IRIREF" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-numeric-escape-09.ttl> ;
+    .
 
 <#turtle-syntax-bad-numeric-escape-10> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-numeric-escape-10" ;
-   rdfs:comment "Surrogates not allowed in IRIREF" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-numeric-escape-10.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-numeric-escape-10" ;
+    rdfs:comment "Surrogates not allowed in IRIREF" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-numeric-escape-10.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-08> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-08" ;
-   rdfs:comment "missing '.' (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-08.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-08" ;
+    rdfs:comment "missing '.' (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-08.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-09> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-09" ;
-   rdfs:comment "extra '.' (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-09.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-09" ;
+    rdfs:comment "extra '.' (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-09.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-10> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-10" ;
-   rdfs:comment "extra '.' (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-10.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-10" ;
+    rdfs:comment "extra '.' (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-10.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-11> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-11" ;
-   rdfs:comment "trailing ';' no '.' (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-11.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-11" ;
+    rdfs:comment "trailing ';' no '.' (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-11.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-12> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-12" ;
-   rdfs:comment "subject, predicate, no object (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-12.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-12" ;
+    rdfs:comment "subject, predicate, no object (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-12.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-13> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-13" ;
-   rdfs:comment "subject, predicate, no object (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-13.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-13" ;
+    rdfs:comment "subject, predicate, no object (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-13.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-14> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-14" ;
-   rdfs:comment "literal as subject (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-14.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-14" ;
+    rdfs:comment "literal as subject (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-14.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-15> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-15" ;
-   rdfs:comment "literal as predicate (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-15.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-15" ;
+    rdfs:comment "literal as predicate (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-15.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-16> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-16" ;
-   rdfs:comment "bnode as predicate (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-16.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-16" ;
+    rdfs:comment "bnode as predicate (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-16.ttl> ;
+    .
 
 <#turtle-syntax-bad-struct-17> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-struct-17" ;
-   rdfs:comment "labeled bnode as predicate (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-struct-17.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-struct-17" ;
+    rdfs:comment "labeled bnode as predicate (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-struct-17.ttl> ;
+    .
 
 <#turtle-syntax-bad-lang-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-lang-01" ;
-   rdfs:comment "langString with bad lang (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-lang-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-lang-01" ;
+    rdfs:comment "langString with bad lang (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-lang-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-esc-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-esc-01" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-esc-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-esc-01" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-esc-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-esc-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-esc-02" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-esc-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-esc-02" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-esc-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-esc-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-esc-03" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-esc-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-esc-03" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-esc-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-esc-04> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-esc-04" ;
-   rdfs:comment "Bad string escape (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-esc-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-esc-04" ;
+    rdfs:comment "Bad string escape (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-esc-04.ttl> ;
+    .
 
 <#turtle-syntax-bad-pname-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-pname-01" ;
-   rdfs:comment "'~' must be escaped in pname (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-pname-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-pname-01" ;
+    rdfs:comment "'~' must be escaped in pname (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-pname-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-pname-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-pname-02" ;
-   rdfs:comment "Bad %-sequence in pname (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-pname-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-pname-02" ;
+    rdfs:comment "Bad %-sequence in pname (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-pname-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-pname-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-pname-03" ;
-   rdfs:comment "Bad unicode escape in pname (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-pname-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-pname-03" ;
+    rdfs:comment "Bad unicode escape in pname (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-pname-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-string-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-string-01" ;
-   rdfs:comment "mismatching string literal open/close (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-string-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-string-01" ;
+    rdfs:comment "mismatching string literal open/close (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-string-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-string-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-string-02" ;
-   rdfs:comment "mismatching string literal open/close (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-string-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-string-02" ;
+    rdfs:comment "mismatching string literal open/close (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-string-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-string-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-string-03" ;
-   rdfs:comment "mismatching string literal long/short (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-string-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-string-03" ;
+    rdfs:comment "mismatching string literal long/short (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-string-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-string-04> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-string-04" ;
-   rdfs:comment "mismatching long string literal open/close (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-string-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-string-04" ;
+    rdfs:comment "mismatching long string literal open/close (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-string-04.ttl> ;
+    .
 
 <#turtle-syntax-bad-string-05> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-string-05" ;
-   rdfs:comment "Long literal with missing end (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-string-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-string-05" ;
+    rdfs:comment "Long literal with missing end (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-string-05.ttl> ;
+    .
 
 <#turtle-syntax-bad-string-06> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-string-06" ;
-   rdfs:comment "Long literal with extra quote (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-string-06.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-string-06" ;
+    rdfs:comment "Long literal with extra quote (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-string-06.ttl> ;
+    .
 
 <#turtle-syntax-bad-string-07> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-string-07" ;
-   rdfs:comment "Long literal with extra squote (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-string-07.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-string-07" ;
+    rdfs:comment "Long literal with extra squote (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-string-07.ttl> ;
+    .
 
 <#turtle-syntax-bad-num-01> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-num-01" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-num-01.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-num-01" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-num-01.ttl> ;
+    .
 
 <#turtle-syntax-bad-num-02> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-num-02" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-num-02.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-num-02" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-num-02.ttl> ;
+    .
 
 <#turtle-syntax-bad-num-03> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-num-03" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-num-03.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-num-03" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-num-03.ttl> ;
+    .
 
 <#turtle-syntax-bad-num-04> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-num-04" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-num-04.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-num-04" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-num-04.ttl> ;
+    .
 
 <#turtle-syntax-bad-num-05> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-num-05" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-num-05.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-num-05" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-num-05.ttl> ;
+    .
 
 <#turtle-eval-struct-01> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-eval-struct-01" ;
-   rdfs:comment "triple with IRIs" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-eval-struct-01.ttl> ;
-   mf:result    <turtle-eval-struct-01.nt> ;
-   .
+    mf:name    "turtle-eval-struct-01" ;
+    rdfs:comment "triple with IRIs" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-eval-struct-01.ttl> ;
+    mf:result    <turtle-eval-struct-01.nt> ;
+    .
 
 <#turtle-eval-struct-02> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-eval-struct-02" ;
-   rdfs:comment "triple with IRIs and embedded whitespace" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-eval-struct-02.ttl> ;
-   mf:result    <turtle-eval-struct-02.nt> ;
-   .
+    mf:name    "turtle-eval-struct-02" ;
+    rdfs:comment "triple with IRIs and embedded whitespace" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-eval-struct-02.ttl> ;
+    mf:result    <turtle-eval-struct-02.nt> ;
+    .
 
 <#turtle-subm-01> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-01" ;
-   rdfs:comment "Blank subject" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-01.ttl> ;
-   mf:result    <turtle-subm-01.nt> ;
-   .
+    mf:name    "turtle-subm-01" ;
+    rdfs:comment "Blank subject" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-01.ttl> ;
+    mf:result    <turtle-subm-01.nt> ;
+    .
 
 <#turtle-subm-02> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-02" ;
-   rdfs:comment "@prefix and qnames" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-02.ttl> ;
-   mf:result    <turtle-subm-02.nt> ;
-   .
+    mf:name    "turtle-subm-02" ;
+    rdfs:comment "@prefix and qnames" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-02.ttl> ;
+    mf:result    <turtle-subm-02.nt> ;
+    .
 
 <#turtle-subm-03> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-03" ;
-   rdfs:comment ", operator" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-03.ttl> ;
-   mf:result    <turtle-subm-03.nt> ;
-   .
+    mf:name    "turtle-subm-03" ;
+    rdfs:comment ", operator" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-03.ttl> ;
+    mf:result    <turtle-subm-03.nt> ;
+    .
 
 <#turtle-subm-04> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-04" ;
-   rdfs:comment "; operator" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-04.ttl> ;
-   mf:result    <turtle-subm-04.nt> ;
-   .
+    mf:name    "turtle-subm-04" ;
+    rdfs:comment "; operator" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-04.ttl> ;
+    mf:result    <turtle-subm-04.nt> ;
+    .
 
 <#turtle-subm-05> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-05" ;
-   rdfs:comment "empty [] as subject and object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-05.ttl> ;
-   mf:result    <turtle-subm-05.nt> ;
-   .
+    mf:name    "turtle-subm-05" ;
+    rdfs:comment "empty [] as subject and object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-05.ttl> ;
+    mf:result    <turtle-subm-05.nt> ;
+    .
 
 <#turtle-subm-06> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-06" ;
-   rdfs:comment "non-empty [] as subject and object" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-06.ttl> ;
-   mf:result    <turtle-subm-06.nt> ;
-   .
+    mf:name    "turtle-subm-06" ;
+    rdfs:comment "non-empty [] as subject and object" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-06.ttl> ;
+    mf:result    <turtle-subm-06.nt> ;
+    .
 
 <#turtle-subm-07> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-07" ;
-   rdfs:comment "'a' as predicate" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-07.ttl> ;
-   mf:result    <turtle-subm-07.nt> ;
-   .
+    mf:name    "turtle-subm-07" ;
+    rdfs:comment "'a' as predicate" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-07.ttl> ;
+    mf:result    <turtle-subm-07.nt> ;
+    .
 
 <#turtle-subm-08> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-08" ;
-   rdfs:comment "simple collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-08.ttl> ;
-   mf:result    <turtle-subm-08.nt> ;
-   .
+    mf:name    "turtle-subm-08" ;
+    rdfs:comment "simple collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-08.ttl> ;
+    mf:result    <turtle-subm-08.nt> ;
+    .
 
 <#turtle-subm-09> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-09" ;
-   rdfs:comment "empty collection" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-09.ttl> ;
-   mf:result    <turtle-subm-09.nt> ;
-   .
+    mf:name    "turtle-subm-09" ;
+    rdfs:comment "empty collection" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-09.ttl> ;
+    mf:result    <turtle-subm-09.nt> ;
+    .
 
 <#turtle-subm-10> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-10" ;
-   rdfs:comment "integer datatyped literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-10.ttl> ;
-   mf:result    <turtle-subm-10.nt> ;
-   .
+    mf:name    "turtle-subm-10" ;
+    rdfs:comment "integer datatyped literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-10.ttl> ;
+    mf:result    <turtle-subm-10.nt> ;
+    .
 
 <#turtle-subm-11> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-11" ;
-   rdfs:comment "decimal integer canonicalization" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-11.ttl> ;
-   mf:result    <turtle-subm-11.nt> ;
-   .
+    mf:name    "turtle-subm-11" ;
+    rdfs:comment "decimal integer canonicalization" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-11.ttl> ;
+    mf:result    <turtle-subm-11.nt> ;
+    .
 
 <#turtle-subm-12> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-12" ;
-   rdfs:comment "- and _ in names and qnames" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-12.ttl> ;
-   mf:result    <turtle-subm-12.nt> ;
-   .
+    mf:name    "turtle-subm-12" ;
+    rdfs:comment "- and _ in names and qnames" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-12.ttl> ;
+    mf:result    <turtle-subm-12.nt> ;
+    .
 
 <#turtle-subm-13> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-13" ;
-   rdfs:comment "tests for rdf:_<numbers> and other qnames starting with _" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-13.ttl> ;
-   mf:result    <turtle-subm-13.nt> ;
-   .
+    mf:name    "turtle-subm-13" ;
+    rdfs:comment "tests for rdf:_<numbers> and other qnames starting with _" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-13.ttl> ;
+    mf:result    <turtle-subm-13.nt> ;
+    .
 
 <#turtle-subm-14> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-14" ;
-   rdfs:comment "bare : allowed" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-14.ttl> ;
-   mf:result    <turtle-subm-14.nt> ;
-   .
+    mf:name    "turtle-subm-14" ;
+    rdfs:comment "bare : allowed" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-14.ttl> ;
+    mf:result    <turtle-subm-14.nt> ;
+    .
 
 <#turtle-subm-15> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-15" ;
-   rdfs:comment "simple long literal" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-15.ttl> ;
-   mf:result    <turtle-subm-15.nt> ;
-   .
+    mf:name    "turtle-subm-15" ;
+    rdfs:comment "simple long literal" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-15.ttl> ;
+    mf:result    <turtle-subm-15.nt> ;
+    .
 
 <#turtle-subm-16> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-16" ;
-   rdfs:comment "long literals with escapes" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-16.ttl> ;
-   mf:result    <turtle-subm-16.nt> ;
-   .
+    mf:name    "turtle-subm-16" ;
+    rdfs:comment "long literals with escapes" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-16.ttl> ;
+    mf:result    <turtle-subm-16.nt> ;
+    .
 
 <#turtle-subm-17> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-17" ;
-   rdfs:comment "floating point number" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-17.ttl> ;
-   mf:result    <turtle-subm-17.nt> ;
-   .
+    mf:name    "turtle-subm-17" ;
+    rdfs:comment "floating point number" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-17.ttl> ;
+    mf:result    <turtle-subm-17.nt> ;
+    .
 
 <#turtle-subm-18> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-18" ;
-   rdfs:comment "empty literals, normal and long variant" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-18.ttl> ;
-   mf:result    <turtle-subm-18.nt> ;
-   .
+    mf:name    "turtle-subm-18" ;
+    rdfs:comment "empty literals, normal and long variant" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-18.ttl> ;
+    mf:result    <turtle-subm-18.nt> ;
+    .
 
 <#turtle-subm-19> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-19" ;
-   rdfs:comment "positive integer, decimal and doubles" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-19.ttl> ;
-   mf:result    <turtle-subm-19.nt> ;
-   .
+    mf:name    "turtle-subm-19" ;
+    rdfs:comment "positive integer, decimal and doubles" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-19.ttl> ;
+    mf:result    <turtle-subm-19.nt> ;
+    .
 
 <#turtle-subm-20> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-20" ;
-   rdfs:comment "negative integer, decimal and doubles" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-20.ttl> ;
-   mf:result    <turtle-subm-20.nt> ;
-   .
+    mf:name    "turtle-subm-20" ;
+    rdfs:comment "negative integer, decimal and doubles" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-20.ttl> ;
+    mf:result    <turtle-subm-20.nt> ;
+    .
 
 <#turtle-subm-21> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-21" ;
-   rdfs:comment "long literal ending in double quote" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-21.ttl> ;
-   mf:result    <turtle-subm-21.nt> ;
-   .
+    mf:name    "turtle-subm-21" ;
+    rdfs:comment "long literal ending in double quote" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-21.ttl> ;
+    mf:result    <turtle-subm-21.nt> ;
+    .
 
 <#turtle-subm-22> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-22" ;
-   rdfs:comment "boolean literals" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-22.ttl> ;
-   mf:result    <turtle-subm-22.nt> ;
-   .
+    mf:name    "turtle-subm-22" ;
+    rdfs:comment "boolean literals" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-22.ttl> ;
+    mf:result    <turtle-subm-22.nt> ;
+    .
 
 <#turtle-subm-23> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-23" ;
-   rdfs:comment "comments" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-23.ttl> ;
-   mf:result    <turtle-subm-23.nt> ;
-   .
+    mf:name    "turtle-subm-23" ;
+    rdfs:comment "comments" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-23.ttl> ;
+    mf:result    <turtle-subm-23.nt> ;
+    .
 
 <#turtle-subm-24> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-24" ;
-   rdfs:comment "no final mewline" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-24.ttl> ;
-   mf:result    <turtle-subm-24.nt> ;
-   .
+    mf:name    "turtle-subm-24" ;
+    rdfs:comment "no final mewline" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-24.ttl> ;
+    mf:result    <turtle-subm-24.nt> ;
+    .
 
 <#turtle-subm-25> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-25" ;
-   rdfs:comment "repeating a @prefix changes pname definition" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-25.ttl> ;
-   mf:result    <turtle-subm-25.nt> ;
-   .
+    mf:name    "turtle-subm-25" ;
+    rdfs:comment "repeating a @prefix changes pname definition" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-25.ttl> ;
+    mf:result    <turtle-subm-25.nt> ;
+    .
 
 <#turtle-subm-26> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-26" ;
-   rdfs:comment "Variations on decimal canonicalization" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-26.ttl> ;
-   mf:result    <turtle-subm-26.nt> ;
-   .
+    mf:name    "turtle-subm-26" ;
+    rdfs:comment "Variations on decimal canonicalization" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-26.ttl> ;
+    mf:result    <turtle-subm-26.nt> ;
+    .
 
 <#turtle-subm-27> rdf:type rdft:TestTurtleEval ;
-   mf:name    "turtle-subm-27" ;
-   rdfs:comment "Repeating @base changes base for relative IRI lookup" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-subm-27.ttl> ;
-   mf:result    <turtle-subm-27.nt> ;
-   .
+    mf:name    "turtle-subm-27" ;
+    rdfs:comment "Repeating @base changes base for relative IRI lookup" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-subm-27.ttl> ;
+    mf:result    <turtle-subm-27.nt> ;
+    .
 
 # tests requested by Jeremy Carroll
 # http://www.w3.org/2011/rdf-wg/wiki/Turtle_Candidate_Recommendation_Comments#c35
 <#comment_following_localName> rdf:type rdft:TestTurtleEval ;
-   mf:name      "comment_following_localName" ;
-   rdfs:comment "comment following localName" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <comment_following_localName.ttl> ;
-   mf:result    <IRI_spo.nt> ;
-   .
+    mf:name      "comment_following_localName" ;
+    rdfs:comment "comment following localName" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <comment_following_localName.ttl> ;
+    mf:result    <IRI_spo.nt> ;
+    .
 
 <#number_sign_following_localName> rdf:type rdft:TestTurtleEval ;
-   mf:name      "number_sign_following_localName" ;
-   rdfs:comment "number sign following localName" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <number_sign_following_localName.ttl> ;
-   mf:result    <number_sign_following_localName.nt> ;
-   .
+    mf:name      "number_sign_following_localName" ;
+    rdfs:comment "number sign following localName" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <number_sign_following_localName.ttl> ;
+    mf:result    <number_sign_following_localName.nt> ;
+    .
 
 <#comment_following_PNAME_NS> rdf:type rdft:TestTurtleEval ;
-   mf:name      "comment_following_PNAME_NS" ;
-   rdfs:comment "comment following PNAME_NS" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <comment_following_PNAME_NS.ttl> ;
-   mf:result    <comment_following_PNAME_NS.nt> ;
-   .
+    mf:name      "comment_following_PNAME_NS" ;
+    rdfs:comment "comment following PNAME_NS" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <comment_following_PNAME_NS.ttl> ;
+    mf:result    <comment_following_PNAME_NS.nt> ;
+    .
 
 <#number_sign_following_PNAME_NS> rdf:type rdft:TestTurtleEval ;
-   mf:name      "number_sign_following_PNAME_NS" ;
-   rdfs:comment "number sign following PNAME_NS" ;
-   rdft:approval rdft:Proposed ;
-   mf:action    <number_sign_following_PNAME_NS.ttl> ;
-   mf:result    <number_sign_following_PNAME_NS.nt> ;
-   .
+    mf:name      "number_sign_following_PNAME_NS" ;
+    rdfs:comment "number sign following PNAME_NS" ;
+    rdft:approval rdft:Proposed ;
+    mf:action    <number_sign_following_PNAME_NS.ttl> ;
+    mf:result    <number_sign_following_PNAME_NS.nt> ;
+    .
 
 # tests from Dave Beckett
 # http://www.w3.org/2011/rdf-wg/wiki/Turtle_Candidate_Recommendation_Comments#c28
 <#LITERAL_LONG2_with_REVERSE_SOLIDUS> rdf:type rdft:TestTurtleEval ;
-   mf:name    "LITERAL_LONG2_with_REVERSE_SOLIDUS" ;
-   rdfs:comment "REVERSE SOLIDUS at end of LITERAL_LONG2" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <LITERAL_LONG2_with_REVERSE_SOLIDUS.ttl> ;
-   mf:result    <LITERAL_LONG2_with_REVERSE_SOLIDUS.nt> ;
-   .
+    mf:name    "LITERAL_LONG2_with_REVERSE_SOLIDUS" ;
+    rdfs:comment "REVERSE SOLIDUS at end of LITERAL_LONG2" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <LITERAL_LONG2_with_REVERSE_SOLIDUS.ttl> ;
+    mf:result    <LITERAL_LONG2_with_REVERSE_SOLIDUS.nt> ;
+    .
 
 <#turtle-syntax-bad-LITERAL2_with_langtag_and_datatype> rdf:type rdft:TestTurtleNegativeSyntax ;
-   mf:name    "turtle-syntax-bad-num-05" ;
-   rdfs:comment "Bad number format (negative test)" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <turtle-syntax-bad-LITERAL2_with_langtag_and_datatype.ttl> ;
-   .
+    mf:name    "turtle-syntax-bad-num-05" ;
+    rdfs:comment "Bad number format (negative test)" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <turtle-syntax-bad-LITERAL2_with_langtag_and_datatype.ttl> ;
+    .
 
 <#two_LITERAL_LONG2s> rdf:type rdft:TestTurtleEval ;
-   mf:name    "two_LITERAL_LONG2s" ;
-   rdfs:comment "two LITERAL_LONG2s testing quote delimiter overrun" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <two_LITERAL_LONG2s.ttl> ;
-   mf:result    <two_LITERAL_LONG2s.nt> ;
-   .
+    mf:name    "two_LITERAL_LONG2s" ;
+    rdfs:comment "two LITERAL_LONG2s testing quote delimiter overrun" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <two_LITERAL_LONG2s.ttl> ;
+    mf:result    <two_LITERAL_LONG2s.nt> ;
+    .
 
 <#langtagged_LONG_with_subtag> rdf:type rdft:TestTurtleEval ;
-   mf:name      "langtagged_LONG_with_subtag" ;
-   rdfs:comment "langtagged LONG with subtag \"\"\"Cheers\"\"\"@en-UK" ;
-   rdft:approval rdft:Approved ;
-   mf:action    <langtagged_LONG_with_subtag.ttl> ;
-   mf:result    <langtagged_LONG_with_subtag.nt> ;
-   .
+    mf:name      "langtagged_LONG_with_subtag" ;
+    rdfs:comment "langtagged LONG with subtag \"\"\"Cheers\"\"\"@en-UK" ;
+    rdft:approval rdft:Approved ;
+    mf:action    <langtagged_LONG_with_subtag.ttl> ;
+    mf:result    <langtagged_LONG_with_subtag.nt> ;
+    .
 
 # tests from David Robillard
 # http://www.w3.org/2011/rdf-wg/wiki/Turtle_Candidate_Recommendation_Comments#c21

--- a/rdf/rdf11/rdf-turtle/manifest.ttl
+++ b/rdf/rdf11/rdf-turtle/manifest.ttl
@@ -2570,125 +2570,125 @@
 # tests from David Robillard
 # http://www.w3.org/2011/rdf-wg/wiki/Turtle_Candidate_Recommendation_Comments#c21
 <#turtle-syntax-bad-blank-label-dot-end>
-	rdf:type rdft:TestTurtleNegativeSyntax ;
-	rdfs:comment "Blank node label must not end in dot" ;
-	mf:name "turtle-syntax-bad-blank-label-dot-end" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-bad-blank-label-dot-end.ttl> .
+    rdf:type rdft:TestTurtleNegativeSyntax ;
+    rdfs:comment "Blank node label must not end in dot" ;
+    mf:name "turtle-syntax-bad-blank-label-dot-end" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-bad-blank-label-dot-end.ttl> .
 
 <#turtle-syntax-bad-number-dot-in-anon>
-	rdf:type rdft:TestTurtleNegativeSyntax ;
-	rdfs:comment "Dot delimeter may not appear in anonymous nodes" ;
-	mf:name "turtle-syntax-bad-number-dot-in-anon" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-bad-number-dot-in-anon.ttl> .
+    rdf:type rdft:TestTurtleNegativeSyntax ;
+    rdfs:comment "Dot delimeter may not appear in anonymous nodes" ;
+    mf:name "turtle-syntax-bad-number-dot-in-anon" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-bad-number-dot-in-anon.ttl> .
 
 <#turtle-syntax-bad-ln-dash-start>
-	rdf:type rdft:TestTurtleNegativeSyntax ;
-	rdfs:comment "Local name must not begin with dash" ;
-	mf:name "turtle-syntax-bad-ln-dash-start" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-bad-ln-dash-start.ttl> .
+    rdf:type rdft:TestTurtleNegativeSyntax ;
+    rdfs:comment "Local name must not begin with dash" ;
+    mf:name "turtle-syntax-bad-ln-dash-start" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-bad-ln-dash-start.ttl> .
 
 <#turtle-syntax-bad-ln-escape>
-	rdf:type rdft:TestTurtleNegativeSyntax ;
-	rdfs:comment "Bad hex escape in local name" ;
-	mf:name "turtle-syntax-bad-ln-escape" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-bad-ln-escape.ttl> .
+    rdf:type rdft:TestTurtleNegativeSyntax ;
+    rdfs:comment "Bad hex escape in local name" ;
+    mf:name "turtle-syntax-bad-ln-escape" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-bad-ln-escape.ttl> .
 
 <#turtle-syntax-bad-ln-escape-start>
-	rdf:type rdft:TestTurtleNegativeSyntax ;
-	rdfs:comment "Bad hex escape at start of local name" ;
-	mf:name "turtle-syntax-bad-ln-escape-start" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-bad-ln-escape-start.ttl> .
+    rdf:type rdft:TestTurtleNegativeSyntax ;
+    rdfs:comment "Bad hex escape at start of local name" ;
+    mf:name "turtle-syntax-bad-ln-escape-start" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-bad-ln-escape-start.ttl> .
 
 <#turtle-syntax-bad-ns-dot-end>
-	rdf:type rdft:TestTurtleNegativeSyntax ;
-	rdfs:comment "Prefix must not end in dot" ;
-	mf:name "turtle-syntax-bad-ns-dot-end" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-bad-ns-dot-end.ttl> .
+    rdf:type rdft:TestTurtleNegativeSyntax ;
+    rdfs:comment "Prefix must not end in dot" ;
+    mf:name "turtle-syntax-bad-ns-dot-end" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-bad-ns-dot-end.ttl> .
 
 <#turtle-syntax-bad-ns-dot-start>
-	rdf:type rdft:TestTurtleNegativeSyntax ;
-	rdfs:comment "Prefix must not start with dot" ;
-	mf:name "turtle-syntax-bad-ns-dot-start" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-bad-ns-dot-start.ttl> .
+    rdf:type rdft:TestTurtleNegativeSyntax ;
+    rdfs:comment "Prefix must not start with dot" ;
+    mf:name "turtle-syntax-bad-ns-dot-start" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-bad-ns-dot-start.ttl> .
 
 <#turtle-syntax-bad-missing-ns-dot-end>
-	rdf:type rdft:TestTurtleNegativeSyntax ;
-	rdfs:comment "Prefix must not end in dot (error in triple, not prefix directive like turtle-syntax-bad-ns-dot-end)" ;
-	mf:name "turtle-syntax-bad-missing-ns-dot-end" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-bad-missing-ns-dot-end.ttl> .
+    rdf:type rdft:TestTurtleNegativeSyntax ;
+    rdfs:comment "Prefix must not end in dot (error in triple, not prefix directive like turtle-syntax-bad-ns-dot-end)" ;
+    mf:name "turtle-syntax-bad-missing-ns-dot-end" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-bad-missing-ns-dot-end.ttl> .
 
 <#turtle-syntax-bad-missing-ns-dot-start>
-	rdf:type rdft:TestTurtleNegativeSyntax ;
-	rdfs:comment "Prefix must not start with dot (error in triple, not prefix directive like turtle-syntax-bad-ns-dot-end)" ;
-	mf:name "turtle-syntax-bad-missing-ns-dot-start" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-bad-missing-ns-dot-start.ttl> .
+    rdf:type rdft:TestTurtleNegativeSyntax ;
+    rdfs:comment "Prefix must not start with dot (error in triple, not prefix directive like turtle-syntax-bad-ns-dot-end)" ;
+    mf:name "turtle-syntax-bad-missing-ns-dot-start" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-bad-missing-ns-dot-start.ttl> .
 
 <#turtle-syntax-ln-dots>
-	rdf:type rdft:TestTurtlePositiveSyntax ;
-	rdfs:comment "Dots in pname local names" ;
-	mf:name "turtle-syntax-ln-dots" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-ln-dots.ttl> .
+    rdf:type rdft:TestTurtlePositiveSyntax ;
+    rdfs:comment "Dots in pname local names" ;
+    mf:name "turtle-syntax-ln-dots" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-ln-dots.ttl> .
 
 <#turtle-syntax-ln-colons>
-	rdf:type rdft:TestTurtlePositiveSyntax ;
-	rdfs:comment "Colons in pname local names" ;
-	mf:name "turtle-syntax-ln-colons" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-ln-colons.ttl> .
+    rdf:type rdft:TestTurtlePositiveSyntax ;
+    rdfs:comment "Colons in pname local names" ;
+    mf:name "turtle-syntax-ln-colons" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-ln-colons.ttl> .
 
 <#turtle-syntax-ns-dots>
-	rdf:type rdft:TestTurtlePositiveSyntax ;
-	rdfs:comment "Dots in namespace names" ;
-	mf:name "turtle-syntax-ns-dots" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-ns-dots.ttl> .
+    rdf:type rdft:TestTurtlePositiveSyntax ;
+    rdfs:comment "Dots in namespace names" ;
+    mf:name "turtle-syntax-ns-dots" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-ns-dots.ttl> .
 
 <#turtle-syntax-blank-label>
-	rdf:type rdft:TestTurtlePositiveSyntax ;
-	rdfs:comment "Characters allowed in blank node labels" ;
-	mf:name "turtle-syntax-blank-label" ;
-        rdft:approval rdft:Approved ;
-	mf:action <turtle-syntax-blank-label.ttl> .
+    rdf:type rdft:TestTurtlePositiveSyntax ;
+    rdfs:comment "Characters allowed in blank node labels" ;
+    mf:name "turtle-syntax-blank-label" ;
+    rdft:approval rdft:Approved ;
+    mf:action <turtle-syntax-blank-label.ttl> .
 
 # IRI resolution tests
 <#IRI-resolution-01>
-	rdf:type rdft:TestTurtleEval ;
-	rdfs:comment "IRI resolution (RFC3986 original cases)" ;
-	mf:name "IRI-resolution-01" ;
-	rdft:approval rdft:Proposed ;
-	mf:action <IRI-resolution-01.ttl> ;
-	mf:result <IRI-resolution-01.nt> .
+    rdf:type rdft:TestTurtleEval ;
+    rdfs:comment "IRI resolution (RFC3986 original cases)" ;
+    mf:name "IRI-resolution-01" ;
+    rdft:approval rdft:Proposed ;
+    mf:action <IRI-resolution-01.ttl> ;
+    mf:result <IRI-resolution-01.nt> .
 
 <#IRI-resolution-02>
-	rdf:type rdft:TestTurtleEval ;
-	rdfs:comment "IRI resolution (RFC3986 using base IRI with trailing slash)" ;
-	mf:name "IRI-resolution-02" ;
-	rdft:approval rdft:Proposed ;
-	mf:action <IRI-resolution-02.ttl> ;
-	mf:result <IRI-resolution-02.nt> .
+    rdf:type rdft:TestTurtleEval ;
+    rdfs:comment "IRI resolution (RFC3986 using base IRI with trailing slash)" ;
+    mf:name "IRI-resolution-02" ;
+    rdft:approval rdft:Proposed ;
+    mf:action <IRI-resolution-02.ttl> ;
+    mf:result <IRI-resolution-02.nt> .
 
 <#IRI-resolution-07>
-	rdf:type rdft:TestTurtleEval ;
-	rdfs:comment "IRI resolution (RFC3986 using base IRI with file path)" ;
-	mf:name "IRI-resolution-07" ;
-	rdft:approval rdft:Proposed ;
-	mf:action <IRI-resolution-07.ttl> ;
-	mf:result <IRI-resolution-07.nt> .
+    rdf:type rdft:TestTurtleEval ;
+    rdfs:comment "IRI resolution (RFC3986 using base IRI with file path)" ;
+    mf:name "IRI-resolution-07" ;
+    rdft:approval rdft:Proposed ;
+    mf:action <IRI-resolution-07.ttl> ;
+    mf:result <IRI-resolution-07.nt> .
 
 <#IRI-resolution-08>
-	rdf:type rdft:TestTurtleEval ;
-	rdfs:comment "IRI resolution (miscellaneous cases)" ;
-	mf:name "IRI-resolution-08" ;
-	rdft:approval rdft:Proposed ;
-	mf:action <IRI-resolution-08.ttl> ;
-	mf:result <IRI-resolution-08.nt> .
+    rdf:type rdft:TestTurtleEval ;
+    rdfs:comment "IRI resolution (miscellaneous cases)" ;
+    mf:name "IRI-resolution-08" ;
+    rdft:approval rdft:Proposed ;
+    mf:action <IRI-resolution-08.ttl> ;
+    mf:result <IRI-resolution-08.nt> .

--- a/rdf/rdf12/rdf-n-quads/manifest.ttl
+++ b/rdf/rdf12/rdf-n-quads/manifest.ttl
@@ -34,4 +34,3 @@ trs:manifest  rdf:type mf:Manifest ;
     <syntax/manifest.ttl>
     <../../rdf11/rdf-n-quads/manifest.ttl>
   ) .
-

--- a/rdf/rdf12/rdf-n-triples/manifest.ttl
+++ b/rdf/rdf12/rdf-n-triples/manifest.ttl
@@ -34,4 +34,3 @@ trs:manifest  rdf:type mf:Manifest ;
     <syntax/manifest.ttl>
     <../../rdf11/rdf-n-triples/manifest.ttl>
   ) .
-

--- a/rdf/rdf12/rdf-trig/eval/manifest.ttl
+++ b/rdf/rdf12/rdf-trig/eval/manifest.ttl
@@ -190,13 +190,13 @@ trs:trig12-reified-triples-annotation-01 rdf:type rdft:TestTrigEval ;
    mf:action    <trig12-eval-reified-triples-annotation-01.trig> ;
    mf:result    <trig12-eval-reified-triples-annotation-01.nq> ;
    .
-   
+
 trs:trig12-reified-triples-annotation-02 rdf:type rdft:TestTrigEval ;
    mf:name      "TriG 1.2 - Annotation on triple with reified triple subject" ;
    mf:action    <trig12-eval-reified-triples-annotation-02.trig> ;
    mf:result    <trig12-eval-reified-triples-annotation-02.nq> ;
    .
-   
+
 trs:trig12-reified-triples-annotation-03 rdf:type rdft:TestTrigEval ;
    mf:name      "TriG 1.2 - Annotation on triple with reified triple object" ;
    mf:action    <trig12-eval-reified-triples-annotation-03.trig> ;

--- a/rdf/rdf12/rdf-trig/manifest.ttl
+++ b/rdf/rdf12/rdf-trig/manifest.ttl
@@ -34,4 +34,3 @@ trs:manifest  rdf:type mf:Manifest ;
     <syntax/manifest.ttl>
     <../../rdf11/rdf-trig/manifest.ttl>
   ) .
-

--- a/rdf/rdf12/rdf-turtle/eval/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/eval/manifest.ttl
@@ -218,16 +218,15 @@ trs:turtle12-reified-triples-annotation-01 rdf:type rdft:TestTurtleEval ;
    mf:action    <turtle12-eval-reified-triples-annotation-01.ttl> ;
    mf:result    <turtle12-eval-reified-triples-annotation-01.nt> ;
    .
-   
+
 trs:turtle12-reified-triples-annotation-02 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle 1.2 - Annotation on triple with reified triple subject" ;
    mf:action    <turtle12-eval-reified-triples-annotation-02.ttl> ;
    mf:result    <turtle12-eval-reified-triples-annotation-02.nt> ;
    .
-   
+
 trs:turtle12-reified-triples-annotation-03 rdf:type rdft:TestTurtleEval ;
    mf:name      "Turtle 1.2 - Annotation on triple with reified triple object" ;
    mf:action    <turtle12-eval-reified-triples-annotation-03.ttl> ;
    mf:result    <turtle12-eval-reified-triples-annotation-03.nt> ;
    .
-

--- a/rdf/rdf12/rdf-turtle/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/manifest.ttl
@@ -34,4 +34,3 @@ trs:manifest  rdf:type mf:Manifest ;
     <syntax/manifest.ttl>
     <../../rdf11/rdf-turtle/manifest.ttl>
   ) .
-

--- a/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
+++ b/rdf/rdf12/rdf-turtle/syntax/manifest.ttl
@@ -3,14 +3,14 @@
 ## [1] https://www.w3.org/Consortium/Legal/2008/04-testsuite-license
 ## [2] https://www.w3.org/Consortium/Legal/2008/03-bsd-license
 
-PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
-PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#> 
-PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> 
-PREFIX rdft:   <http://www.w3.org/ns/rdftest#> 
-PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#> 
-PREFIX dct:    <http://purl.org/dc/terms/> 
-PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#> 
-PREFIX foaf:   <http://xmlns.com/foaf/0.1/> 
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+PREFIX rdft:   <http://www.w3.org/ns/rdftest#>
+PREFIX trs:    <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax#>
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
 PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
 
 trs:manifest  rdf:type mf:Manifest ;
@@ -18,8 +18,8 @@ trs:manifest  rdf:type mf:Manifest ;
    skos:prefLabel "La suite des tests pour la syntaxe RDF 1.2 Turtle"@fr ;
    skos:prefLabel "Conjunto de pruebas para la sintaxis RDF 1.2 Turtle"@es ;
    mf:assumedTestBase <https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax/> ;
-   dct:issued "2023-07-20"^^xsd:date ; 
-   dct:modified "2025-06-10"^^xsd:date ; 
+   dct:issued "2023-07-20"^^xsd:date ;
+   dct:modified "2025-06-10"^^xsd:date ;
    dct:licence <https://www.w3.org/Consortium/Legal/2008/03-bsd-license> ;
    dct:creator [ foaf:homepage <https://w3c.github.io/rdf12-wg/> ; foaf:name "W3C RDF & SPARQL Working Group" ] ;
     mf:entries
@@ -63,7 +63,7 @@ trs:manifest  rdf:type mf:Manifest ;
         trs:turtle12-ann-6
         trs:turtle12-ann-7
         trs:turtle12-ann-8
-        
+
         trs:turtle12-bad-ann-1
         trs:turtle12-bad-ann-2
 
@@ -351,12 +351,12 @@ trs:nt-ttl12-nested-1 rdf:type rdft:TestTurtlePositiveSyntax ;
    .
 
 ## Bad syntax
- 
+
 trs:nt-ttl12-bad-01 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "N-Triples 1.2 as Turtle 1.2 - Bad - triple term as predicate" ;
     mf:action    <nt-ttl12-bad-syntax-01.ttl> ;
     .
-    
+
 trs:nt-ttl12-bad-02 rdf:type rdft:TestTurtleNegativeSyntax ;
     mf:name      "N-Triples 1.2 as Turtle 1.2 - Bad - triple term, literal subject" ;
     mf:action    <nt-ttl12-bad-syntax-02.ttl> ;
@@ -486,7 +486,7 @@ trs:turtle12-surrogate-pair-bad-01 rdf:type rdft:TestTurtleNegativeSyntax ;
    mf:name      "Turtle 1.2 - Bad - Surrogate pair numeric escape sequence" ;
    mf:action    <turtle12-surrogate-pair-bad-01.ttl>
    .
-   
+
 trs:turtle12-surrogate-pair-bad-02 rdf:type rdft:TestTurtleNegativeSyntax ;
    mf:name      "Turtle 1.2 - Bad - Surrogate pair via numeric escape sequence" ;
    mf:action    <turtle12-surrogate-pair-bad-02.ttl>

--- a/rdf/rdf12/rdf-xml/eval/manifest.ttl
+++ b/rdf/rdf12/rdf-xml/eval/manifest.ttl
@@ -58,7 +58,7 @@ trs:manifest  rdf:type mf:Manifest ;
         trs:rdf12-xml-an-14
         trs:rdf12-xml-an-15
         trs:rdf12-xml-an-16
-        
+
         trs:rdf12-xml-an-reif-01
     ) .
 

--- a/rdf/rdf12/rdf-xml/manifest.ttl
+++ b/rdf/rdf12/rdf-xml/manifest.ttl
@@ -33,4 +33,3 @@ trs:manifest  rdf:type mf:Manifest ;
     <eval/manifest.ttl>
     <../../rdf11/rdf-xml/manifest.ttl>
   ) .
-


### PR DESCRIPTION
Some minor cleanups towards more consistent/canonical test outputs, along with some superficial manifest tidying.

The larger motivation here is to reduce the disparity between the syntax emitted by implementations and the given expected outputs. Ideally this should be eliminated entirely, but that would require more significant (but still just superficial) changes, so this is a very small and hopefully uncontroversial step towards that, which at least reduces the number of changes that developers of implementations that check test outputs exactly (like mine) need to manually re-fix when updating the test suite.